### PR TITLE
Remap flash to user code after reset on LPC

### DIFF
--- a/pyOCD/target/target_lpc11u24.py
+++ b/pyOCD/target/target_lpc11u24.py
@@ -31,3 +31,13 @@ class LPC11U24(CortexM):
         super(LPC11U24, self).__init__(transport)
         self.auto_increment_page_size = 0x400
 
+    def resetStopOnReset(self, software_reset = None, map_to_user = True):
+        CortexM.resetStopOnReset(self, software_reset)
+
+        # Remap to use flash and set SP and SP accordingly
+        if map_to_user:
+            self.writeMemory(0x40048000, 0x2, 32)
+            sp = self.readMemory(0x0)
+            pc = self.readMemory(0x4)
+            self.writeCoreRegisterRaw('sp', sp)
+            self.writeCoreRegisterRaw('pc', pc)

--- a/pyOCD/target/target_lpc800.py
+++ b/pyOCD/target/target_lpc800.py
@@ -31,3 +31,14 @@ class LPC800(CortexM):
     def __init__(self, transport):
         super(LPC800, self).__init__(transport)
         self.auto_increment_page_size = 0x400
+
+    def resetStopOnReset(self, software_reset = None, map_to_user = True):
+        CortexM.resetStopOnReset(self, software_reset)
+
+        # Remap to use flash and set SP and SP accordingly
+        if map_to_user:
+            self.writeMemory(0x40048000, 0x2, 32)
+            sp = self.readMemory(0x0)
+            pc = self.readMemory(0x4)
+            self.writeCoreRegisterRaw('sp', sp)
+            self.writeCoreRegisterRaw('pc', pc)


### PR DESCRIPTION
On the LPC11u24 and LPC800 the vector table is mapped to the boot
loader flash on reset rather than user flash.  This patch remaps the
flash back to user code and sets the SP and PC when resetStopOnReset
is called.