### PR TITLE
Fix Nordic nRF51822 board to work on Linux

### DIFF
--- a/pyOCD/interface/pyusb_backend.py
+++ b/pyOCD/interface/pyusb_backend.py
@@ -111,7 +111,7 @@ class PyUSB(Interface):
             product_name = usb.util.get_string(board, 2)
             vendor_name = usb.util.get_string(board, 1)
             """If there is no EP for OUT then we can use CTRL EP"""
-            if not ep_in or not ep_out:
+            if not ep_in:
                 logging.error('Endpoints not found')
                 return None
             


### PR DESCRIPTION
A bug was introduced in commit caca94c720c93f30c7465ec84fc43c15d63274f8
which would no longer accept interface devices that used the control
endpoint for ep_out.  Without this fix pyOCD wouldn't connect to my
Nordic mbed enabled development kit on Ubuntu.