### PR TITLE
Prevent uninit timeout in pyusb_backend

### DIFF
--- a/pyOCD/interface/pyusb_backend.py
+++ b/pyOCD/interface/pyusb_backend.py
@@ -165,10 +165,6 @@ class PyUSB(Interface):
             pass
         return self.rcv_data.pop(0)
 
-    def setPacketCount(self, count):
-        # No interface level restrictions on count
-        self.packet_count = count
-
     def close(self):
         """
         close the interface


### PR DESCRIPTION
The PyUSB backend in a virtual machine can't seem to keep up with 
multiple packets being sent at the same time. Even with no timeout, 
the speed_test script hangs as soon as the overlapped test starts.

There may be a more efficient solution than just limiting the backend 
to a single packet, but this at least prevents PyUSB from crashing.
Should PyUSB be able to handle multiple packets on slow connections?

Tested on the K64F and nRF51822 in Ubuntu 14.04.