### PR TITLE
LPC1768 has both 4k and 32k pages

### DIFF
--- a/pyOCD/flash/flash_lpc11u24.py
+++ b/pyOCD/flash/flash_lpc11u24.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013 ARM Limited
+ Copyright (c) 2006-2015 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -52,8 +52,6 @@ class Flash_lpc11u24(Flash):
     # TODO - temporary until flash algo is rebuilt with 4K page program size
     def programPage(self, flashPtr, bytes):
         write_size = 1024
-        self.page_size = write_size # temporarily override page size
         for i in range(0, 4):
             data = bytes[i * write_size : (i + 1) * write_size]
             Flash.programPage(self, flashPtr + i * write_size, data)
-        self.page_size = flash_algo['page_size'] # restore page size

--- a/pyOCD/flash/flash_lpc1768.py
+++ b/pyOCD/flash/flash_lpc1768.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013 ARM Limited
+ Copyright (c) 2006-2015 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -39,24 +39,29 @@ flash_algo = { 'load_address' : 0x10000000,
                                 ],
                'pc_init' : 0x10000047,
                'pc_eraseAll' : 0x100000e1,
-               'pc_erase_sector' : 0x10000122,
+               'pc_erase_sector' : 0x10000123,
                'pc_program_page' : 0x10000169,
-               'begin_data' : 0x1000023c,
+               'begin_data' : 0x2007c000,
                'begin_stack' : 0x10001000,
                'static_base' : 0x10000214,
-               'page_size' : 0x1000
+               'page_size' : 0x8000
               };
-              
+
 class Flash_lpc1768(Flash):
-    
+
     def __init__(self, target):
         super(Flash_lpc1768, self).__init__(target, flash_algo)
 
-    # TODO - temporary until flash algo is rebuilt with 4K page program size
+    def erasePage(self, flashPtr):
+        if flashPtr < 0x10000:
+            erase_size = 0x1000
+        else:
+            erase_size = 0x8000
+        for i in range(0, 0x8000 / erase_size):
+            Flash.erasePage(self, flashPtr + i * erase_size)
+
     def programPage(self, flashPtr, bytes):
         write_size = 1024
-        self.page_size = write_size # temporarily override page size
-        for i in range(0, 4):
+        for i in range(0, 32):
             data = bytes[i * write_size : (i + 1) * write_size]
             Flash.programPage(self, flashPtr + i * write_size, data)
-        self.page_size = flash_algo['page_size'] # restore page size

--- a/pyOCD/target/target_lpc1768.py
+++ b/pyOCD/target/target_lpc1768.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013 ARM Limited
+ Copyright (c) 2006-2015 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ class LPC1768(CortexM):
     memoryMapXML =  """<?xml version="1.0"?>
 <!DOCTYPE memory-map PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN" "http://sourceware.org/gdb/gdb-memory-map.dtd">
 <memory-map>
-    <memory type="flash" start="0x0" length="0x80000"> <property name="blocksize">0x400</property></memory>
+    <memory type="flash" start="0x0" length="0x10000"> <property name="blocksize">0x1000</property></memory>
+    <memory type="flash" start="0x10000" length="0x70000"> <property name="blocksize">0x8000</property></memory>
     <memory type="ram" start="0x10000000" length="0x8000"> </memory>
     <memory type="ram" start="0x2007C000" length="0x8000"> </memory>
 </memory-map>


### PR DESCRIPTION
I updated the flashing code to handle the LPC1768 which has sectors of multiple sizes: 
* the first 64k of FLASH uses 4k pages.
* the rest of FLASH uses 32k pages.

This commit includes these updates:
* I updated both the Flash_lpc11u24 and Flash_lpc1768 classes to no
  longer have code in the programPage() method to override the
  page_size field.  This does cause the program_page flashing algorithm
  routine to be passed the current page size (4k or 32k) instead of the
  fixed 1k value.  This is ok as those functions ignore that parameter
  anyway since that is the cause of needing this programPage()
  workaround in the first plae.
* For the LPC1768, I made the pc_erase_sector address odd to be
  consistent with the rest of the addresses in this map. It will work
  either way but this is consistent with the rest.
* For the LPC1768, I moved begin_data up into the upper AHB RAM banks
  so that a whole 32k is available once program_page is able to take
  a whole page at once and not just a fixed 1k.
* For the LPC1768, I updated the memoryMapXML to return the correct
  FLASH block sizes, including the switch from 4k to 32k pages.
* For the LPC1768, I bumped the page size up to 32k and then override
  the erasePage() and programPage() methods to loop the necessary
  amount of times to properly erase and program 32k.

I ran the basic_test.py tests on my LPC1768, LPC11U24, KL25Z, NRF51822, and LPC4330 boards.  I also used gdb_server.py to upload a 90,472 byte image to my LPC1768 to include a mix of 4k and 32k pages.