### PR TITLE
Switch from 'S' to 'T' GDB responses

### DIFF
--- a/pyOCD/flash/flash_nrf51822.py
+++ b/pyOCD/flash/flash_nrf51822.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013 ARM Limited
+ Copyright (c) 2006-2015 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ class Flash_nrf51822(Flash):
         Erase one page
         """
 
-        logging.info("Flash_nrf51822: Erase page: 0x%X", flashPtr)
+        logging.debug("Flash_nrf51822: Erase page: 0x%X", flashPtr)
         self.target.writeMemory(NVMC_CONFIG, NVMC_CONFIG_EEN)
         while self.target.readMemory(NVMC_READY) == 0:
             pass

--- a/pyOCD/gdbserver/signals.py
+++ b/pyOCD/gdbserver/signals.py
@@ -1,0 +1,22 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2006-2015 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+SIGINT = 2
+SIGSEGV = 11
+SIGILL = 4
+SIGSTOP = 17
+SIGTRAP = 5
+SIGBUS = 10

--- a/pyOCD/target/target.py
+++ b/pyOCD/target/target.py
@@ -107,3 +107,6 @@ class Target(object):
 
     def setRegister(self, reg, data):
         return
+
+    def getTResponse(self, gdbInterrupt = False):
+        return ''


### PR DESCRIPTION
'T' responses allow the remote stub to return the value of a few
important registers (FP, SP, LR, PC) each time the debuggee stops. This
often makes operations like stepping through highlevel code faster
since GDB no longer needs to issue a larger 'g' packet request for each
machine code instruction that is stepped over as part of a higher level
instruction.

Changes in this commit include:
* Replacing all 'S' response packets with 'T' response packets.
* Moved the definition of signal values expected by GDB out into their
  own signals.py module.
* The T response is now created in the CortexM class rather than in the
  GDBServer class where the S response was previously created.  This
  change was made because the determination of the signal value and
  registers that should be included in these responses are actually
  target specific.  The target method to provide this functionality is
  named getTResponse().
* I replaced every location in the GDBServer class that returned a
  'S' response packet with a call to getTResponse().  There were
  a few cases where the response was hardcoded.  Now the code
  always looks at the CPU state to determine the cause of the stop and
  determine the contents of the SP, LR, and PC registers.  One
  special case is if GDB sends a CTRL+C while in GDBServer::resume().
  The case passes in True for the gdbInterrupt parameter so that
  getTResponse() knows to return a SIGINT signal value.
* Moved the FAULTS global from gdbserver.py to cortex_m.py where it is
  now referenced.  It now contains integer signal values from
  signals.py which will be converted to hexadecimal text when the 'T'
  response is created.  This actually fixes a bug in the old code since
  before it would return a response containing "17" to represent SIGSTOP
  but that is the decimal value of SIGSTOP and GDB expects hexadecimal.
* I used a shorter FAULT list since all IPSR values higher than
  UsageFault, including device specific interrupts, should be flagged
  as SIGSTOP anyway.
* Before allowing the CPU to execute more instructions, via resume() or
  step() methods, the DFSR bits are cleared via the
  clearDebugCauseBits() method.  If these aren't manually cleared then
  they will accumulate over time and confuse the isDebugTrap() method
  when it tries to determine if the cause of a stop was a debug trap
  such as breakpoint, watchpoint, etc.
* I removed the unused CortexM::getRegisterName() method.
* Added an implementation of getTResponse() to the CortexM class.  This
  builds up the T response which contains the signal value indicating the
  reason for the stop and the values of the FP, SP, LR, and PC registers.
  The signal value will be:
  * SIGTRAP if watchpoint or breakpoint was encountered.  Also if
    single stepping.
  * Value specific to the IPSR value.  The FAULT array is used for this
    mapping.  For example a HardFault IPSR value of 3 will generate a
    SIGSEGV response.
  * SIGSTOP is the default if the IPSR value isn't represented in the
    FAULT array.
* Sneaking in a change to the Flash_nrf51822 class to properly log some
  debug information at the proper level :)

Thanks to @c1728p9 for testing out this branch so that it actually helped his KDS single stepping scenario (adding of r7, the frame pointer, was his discovery). @c1728p9 has probably spent more time on this change than I have at this point.