### PR TITLE
Jtagonly

### DIFF
--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -488,7 +488,10 @@ class CortexM(Target):
         write a memory location.
         By default the transfer size is a word
         """
-        self.transport.writeMem(addr, value, transfer_size)
+        try:
+            self.transport.writeMem(addr, value, transfer_size)
+        except:
+            self.handleMemoryError()
         return
 
     def write32(self, addr, value):
@@ -514,7 +517,11 @@ class CortexM(Target):
         read a memory location. By default, a word will
         be read
         """
-        return self.transport.readMem(addr, transfer_size)
+        try:
+            return self.transport.readMem(addr, transfer_size)
+        except:
+            self.handleMemoryError()
+            return 0
 
     def read32(self, addr):
         """
@@ -643,7 +650,10 @@ class CortexM(Target):
             n = self.auto_increment_page_size - (addr & (self.auto_increment_page_size - 1))
             if size*4 < n:
                 n = (size*4) & 0xfffffffc
-            self.transport.writeBlock32(addr, data[:n/4])
+            try:
+                self.transport.writeBlock32(addr, data[:n/4])
+            except:
+                self.handleMemoryError()
             data = data[n/4:]
             size -= n/4
             addr += n
@@ -659,7 +669,10 @@ class CortexM(Target):
             n = self.auto_increment_page_size - (addr & (self.auto_increment_page_size - 1))
             if size*4 < n:
                 n = (size*4) & 0xfffffffc
-            resp += self.transport.readBlock32(addr, n/4)
+            try:
+                resp += self.transport.readBlock32(addr, n/4)
+            except:
+                self.handleMemoryError()
             size -= n/4
             addr += n
         return resp
@@ -1155,3 +1168,7 @@ class CortexM(Target):
             return '0' + val
         else:
             return val
+
+    def handleMemoryError(self):
+            self.transport.reinit()
+            self.init()

--- a/pyOCD/transport/cmsis_dap.py
+++ b/pyOCD/transport/cmsis_dap.py
@@ -123,6 +123,22 @@ class CMSIS_DAP(Transport):
             self.writeDP(DP_REG['CTRL_STAT'], STICKYERR | STICKCMP | STICKORUN)
         return
 
+    def reinit(self):
+        # clear internal state
+        self.csw = -1
+        self.dp_select = -1
+        if (self.mode == DAP_MODE_SWD):
+            # switch from jtag to swd
+            JTAG2SWD(self.interface)
+            # clear abort err
+            dapWriteAbort(self.interface, 0x1e);
+        elif (self.mode == DAP_MODE_JTAG):
+            # Test logic reset, run test idle
+            dapSWJSequence(self.interface, [0x1F])
+            # clear errors
+            self.writeDP(DP_REG['CTRL_STAT'], STICKYERR | STICKCMP | STICKORUN)
+        return
+
     def uninit(self):
         dapDisconnect(self.interface)
         return

--- a/pyOCD/transport/cmsis_dap.py
+++ b/pyOCD/transport/cmsis_dap.py
@@ -65,12 +65,14 @@ TRANSFER_SIZE = {8: CSW_SIZE8,
                  32: CSW_SIZE32
                  }
 
+# Response values to DAP_Connect command
 DAP_MODE_SWD = 1
 DAP_MODE_JTAG = 2
 
-STICKORUN = 0x00000002
-STICKCMP = 0x00000010
-STICKYERR = 0x00000020
+# DP Control / Status Register bit definitions
+CTRLSTAT_STICKORUN = 0x00000002
+CTRLSTAT_STICKYCMP = 0x00000010
+CTRLSTAT_STICKYERR = 0x00000020
 
 def JTAG2SWD(interface):
     data = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
@@ -120,7 +122,7 @@ class CMSIS_DAP(Transport):
             # read ID code
             logging.info('IDCODE: 0x%X', dapJTAGIDCode(self.interface))
             # clear errors
-            self.writeDP(DP_REG['CTRL_STAT'], STICKYERR | STICKCMP | STICKORUN)
+            self.writeDP(DP_REG['CTRL_STAT'], CTRLSTAT_STICKYERR | CTRLSTAT_STICKYCMP | CTRLSTAT_STICKORUN)
         return
 
     def reinit(self):
@@ -136,7 +138,7 @@ class CMSIS_DAP(Transport):
             # Test logic reset, run test idle
             dapSWJSequence(self.interface, [0x1F])
             # clear errors
-            self.writeDP(DP_REG['CTRL_STAT'], STICKYERR | STICKCMP | STICKORUN)
+            self.writeDP(DP_REG['CTRL_STAT'], CTRLSTAT_STICKYERR | CTRLSTAT_STICKYCMP | CTRLSTAT_STICKORUN)
         return
 
     def uninit(self):
@@ -155,7 +157,7 @@ class CMSIS_DAP(Transport):
         if (self.mode == DAP_MODE_SWD):
             self.writeDP(0x0, (1 << 2))
         elif (self.mode == DAP_MODE_JTAG):
-            self.writeDP(DP_REG['CTRL_STAT'], STICKYERR)
+            self.writeDP(DP_REG['CTRL_STAT'], CTRLSTAT_STICKYERR)
 
     def writeMem(self, addr, data, transfer_size = 32):
         self.writeAP(AP_REG['CSW'], CSW_VALUE | TRANSFER_SIZE[transfer_size])

--- a/pyOCD/transport/cmsis_dap.py
+++ b/pyOCD/transport/cmsis_dap.py
@@ -15,7 +15,7 @@
  limitations under the License.
 """
 
