### PR TITLE
Refactoring for PyUSB backend

### DIFF
--- a/pyOCD/interface/pyusb_backend.py
+++ b/pyOCD/interface/pyusb_backend.py
@@ -80,8 +80,7 @@ class PyUSB(Interface):
 
         # iterate on all devices found
         for board in all_devices:
-            intf_number = 0
-            found = False
+            interface_number = -1
             
             # get active config
             config = board.get_active_configuration()
@@ -90,39 +89,23 @@ class PyUSB(Interface):
             #    - if we found a HID interface -> CMSIS-DAP
             for interface in config:
                 if interface.bInterfaceClass == 0x03:
-                    intf_number = interface.bInterfaceNumber
-                    found = True
+                    interface_number = interface.bInterfaceNumber
                     break
             
-            if found == False:
+            if interface_number == -1:
                 continue
             
             try:
-                if board.is_kernel_driver_active(intf_number) is True:
-                    board.detach_kernel_driver(intf_number)
+                if board.is_kernel_driver_active(interface_number):
+                    board.detach_kernel_driver(interface_number)
             except Exception as e:
                 print e
-                pass
-        
-            intf = usb.util.find_descriptor(config, bInterfaceNumber = intf_number)
-            ep_out = usb.util.find_descriptor(intf,
-                                              # match the first OUT endpoint
-                                              custom_match = \
-                                              lambda e: \
-                                              usb.util.endpoint_direction(e.bEndpointAddress) == \
-                                              usb.util.ENDPOINT_OUT
-                                              )
-            ep_in = usb.util.find_descriptor(intf,
-                                             # match the first IN endpoint
-                                             custom_match = \
-                                             lambda e: \
-                                             usb.util.endpoint_direction(e.bEndpointAddress) == \
-                                             usb.util.ENDPOINT_IN
-                                             )
+            
+            ep_in, ep_out = interface.endpoints()
             product_name = usb.util.get_string(board, 256, 2)
             vendor_name = usb.util.get_string(board, 256, 1)
             """If there is no EP for OUT then we can use CTRL EP"""
-            if ep_in is None: #ep_out is None or
+            if not ep_in or not ep_out:
                 logging.error('Endpoints not found')
                 return None
             
@@ -132,7 +115,7 @@ class PyUSB(Interface):
             new_board.dev = board
             new_board.vid = vid
             new_board.pid = pid
-            new_board.intf_number = intf_number
+            new_board.intf_number = interface_number
             new_board.product_name = product_name
             new_board.vendor_name = vendor_name
             new_board.start_rx()
@@ -149,7 +132,7 @@ class PyUSB(Interface):
 
         self.read_sem.release()
         
-        if self.ep_out is None:
+        if not self.ep_out:
             bmRequestType = 0x21              #Host to device request of type Class of Recipient Interface
             bmRequest     = 0x09              #Set_REPORT (HID class-specific request for transferring data over EP0)
             wValue        = 0x200             #Issuing an OUT report


### PR DESCRIPTION
Most of refactoring is to make the code more Pythonic. Namely PyUSB's
.endpoints() is used now instead of the manual lookup for the endpoints
of the interface.

Also some problematic value-checking is fixed. There was `is` used when
checking value. This is problematic and prone to bugs since `is` checks
by identity instead of checking by value.