### PR TITLE
Map boards to board info rather than to target

### DIFF
--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -40,8 +40,7 @@ def basic_test(board_id, file):
         target_type = board.getTargetType()
 
         if file is None:
-            binary_file += target_type + ".bin"
-            binary_file = os.path.join(parentdir, 'binaries', binary_file)
+            binary_file = os.path.join(parentdir, 'binaries', board.getTestBinary())
         else:
             binary_file = file
 

--- a/test/blank_test.py
+++ b/test/blank_test.py
@@ -48,9 +48,7 @@ for i in range(0, 100):
 
 print "\r\n\r\n------ Flashing new code ------"
 with MbedBoard.chooseBoard() as board:
-    target_type = board.getTargetType()
-    binary_file = "l1_" + target_type + ".bin"
-    binary_file = os.path.join(parentdir, 'binaries', binary_file)
+    binary_file = os.path.join(parentdir, 'binaries', board.getTestBinary())
     board.flash.flashBinary(binary_file)
 
 print "\r\n\r\n------ Testing Attaching to regular board ------"

--- a/test/flash_test.py
+++ b/test/flash_test.py
@@ -191,9 +191,7 @@ def flash_test(board_id):
                         print("Progress went backwards during flash")
         print_progress.prev_progress = 0
 
-        binary_file = "l1_"
-        binary_file += target_type + ".bin"
-        binary_file = os.path.join(parentdir, 'binaries', binary_file)
+        binary_file = os.path.join(parentdir, 'binaries', board.getTestBinary())
         with open(binary_file, "rb") as f:
             data = f.read()
         data = struct.unpack("%iB" % len(data), data)


### PR DESCRIPTION
Map each board ID to a board info object rather than only to a target.
This make it possible to have a different test binary for each board.
Dedicated test binaries are important on boards that use the same
processor, but have buttons, lights or other hardware on different
pins.

Let me know what you think of this patch.  It's not finished yet, but I figured I would push it up so I could get some feedback.