### PR TITLE
Fix crash when loading multiple times from GDB

### DIFF
--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -384,6 +384,11 @@ class GDBServer(threading.Thread):
 
             self.flashBuilder.program(progress_cb = print_progress)
             sys.stdout.write("\r\n")
+
+            # Set flash builder to None so that on the next flash command a new
+            # object is used.
+            self.flashBuilder = None
+
             return self.createRSPPacket("OK")
         
         elif 'Cont' in ops:


### PR DESCRIPTION
Fix a crash caused by overlapping data in GDB server's flashBuilder
object by setting flashBuilder to none after it has been used.  With
this change the GDB server will create a new flash builder object
on the second load, and there will be no overlap.

This problem was introduced in the commit:
ecd0979967fe86747e8232357d7f7abfbd0531c2 -
Update gdbserver to support more generic programming