### PR TITLE
Lower CPU usage

### DIFF
--- a/pyOCD/flash/flash.py
+++ b/pyOCD/flash/flash.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013 ARM Limited
+ Copyright (c) 2006-2015 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ class Flash(object):
         # check the return code
         result = self.target.readCoreRegister('r0')
         if result != 0:
-            logging.error('eraseAll error: %i', result)
+            logging.error('init error: %i', result)
 
         return
 

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -143,6 +143,7 @@ class GDBServer(threading.Thread):
                     if (new_command == True):
                         new_command = False
                         break
+                    sleep(0.1)
                     try:
                         if self.shutdown_event.isSet() or self.detach_event.isSet():
                             break
@@ -301,7 +302,7 @@ class GDBServer(threading.Thread):
         val = ''
         
         while True:
-            sleep(0.01)
+            sleep(0.1)
             if self.shutdown_event.isSet():
                 return self.createRSPPacket(val), 0, 0
             

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -19,7 +19,7 @@ import logging, threading, socket
 from pyOCD.target.target import TARGET_HALTED, WATCHPOINT_READ, WATCHPOINT_WRITE, WATCHPOINT_READ_WRITE
 from pyOCD.transport import TransferError
 from struct import unpack
-from time import sleep
+from time import sleep, time
 import sys
 from gdb_socket import GDBSocket
 from gdb_websocket import GDBWebSocket
@@ -109,6 +109,7 @@ class GDBServer(threading.Thread):
         return
         
     def run(self):
+        self.timeOfLastPacket = time()
         while True:
             new_command = False
             data = ""
@@ -143,7 +144,12 @@ class GDBServer(threading.Thread):
                     if (new_command == True):
                         new_command = False
                         break
-                    sleep(0.1)
+
+                    # Reduce CPU usage by sleep()ing once we know that the
+                    # debugger doesn't have a queue of commands that we should
+                    # execute as quickly as possible.
+                    if time() - self.timeOfLastPacket > 0.5:
+                        sleep(0.1)
                     try:
                         if self.shutdown_event.isSet() or self.detach_event.isSet():
                             break
@@ -192,7 +198,9 @@ class GDBServer(threading.Thread):
                         self.abstract_socket.close()
                         self.lock.release()
                         break
-                    
+
+                    self.timeOfLastPacket = time()
+
                 self.lock.release()
         
         
@@ -300,12 +308,16 @@ class GDBServer(threading.Thread):
         self.target.resume()
         
         val = ''
-        
+
+        self.timeOfLastPacket = time()
         while True:
-            sleep(0.1)
             if self.shutdown_event.isSet():
                 return self.createRSPPacket(val), 0, 0
-            
+
+            # Introduce a delay between non-blocking socket reads once we know
+            # that the CPU isn't going to halt quickly.
+            if time() - self.timeOfLastPacket > 0.5:
+                sleep(0.1)
             try:
                 data = self.abstract_socket.read()
                 if (data[0] == '\x03'):


### PR DESCRIPTION
When I had a device halted under pyOCD, the CPU usage on my development
machine would sky rocket.  The effect of this was very noticeable when
running off of batteries.  This was due to pyOCD's usage of
non-blocking socket reads in a tight loop while it tries to read
packets sent from GDB.  I added a sleep() call to the run() method as
already used in the resume() method.  I set both of these sleeps to be
100 milliseconds. For me, I didn't find this decreased the perceived
responsiveness of pyOCD when I was using GDB and it greatly reduces the
CPU usage.

**Edit**: Below feature is no longer required after PR #93 so it has been
removed from this PR.

~~As I have been working to implement pyOCD support for the LPC4330, I
would hit issues where resume() would hit an excpeption as it tried to
read the hard fault handler address from the interrupt vector table at
an address of 0x12.  This happened because the external SPIFI FLASH
isn't always available and mapped into this shadow region.  I added
code which handles this exception and treats it the same as when no
hardware breakpoints are available.~~