### PR TITLE
Fix resume, prevent stepping into interrupts and add hard fault vector catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ A series of tests are provided in the test directory:
   * "-l", "--list", help = "List all the connected board"
   * "-d", "--debug", help = "Set the level of system logging output, the available value for DEBUG_LEVEL: debug, info, warning, error, critical"
   * "-t", "--target", help = "Override target to debug"
-  * "-n", "--nobreak", help = "Disable breakpoint at hardfault handler. Required for nrf51 chip with SoftDevice based application."
+  * "-n", "--nobreak", help = "Disable halt at hardfault handler."
+  * "-r", "--reset-break", help = "Halt the target when reset."
+  * "-s", "--step-int", help = "Allow single stepping to step into interrupts."
 
 
 ### Hello World example code

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -68,6 +68,9 @@ class GDBServer(threading.Thread):
         else:
             self.port = port_urlWSS
         self.break_at_hardfault = bool(options.get('break_at_hardfault', True))
+        self.board.target.setVectorCatchFault(self.break_at_hardfault)
+        self.break_on_reset = options.get('break_on_reset', False)
+        self.board.target.setVectorCatchReset(self.break_on_reset)
         self.step_into_interrupt = options.get('step_into_interrupt', False)
         self.packet_size = 2048
         self.flashData = list()
@@ -293,18 +296,6 @@ class GDBServer(threading.Thread):
     def resume(self):
         self.ack()
         self.abstract_socket.setBlocking(0)
-        
-        # Try to set break point at hardfault handler to avoid
-        # halting target constantly
-        if not self.break_at_hardfault:
-            bpSet=False
-        elif (self.target.availableBreakpoint() >= 1):
-            bpSet=True
-            hardfault_handler = self.target.readMemory(4*3)
-            self.target.setBreakpoint(hardfault_handler)
-        else:
-            bpSet=False
-            logging.info("No breakpoint available. Interfere target constantly.")
 
         self.target.resume()
         
@@ -337,20 +328,6 @@ class GDBServer(threading.Thread):
                     break
             except:
                 logging.debug('Target is unavailable temporary.')
-
-            if (not bpSet) and self.break_at_hardfault:
-                # Only do this when no bp available as it slows resume operation
-                self.target.halt()
-                xpsr = self.target.readCoreRegister('xpsr')
-                logging.debug("GDB resume xpsr: 0x%X", xpsr)
-                # Get IPSR value from XPSR
-                if (xpsr & 0x1f) == 3:
-                    val = "S" + FAULT[3]
-                    break
-                self.target.resume()
-        
-        if bpSet and self.break_at_hardfault:
-            self.target.removeBreakpoint(hardfault_handler)
 
         self.abstract_socket.setBlocking(1)
         return self.createRSPPacket(val), 0, 0

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -68,6 +68,7 @@ class GDBServer(threading.Thread):
         else:
             self.port = port_urlWSS
         self.break_at_hardfault = bool(options.get('break_at_hardfault', True))
+        self.step_into_interrupt = options.get('step_into_interrupt', False)
         self.packet_size = 2048
         self.flashData = list()
         self.flashOffset = None
@@ -356,7 +357,7 @@ class GDBServer(threading.Thread):
     
     def step(self):
         self.ack()
-        self.target.step()
+        self.target.step(not self.step_into_interrupt)
         return self.createRSPPacket("S05"), 0, 0
     
     def halt(self):

--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -593,8 +593,7 @@ class CortexM(Target):
         if self.getState() != TARGET_HALTED:
             logging.debug('cannot step: target not halted')
             return
-        if self.maybeSkipBreakpoint() is None:
-            self.writeMemory(DHCSR, DBGKEY | C_DEBUGEN | C_STEP)
+        self.writeMemory(DHCSR, DBGKEY | C_DEBUGEN | C_STEP)
         return
 
     def reset(self, software_reset = False):
@@ -645,21 +644,8 @@ class CortexM(Target):
         if self.getState() != TARGET_HALTED:
             logging.debug('cannot resume: target not halted')
             return
-        self.maybeSkipBreakpoint()
         self.writeMemory(DHCSR, DBGKEY | C_DEBUGEN)
         return
