### PR TITLE
Add double buffer support to remaining targets

### DIFF
--- a/pyOCD/flash/flash_lpc11u24.py
+++ b/pyOCD/flash/flash_lpc11u24.py
@@ -39,6 +39,7 @@ flash_algo = { 'load_address' : 0x10000000,
                'pc_erase_sector' : 0x100000ab,
                'pc_program_page' : 0x100000ed,
                'begin_data' : 0x100001c4,
+               # Double buffering is not supported since there is not enough ram
                'begin_stack' : 0x10001000,
                'static_base' : 0x1000019c,
                'page_size' : 0x1000,

--- a/pyOCD/flash/flash_lpc1768.py
+++ b/pyOCD/flash/flash_lpc1768.py
@@ -48,6 +48,7 @@ flash_algo = { 'load_address' : 0x10000000,
                'pc_erase_sector' : 0x10000123,
                'pc_program_page' : 0x10000169,
                'begin_data' : 0x2007c000,       # Analyzer uses a max of 120 B data (30 pages * 4 bytes / page)
+               # Double buffering is not supported since there is not enough ram
                'begin_stack' : 0x10001000,
                'static_base' : 0x10000214,
                'page_size' : 0x8000,

--- a/pyOCD/flash/flash_lpc4330.py
+++ b/pyOCD/flash/flash_lpc4330.py
@@ -304,6 +304,7 @@ flash_algo = { 'load_address' : 0x10000000,
                'pc_erase_sector' : 0x1000009F,
                'pc_program_page' : 0x100000CD,
                'begin_data'      : 0x10004000,  # Analyzer uses a max of 128 KB data (32,768 pages * 4 bytes / page)
+               'page_buffers'    : [0x10004000, 0x10004800],   # Enable double buffering
                'begin_stack'     : 0x10008000,
                'static_base'     : 0x10002240,
                'page_size'       : 2048,

--- a/pyOCD/flash/flash_lpc800.py
+++ b/pyOCD/flash/flash_lpc800.py
@@ -38,6 +38,7 @@ flash_algo = { 'load_address' : 0x10000000,
                'pc_erase_sector' : 0x10000092,
                'pc_program_page' : 0x100000d4,
                'begin_data' : 0x10000400,       # Analyzer uses a max of 128 B data (32 pages * 4 bytes / page)
+               # Double buffering is not supported since there is not enough ram
                'begin_stack' : 0x10001000,
                'static_base' : 0x10000300,
                'page_size' : 1024,

--- a/pyOCD/flash/flash_max32600mbed.py
+++ b/pyOCD/flash/flash_max32600mbed.py
@@ -42,6 +42,7 @@ flash_algo = { 'load_address' : 0x20000000,
                'pc_erase_sector' : 0x200000B1,
                'pc_program_page' : 0x200000F9,
                'begin_data' : 0x20003000,       # Analyzer uses a max of 512 B data (128 pages * 4 bytes / page)
+               'page_buffers' : [0x20003000, 0x20003800],   # Enable double buffering
                'begin_stack' : 0x20001000,
                'static_base' : 0x20000230,
                'page_size' : 0x800,

--- a/pyOCD/flash/flash_maxwsnenv.py
+++ b/pyOCD/flash/flash_maxwsnenv.py
@@ -42,6 +42,7 @@ flash_algo = { 'load_address' : 0x20000000,
                'pc_erase_sector' : 0x200000B1,
                'pc_program_page' : 0x200000F9,
                'begin_data' : 0x20003000,       # Analyzer uses a max of 512 B data (128 pages * 4 bytes / page)
+               'page_buffers' : [0x20003000, 0x20003800],   # Enable double buffering
                'begin_stack' : 0x20001000,
                'static_base' : 0x20000230,
                'page_size' : 0x800,

--- a/pyOCD/flash/flash_nrf51.py
+++ b/pyOCD/flash/flash_nrf51.py
@@ -33,6 +33,7 @@ flash_algo = { 'load_address' : 0x20000000,
                'pc_erase_sector'  : 0x20000049,
                'pc_program_page'  : 0x20000071,
                'begin_data'       : 0x20002000, # Analyzer uses a max of 1 KB data (256 pages * 4 bytes / page)
+               'page_buffers'    : [0x20002000, 0x20002400],   # Enable double buffering
                'begin_stack'      : 0x20001000,
                'static_base'      : 0x20000170,
                'page_size'        : 1024,

--- a/pyOCD/flash/flash_stm32f051.py
+++ b/pyOCD/flash/flash_stm32f051.py
@@ -40,10 +40,11 @@ flash_algo = { 'load_address' : 0x20000000,
                'pc_program_page'  : 0x200000F7,
                'static_base'      : 0x200001A0,               
                'begin_data'       : 0x20000400, # Analyzer uses a max of 256 B data (64 pages * 4 bytes / page)
-               'begin_stack'      : 0x20000C00,
+               'page_buffers'     : [0x20000400, 0x20000800],   # Enable double buffering
+               'begin_stack'      : 0x20001000,
                'page_size'        : 1024,
                'analyzer_supported' : True,
-               'analyzer_address' : 0x20001000 # Analyzer 0x20001000..0x20001600
+               'analyzer_address' : 0x20001400 # Analyzer 0x20001400..0x20001A00
               };
 
               

--- a/pyOCD/flash/flash_stm32f103rc.py
+++ b/pyOCD/flash/flash_stm32f103rc.py
@@ -37,7 +37,8 @@ flash_algo = { 'load_address' : 0x20000000,
                'pc_program_page'  : 0x200000AD,
                'static_base'      : 0x20000200,               
                'begin_data'       : 0x20001000, # Analyzer uses a max of 1 KB data (256 pages * 4 bytes / page)
-               'begin_stack'      : 0x20002000,
+               'page_buffers'    : [0x20001000, 0x20001800],   # Enable double buffering
+               'begin_stack'      : 0x20002800,
                'page_size'        : 2048,
                'analyzer_supported' : True,
                'analyzer_address' : 0x20003000 # Analyzer 0x20003000..0x20003600


### PR DESCRIPTION
Add double buffer support to the lpc4330, max32600, maxwsnenv, nrf51,
stm32f051 and stm32f103rc.  Double buffering is not available due to
limited resources on the lpc11u24, lpc1768 and lpc800.