### PR TITLE
Fix MAXWSNENV and MAX32600MBED

### DIFF
--- a/pyOCD/flash/flash_max32600mbed.py
+++ b/pyOCD/flash/flash_max32600mbed.py
@@ -41,10 +41,12 @@ flash_algo = { 'load_address' : 0x20000000,
                'pc_eraseAll' : 0x2000006D,
                'pc_erase_sector' : 0x200000B1,
                'pc_program_page' : 0x200000F9,
-               'begin_data' : 0x20003000,
+               'begin_data' : 0x20003000,       # Analyzer uses a max of 512 B data (128 pages * 4 bytes / page)
                'begin_stack' : 0x20001000,
                'static_base' : 0x20000230,
-               'page_size' : 0x800
+               'page_size' : 0x800,
+               'analyzer_supported' : True,
+               'analyzer_address' : 0x20004000  # Analyzer 0x20004000..0x20004600
               };
               
 class Flash_max32600mbed(Flash):

--- a/pyOCD/flash/flash_maxwsnenv.py
+++ b/pyOCD/flash/flash_maxwsnenv.py
@@ -41,10 +41,12 @@ flash_algo = { 'load_address' : 0x20000000,
                'pc_eraseAll' : 0x2000006D,
                'pc_erase_sector' : 0x200000B1,
                'pc_program_page' : 0x200000F9,
-               'begin_data' : 0x20003000,
+               'begin_data' : 0x20003000,       # Analyzer uses a max of 512 B data (128 pages * 4 bytes / page)
                'begin_stack' : 0x20001000,
                'static_base' : 0x20000230,
-               'page_size' : 0x800
+               'page_size' : 0x800,
+               'analyzer_supported' : True,
+               'analyzer_address' : 0x20004000  # Analyzer 0x20004000..0x20004600
               };
               
 class Flash_maxwsnenv(Flash):


### PR DESCRIPTION
Fix and add analyzer support to the targets MAXWSNENV and MAX32600MBED.

This was broken in the commit:
5ad7270f0998749e301ac5c7442558f18f086eed -
"Compute CRCs to analyze flash faster"