-
-    def maybeSkipBreakpoint(self):
-        pc = self.readCoreRegister('pc')
-        bp = self.findBreakpoint(pc)
-        if bp is not None:
-            logging.debug('skip/resume breakpoint: pc 0x%X', pc)
-            self.removeBreakpoint(pc)
-            self.writeMemory(DHCSR, DBGKEY | C_DEBUGEN | C_STEP)
-            self.setBreakpoint(pc)
-            logging.debug('step over breakpoint: now pc0x%X', self.readCoreRegister('pc'))
-            return bp
-        return None
 
     def findBreakpoint(self, addr):
         for bp in self.breakpoints:

--- a/pyOCD/target/target_nrf51822.py
+++ b/pyOCD/target/target_nrf51822.py
@@ -37,18 +37,6 @@ class NRF51822(CortexM):
         super(NRF51822, self).__init__(transport)
         self.auto_increment_page_size = 0x400
 
-    def step(self):
-        """
-        perform an instruction level step
-        Mask interrupts on nrf51 due to SoftDevice background interrupts.
-        Without this GDB client can't step through the code.
-        """
-        if self.getState() != TARGET_HALTED:
-            logging.debug('cannot step: target not halted')
-            return
-        self.writeMemory(DHCSR, DBGKEY | C_DEBUGEN | C_MASKINTS | C_STEP)
-        return
-
     def reset(self, software_reset = False):
         """
         reset a core. After a call to this function, the core

--- a/pyOCD/target/target_nrf51822.py
+++ b/pyOCD/target/target_nrf51822.py
@@ -46,8 +46,7 @@ class NRF51822(CortexM):
         if self.getState() != TARGET_HALTED:
             logging.debug('cannot step: target not halted')
             return
-        if self.maybeSkipBreakpoint() is None:
-            self.writeMemory(DHCSR, DBGKEY | C_DEBUGEN | C_MASKINTS | C_STEP)
+        self.writeMemory(DHCSR, DBGKEY | C_DEBUGEN | C_MASKINTS | C_STEP)
         return
 
     def reset(self, software_reset = False):

--- a/pyOCD/target/target_nrf51822.py
+++ b/pyOCD/target/target_nrf51822.py
@@ -37,21 +37,15 @@ class NRF51822(CortexM):
         super(NRF51822, self).__init__(transport)
         self.auto_increment_page_size = 0x400
 
-    def reset(self, software_reset = False):
+    def reset(self, software_reset = True):
         """
         reset a core. After a call to this function, the core
         is running
         """
-        # For some reason hardware reset prevent normal operation.
-        self.resetStopResume()
-
-    def resetStopResume(self):
-        """
-        reset a core. After a call to this function, the core
-        is running
-        """
-        self.resetStopOnReset()
-        self.resume()
+        # Keep call to CortexM version of reset but make the default a
+        # software reset since a hardware reset does not work when 
+        # debugging is enabled
+        CortexM.reset(self, software_reset)
 
     def resetn(self):
         """
@@ -65,26 +59,11 @@ class NRF51822(CortexM):
         logging.debug("target_nrf518.reset: trigger nRST pin")
         CortexM.reset(self)
 
-    def resetStopOnReset(self, software_reset = False):
+    def resetStopOnReset(self, software_reset = True):
         """
         perform a reset and stop the core on the reset handler
         """
-        # read address of reset handler
-        reset_handler = self.readMemory(4)
-
-        # halt on reset the target
-        self.halt()
-        # set a breakpoint to the reset handler and reset the target
-        self.setBreakpoint(reset_handler)
-
-        #Soft Reset will keep NRF in debug mode
-        self.writeMemory(DEMCR, VC_CORERESET)
-        self.writeMemory(NVIC_AIRCR, NVIC_AIRCR_VECTKEY | NVIC_AIRCR_SYSRESETREQ)
-        
-        # wait until the bp is reached
-        while (self.getState() == TARGET_RUNNING):
-            pass
-        
-        # remove the breakpoint
-        self.removeBreakpoint(reset_handler)
-
+        # Keep call to CortexM version of resetStopOnReset but make 
+        # the default a software reset since a hardware reset does 
+        # not work when debugging is enabled
+        CortexM.resetStopOnReset(self, software_reset)

