### PR TITLE
Fixes to pyusb interface to support Atmel EDBG CMSIS-DAP implementation

### DIFF
--- a/pyOCD/interface/pyusb_backend.py
+++ b/pyOCD/interface/pyusb_backend.py
@@ -133,7 +133,12 @@ class PyUSB(Interface):
         """
         write data on the OUT endpoint associated to the HID interface
         """
-        for _ in range(64 - len(data)):
+
+        report_size = 64
+        if self.ep_out:
+            report_size = self.ep_out.wMaxPacketSize
+
+        for _ in range(report_size - len(data)):
            data.append(0)
 
         self.read_sem.release()

--- a/pyOCD/interface/pyusb_backend.py
+++ b/pyOCD/interface/pyusb_backend.py
@@ -101,7 +101,13 @@ class PyUSB(Interface):
             except Exception as e:
                 print e
             
-            ep_in, ep_out = interface.endpoints()
+            ep_in, ep_out = None, None
+            for ep in interface:
+                if ep.bEndpointAddress & 0x80:
+                    ep_in = ep
+                else:
+                    ep_out = ep
+
             product_name = usb.util.get_string(board, 256, 2)
             vendor_name = usb.util.get_string(board, 256, 1)
             """If there is no EP for OUT then we can use CTRL EP"""


### PR DESCRIPTION
Some small tweaks to make PyOCD talk to the integrated CMSIS-DAP debugger on the Atmel SAMD21 Xplained board.

The `MbedBoard` class seems very specific to Mbed hardware, so I wasn't sure where to add automatic detection of the Xplained board, but creating the `Interface` manually works:
https://gist.github.com/kevinmehall/9b23ef99192b76d55e07