### PR TITLE
Fix hidapi back end

### DIFF
--- a/pyOCD/interface/hidapi_backend.py
+++ b/pyOCD/interface/hidapi_backend.py
@@ -39,6 +39,7 @@ class HidApiUSB(Interface):
     isAvailable = isAvailable
 
     def __init__(self):
+        super(HidApiUSB, self).__init__()
         # Vendor page and usage_id = 2
         self.device = None
 


### PR DESCRIPTION
In HidApiUSB call the parent class's constructor so all the required
fields are present.  In particular the addition of the member
'packet_count'  fixes crashes when running hidapi.

The HID API interface was broken by the patch:
d2b5c06d4cde08c2ed8a1121c055d3e6e56fb756 -
"Improve dapTransfer speed by queuing packets"