--- a/test/gdb_server.py
+++ b/test/gdb_server.py
@@ -46,6 +46,7 @@ parser.add_option("-l", "--list", action = "store_true", dest = "list_all", defa
 parser.add_option("-d", "--debug", dest = "debug_level", default = 'info', help = "Set the level of system logging output, the available value for DEBUG_LEVEL: debug, info, warning, error, critical" )
 parser.add_option("-t", "--target", dest = "target_override", default = None, help = "Override target to debug" )
 parser.add_option("-n", "--nobreak", dest = "break_at_hardfault", default = True, action="store_false", help = "Disable breakpoint at hardfault handler. Required for nrf51 chip with SoftDevice based application." )
+parser.add_option("-s", "--step-int", dest = "step_into_interrupt", default = False, action="store_true", help = "Allow single stepping to step into interrupts." )
 (option, args) = parser.parse_args()
 
 gdb = None
@@ -57,7 +58,7 @@ else:
     try:
         board_selected = MbedBoard.chooseBoard(board_id = option.board_id, target_override = option.target_override)
         with board_selected as board:
-            gdb = GDBServer(board, int(option.port_number), {'break_at_hardfault' : option.break_at_hardfault})
+            gdb = GDBServer(board, int(option.port_number), {'break_at_hardfault' : option.break_at_hardfault, 'step_into_interrupt' : option.step_into_interrupt })
             while gdb.isAlive():
                 gdb.join(timeout = 0.5)
     except KeyboardInterrupt:

--- a/test/gdb_server.py
+++ b/test/gdb_server.py
@@ -45,7 +45,8 @@ parser.add_option("-b", "--board", dest = "board_id", default = None, help = "Wr
 parser.add_option("-l", "--list", action = "store_true", dest = "list_all", default = False, help = "List all the connected board")
 parser.add_option("-d", "--debug", dest = "debug_level", default = 'info', help = "Set the level of system logging output, the available value for DEBUG_LEVEL: debug, info, warning, error, critical" )
 parser.add_option("-t", "--target", dest = "target_override", default = None, help = "Override target to debug" )
-parser.add_option("-n", "--nobreak", dest = "break_at_hardfault", default = True, action="store_false", help = "Disable breakpoint at hardfault handler. Required for nrf51 chip with SoftDevice based application." )
+parser.add_option("-n", "--nobreak", dest = "break_at_hardfault", default = True, action="store_false", help = "Disable halt at hardfault handler." )
+parser.add_option("-r", "--reset-break", dest = "break_on_reset", default = False, action="store_true", help = "Halt the target when reset." )
 parser.add_option("-s", "--step-int", dest = "step_into_interrupt", default = False, action="store_true", help = "Allow single stepping to step into interrupts." )
 (option, args) = parser.parse_args()
 
@@ -58,7 +59,8 @@ else:
     try:
         board_selected = MbedBoard.chooseBoard(board_id = option.board_id, target_override = option.target_override)
         with board_selected as board:
-            gdb = GDBServer(board, int(option.port_number), {'break_at_hardfault' : option.break_at_hardfault, 'step_into_interrupt' : option.step_into_interrupt })
+            gdb = GDBServer(board, int(option.port_number), {'break_at_hardfault' : option.break_at_hardfault, 
+                'step_into_interrupt' : option.step_into_interrupt, 'break_on_reset' : option.break_on_reset })
             while gdb.isAlive():
                 gdb.join(timeout = 0.5)
     except KeyboardInterrupt:


### PR DESCRIPTION
When using GDB, a typical way of moving the execution address is to set
a breakpoint with the command 'break [line]' and then jump to that
address with the command 'jump [line]'.  This does not work because
the function maybeSkipBreakpoint will cause GDB to skip the breakpoint.
This patch fixes that problem by removing the function
maybeSkipBreakpoint.

GDB single stepping still works as expected and does not get stuck
when trying to step over breakpoints.  This is because the GDB
client automatically removes the breakpoint when stepping over it
and restores it after.

When using Eclipse as a GDB front end this fixes the problem where
where "Move to line" causes the device to begin executing code,
rather than just moving the PC.