-from cmsis_dap_core import dapTransferBlock, dapWriteAbort, dapSWJPins, dapConnect, dapDisconnect, dapTransfer, dapSWJSequence, dapSWDConfigure, dapSWJClock, dapTransferConfigure, dapInfo
+from cmsis_dap_core import dapTransferBlock, dapWriteAbort, dapSWJPins, dapConnect, dapDisconnect, dapTransfer, dapSWJSequence, dapSWDConfigure, dapSWJClock, dapTransferConfigure, dapInfo, dapJTAGIDCode, dapJTAGConfigure
 from transport import Transport, TransferError
 import logging
 from time import sleep
@@ -65,6 +65,12 @@ TRANSFER_SIZE = {8: CSW_SIZE8,
                  32: CSW_SIZE32
                  }
 
+DAP_MODE_SWD = 1
+DAP_MODE_JTAG = 2
+
+STICKORUN = 0x00000002
+STICKCMP = 0x00000010
+STICKYERR = 0x00000020
 
 def JTAG2SWD(interface):
     data = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
@@ -91,20 +97,30 @@ class CMSIS_DAP(Transport):
         self.dp_select = -1
 
     def init(self, frequency = 1000000):
-        # init dap IO
-        dapConnect(self.interface)
+        # connect to DAP, check for SWD or JTAG
+        self.mode = dapConnect(self.interface)
         # set clock frequency
         dapSWJClock(self.interface, frequency)
         # configure transfer
         dapTransferConfigure(self.interface)
-        # configure swd protocol
-        dapSWDConfigure(self.interface)
-        # switch from jtag to swd
-        JTAG2SWD(self.interface)
-        # read ID code
-        logging.info('IDCODE: 0x%X', self.readDP(DP_REG['IDCODE']))
-        # clear abort err
-        dapWriteAbort(self.interface, 0x1e);
+        if (self.mode == DAP_MODE_SWD):
+            # configure swd protocol
+            dapSWDConfigure(self.interface)
+            # switch from jtag to swd
+            JTAG2SWD(self.interface)
+            # read ID code
+            logging.info('IDCODE: 0x%X', self.readDP(DP_REG['IDCODE']))
+            # clear errors
+            dapWriteAbort(self.interface, 0x1e);
+        elif (self.mode == DAP_MODE_JTAG):
+            # configure jtag protocol
+            dapJTAGConfigure(self.interface, 4)
+            # Test logic reset, run test idle
+            dapSWJSequence(self.interface, [0x1F])
+            # read ID code
+            logging.info('IDCODE: 0x%X', dapJTAGIDCode(self.interface))
+            # clear errors
+            self.writeDP(DP_REG['CTRL_STAT'], STICKYERR | STICKCMP | STICKORUN)
         return
 
     def uninit(self):
@@ -119,6 +135,12 @@ class CMSIS_DAP(Transport):
             logging.error('request %s not supported', request)
         return resp
 
+    def clearStickyErr(self):
+        if (self.mode == DAP_MODE_SWD):
+            self.writeDP(0x0, (1 << 2))
+        elif (self.mode == DAP_MODE_JTAG):
+            self.writeDP(DP_REG['CTRL_STAT'], STICKYERR)
+
     def writeMem(self, addr, data, transfer_size = 32):
         self.writeAP(AP_REG['CSW'], CSW_VALUE | TRANSFER_SIZE[transfer_size])
 
@@ -132,8 +154,7 @@ class CMSIS_DAP(Transport):
                                             WRITE | AP_ACC | AP_REG['DRW']],
                                            [addr, data])
         except TransferError:
