### PR TITLE
Fix halting target in gdb_server.py

### DIFF
--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -162,6 +162,9 @@ class GDBServer(threading.Thread):
                 if len(data) != 0:
                     # decode and prepare resp
                     [resp, ack, detach] = self.handleMsg(data)
+
+                    # Clear out data
+                    data = ""
             
                     if resp is not None:
                         # ack
@@ -680,7 +683,7 @@ class GDBServer(threading.Thread):
 
         if feature == 'StartNoAckMode':
             # Disable acks after the reply and ack.
-            self.clear_send_acks = False
+            self.clear_send_acks = True
             return self.createRSPPacket("OK")
         else:
             return self.createRSPPacket("")
@@ -733,6 +736,7 @@ class GDBServer(threading.Thread):
         return resp
     
     def ack(self):
-        self.abstract_socket.write("+")
+        if self.send_acks:
+            self.abstract_socket.write("+")
 
 


### PR DESCRIPTION
The gdb server reports it supports "no ack" mode, but still sends acks
after switching modes.  This causes the gdb client to hang when sending
the halt command (ctrl-c).

This patch prevents gdb server from sending acks after it has switched
modes.  It also explicitly clears out the data buffer after calling
handleMsg, since this was done implicitly by the code responsible for
reading acks.

The problems halting the target were introduced in the commit:
29e552501686908fc6c05abdf98c9fadf0446b76 -
"GDBServer no ack mode support."