-            # Clear STICKYERR flag
-            self.writeDP(0x0, (1 << 2))
+            self.clearStickyErr()
             raise
 
     def readMem(self, addr, transfer_size = 32):
@@ -144,8 +165,7 @@ class CMSIS_DAP(Transport):
                                                    READ | AP_ACC | AP_REG['DRW']],
                                                   [addr])
         except TransferError:
-            # Clear STICKYERR flag
-            self.writeDP(0x0, (1 << 2))
+            self.clearStickyErr()
             raise
 
         res =   (resp[0] << 0)  | \
@@ -168,8 +188,7 @@ class CMSIS_DAP(Transport):
         try:
             dapTransferBlock(self.interface, len(data), WRITE | AP_ACC | AP_REG['DRW'], data)
         except TransferError:
-            # Clear STICKYERR flag
-            self.writeDP(0x0, (1 << 2))
+            self.clearStickyErr()
             raise
         return
 
@@ -182,8 +201,7 @@ class CMSIS_DAP(Transport):
         try:
             resp = dapTransferBlock(self.interface, size, READ | AP_ACC | AP_REG['DRW'])
         except TransferError:
-            # Clear STICKYERR flag
-            self.writeDP(0x0, (1 << 2))
+            self.clearStickyErr()
             raise
         for i in range(len(resp)/4):
             data.append( (resp[i*4 + 0] << 0)   | \

--- a/pyOCD/transport/cmsis_dap_core.py
+++ b/pyOCD/transport/cmsis_dap_core.py
@@ -34,6 +34,9 @@ COMMAND_ID = {'DAP_INFO': 0x00,
               'DAP_SWJ_CLOCK': 0x11,
               'DAP_SWJ_SEQUENCE': 0x12,
               'DAP_SWD_CONFIGURE': 0x13,
+              'DAP_JTAG_SEQUENCE': 0x14,
+              'DAP_JTAG_CONFIGURE': 0x15,
+              'DAP_JTAG_IDCODE': 0x16,
               }
 
 ID_INFO = {'VENDOR_ID': 0x01,
@@ -335,4 +338,54 @@ def dapSWJSequence(interface, data):
         raise ValueError('DAP SWJ Sequence failed')
         
     return resp[1]
-    
+
+def dapJTAGSequence(interface, info, tdi):
+    cmd = []
+    cmd.append(COMMAND_ID['DAP_JTAG_SEQUENCE'])
+    cmd.append(1)
+    cmd.append(info)
+    cmd.append(tdi)
+    interface.write(cmd)
+
+    resp = interface.read()
+    if resp[0] != COMMAND_ID['DAP_JTAG_SEQUENCE']:
+        raise ValueError('DAP_JTAG_SEQUENCE response error')
+
+    if resp[1] != DAP_OK:
+        raise ValueError('DAP JTAG Sequence failed')
+
+    return resp[2]
+
+def dapJTAGConfigure(interface, irlen, dev_num = 1):
+    cmd = []
+    cmd.append(COMMAND_ID['DAP_JTAG_CONFIGURE'])
+    cmd.append(dev_num)
+    cmd.append(irlen)
+    interface.write(cmd)
+
+    resp = interface.read()
+    if resp[0] != COMMAND_ID['DAP_JTAG_CONFIGURE']:
+        raise ValueError('DAP_JTAG_CONFIGURE response error')
+
+    if resp[1] != DAP_OK:
+        raise ValueError('DAP JTAG Configure failed')
+
+    return resp[2:]
+
+def dapJTAGIDCode(interface, index = 0):
+    cmd = []
+    cmd.append(COMMAND_ID['DAP_JTAG_IDCODE'])
+    cmd.append(index)
+    interface.write(cmd)
+
+    resp = interface.read()
+    if resp[0] != COMMAND_ID['DAP_JTAG_IDCODE']:
+        raise ValueError('DAP_JTAG_IDCODE response error')
+
+    if resp[1] != DAP_OK:
+        raise ValueError('DAP JTAG ID code failed')
+
+    return  (resp[2] << 0)  | \
+            (resp[3] << 8)  | \
+            (resp[4] << 16) | \
+            (resp[5] << 24)


### PR DESCRIPTION
1) Currently, pyOCD does not work for targets that only support JTAG (no SWD). This patch adds support for JTAG only devices.

2) If the JTAG tap is externally reset (e.g. target power cycle), pyOCD throws an exception and stops workings. This patch, adds handling of this exception and reconnects to the target.