### PR TITLE
Refactored cmsis_dap_core functions into a CMSIS_DAP_Protocol class

### DIFF
--- a/pyOCD/target/target_max32600mbed.py
+++ b/pyOCD/target/target_max32600mbed.py
@@ -16,7 +16,7 @@
 """
 
 from cortex_m import CortexM
-from pyOCD.transport.cmsis_dap_core import dapJTAGIDCode, dapVendor, dapSWJPins, PINS
+from pyOCD.transport.cmsis_dap_core import PINS
 import logging
 
 class MAX32600MBED(CortexM):
@@ -39,13 +39,13 @@ class MAX32600MBED(CortexM):
         return the IDCODE of the core
         """
         if self.idcode == 0:
-            self.idcode = dapJTAGIDCode(self.transport.interface)
+            self.idcode = self.protocol.dapJTAGIDCode()
         return self.idcode
 
     def dsb(self):
         logging.info("Triggering Destructive Security Bypass...")
 
-        dapVendor(self.transport.interface, 1)
+        self.protocol.dapVendor(1)
 
         # Reconnect debugger
         self.transport.init()
@@ -53,7 +53,7 @@ class MAX32600MBED(CortexM):
     def fge(self):
         logging.info("Triggering Factory Global Erase...")
 
-        dapVendor(self.transport.interface, 2)
+        self.protocol.dapVendor(2)
 
         # Reconnect debugger
         self.transport.init()

--- a/pyOCD/target/target_max32600mbed.py
+++ b/pyOCD/target/target_max32600mbed.py
@@ -39,13 +39,13 @@ class MAX32600MBED(CortexM):
         return the IDCODE of the core
         """
         if self.idcode == 0:
-            self.idcode = self.protocol.dapJTAGIDCode()
+            self.idcode = self.protocol.jtagIDCode()
         return self.idcode
 
     def dsb(self):
         logging.info("Triggering Destructive Security Bypass...")
 
-        self.protocol.dapVendor(1)
+        self.protocol.vendor(1)
 
         # Reconnect debugger
         self.transport.init()
@@ -53,7 +53,7 @@ class MAX32600MBED(CortexM):
     def fge(self):
         logging.info("Triggering Factory Global Erase...")
 
-        self.protocol.dapVendor(2)
+        self.protocol.vendor(2)
 
         # Reconnect debugger
         self.transport.init()

--- a/pyOCD/target/target_maxwsnenv.py
+++ b/pyOCD/target/target_maxwsnenv.py
@@ -39,13 +39,13 @@ class MAXWSNENV(CortexM):
         return the IDCODE of the core
         """
         if self.idcode == 0:
-            self.idcode = self.protocol.dapJTAGIDCode()
+            self.idcode = self.protocol.jtagIDCode()
         return self.idcode
 
     def dsb(self):
         logging.info("Triggering Destructive Security Bypass...")
 
-        self.protocol.dapVendor(1)
+        self.protocol.vendor(1)
 
         # Reconnect debugger
         self.transport.init()
@@ -53,7 +53,7 @@ class MAXWSNENV(CortexM):
     def fge(self):
         logging.info("Triggering Factory Global Erase...")
 
-        self.protocol.dapVendor(2)
+        self.protocol.vendor(2)
 
         # Reconnect debugger
         self.transport.init()

--- a/pyOCD/target/target_maxwsnenv.py
+++ b/pyOCD/target/target_maxwsnenv.py
@@ -16,7 +16,7 @@
 """
 
 from cortex_m import CortexM
-from pyOCD.transport.cmsis_dap_core import dapJTAGIDCode, dapVendor, dapSWJPins, PINS
+from pyOCD.transport.cmsis_dap_core import PINS
 import logging
 
 class MAXWSNENV(CortexM):
@@ -39,13 +39,13 @@ class MAXWSNENV(CortexM):
         return the IDCODE of the core
         """
         if self.idcode == 0:
-            self.idcode = dapJTAGIDCode(self.transport.interface)
+            self.idcode = self.protocol.dapJTAGIDCode()
         return self.idcode
 
     def dsb(self):
         logging.info("Triggering Destructive Security Bypass...")
 
-        dapVendor(self.transport.interface, 1)
+        self.protocol.dapVendor(1)
 
         # Reconnect debugger
         self.transport.init()
@@ -53,7 +53,7 @@ class MAXWSNENV(CortexM):
     def fge(self):
         logging.info("Triggering Factory Global Erase...")
 
-        dapVendor(self.transport.interface, 2)
+        self.protocol.dapVendor(2)
 
         # Reconnect debugger
         self.transport.init()

--- a/pyOCD/transport/cmsis_dap.py
+++ b/pyOCD/transport/cmsis_dap.py
@@ -15,7 +15,7 @@
  limitations under the License.
 """
 
-from cmsis_dap_core import dapTransferBlock, dapWriteAbort, dapSWJPins, dapConnect, dapDisconnect, dapTransfer, dapSWJSequence, dapSWDConfigure, dapSWJClock, dapTransferConfigure, dapInfo, dapJTAGIDCode, dapJTAGConfigure
+from cmsis_dap_core import CMSIS_DAP_Protocol
 from transport import Transport, TransferError, READ_START, READ_NOW, READ_END
 import logging
 from time import sleep
@@ -77,25 +77,13 @@ CTRLSTAT_STICKYERR = 0x00000020
 
 COMMANDS_PER_DAP_TRANSFER = 12
 
-def JTAG2SWD(interface):
-    data = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
-    dapSWJSequence(interface, data)
-
-    data = [0x9e, 0xe7]
-    dapSWJSequence(interface, data)
-
-    data = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
-    dapSWJSequence(interface, data)
-
-    data = [0x00]
-    dapSWJSequence(interface, data)
-
 class CMSIS_DAP(Transport):
     """
     This class implements the CMSIS-DAP protocol
     """
     def __init__(self, interface):
         super(CMSIS_DAP, self).__init__(interface)
+        self.protocol = CMSIS_DAP_Protocol(interface)
         self.packet_max_count = 0
         self.packet_max_size = 0
         self.csw = -1
@@ -109,41 +97,54 @@ class CMSIS_DAP(Transport):
         # Flush to be safe
         self.flush()
         # connect to DAP, check for SWD or JTAG
-        self.mode = dapConnect(self.interface)
+        self.mode = self.protocol.dapConnect()
         # set clock frequency
-        dapSWJClock(self.interface, frequency)
+        self.protocol.dapSWJClock(frequency)
         # configure transfer
-        dapTransferConfigure(self.interface)
+        self.protocol.dapTransferConfigure()
         if (self.mode == DAP_MODE_SWD):
             # configure swd protocol
-            dapSWDConfigure(self.interface)
+            self.protocol.dapSWDConfigure()
             # switch from jtag to swd
-            JTAG2SWD(self.interface)
+            self.JTAG2SWD()
             # read ID code
             logging.info('IDCODE: 0x%X', self.readDP(DP_REG['IDCODE']))
             # clear errors
-            dapWriteAbort(self.interface, 0x1e);
+            self.protocol.dapWriteAbort(0x1e);
         elif (self.mode == DAP_MODE_JTAG):
             # configure jtag protocol
-            dapJTAGConfigure(self.interface, 4)
+            self.protocol.dapJTAGConfigure(4)
             # Test logic reset, run test idle
-            dapSWJSequence(self.interface, [0x1F])
+            self.protocol.dapSWJSequence([0x1F])
             # read ID code
-            logging.info('IDCODE: 0x%X', dapJTAGIDCode(self.interface))
+            logging.info('IDCODE: 0x%X', self.protocol.dapJTAGIDCode())
             # clear errors
             self.writeDP(DP_REG['CTRL_STAT'], CTRLSTAT_STICKYERR | CTRLSTAT_STICKYCMP | CTRLSTAT_STICKYORUN)
         return
 
     def uninit(self):
         self.flush()
-        dapDisconnect(self.interface)
+        self.protocol.dapDisconnect()
         return
+
+    def JTAG2SWD(self):
+        data = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
+        self.protocol.dapSWJSequence(data)
+
+        data = [0x9e, 0xe7]
+        self.protocol.dapSWJSequence(data)
+
+        data = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
+        self.protocol.dapSWJSequence(data)
+
+        data = [0x00]
+        self.protocol.dapSWJSequence(data)
 
     def info(self, request):
         self.flush()
         resp = None
         try:
-            resp = dapInfo(self.interface, request)
+            resp = self.protocol.dapInfo(request)
         except KeyError:
             logging.error('request %s not supported', request)
         return resp
@@ -306,23 +307,24 @@ class CMSIS_DAP(Transport):
             self.flush()
 
         return res
+
     def reset(self):
         self.flush()
-        dapSWJPins(self.interface, 0, 'nRESET')
+        self.protocol.dapSWJPins(0, 'nRESET')
         sleep(0.1)
-        dapSWJPins(self.interface, 0x80, 'nRESET')
+        self.protocol.dapSWJPins(0x80, 'nRESET')
         sleep(0.1)
 
     def assertReset(self, asserted):
         self.flush()
         if asserted:
-            dapSWJPins(self.interface, 0, 'nRESET')
+            self.protocol.dapSWJPins(0, 'nRESET')
         else:
-            dapSWJPins(self.interface, 0x80, 'nRESET')
+            self.protocol.dapSWJPins(0x80, 'nRESET')
 
     def setClock(self, frequency):
         self.flush()
-        dapSWJClock(self.interface, frequency)
+        self.protocol.dapSWJClock(frequency)
 
     def setDeferredTransfer(self, enable):
         """
@@ -338,7 +340,7 @@ class CMSIS_DAP(Transport):
         exception to occur on a later, unrelated write.  To guarantee
         that previous writes are complete call the flush() function.
 
-        The behaviour of read operations is determined by the modes 
+        The behaviour of read operations is determined by the modes
         READ_START, READ_NOW and READ_END.  The option READ_NOW is the
         default and will cause the read to flush all previous writes,
         and read the data immediately.  To improve performance, multiple
@@ -358,7 +360,7 @@ class CMSIS_DAP(Transport):
         if transfer_count > 0:
             assert transfer_count <= COMMANDS_PER_DAP_TRANSFER
             try:
-                data = dapTransfer(self.interface, transfer_count, self.request_list, self.data_list)
+                data = self.protocol.dapTransfer(transfer_count, self.request_list, self.data_list)
                 self.data_read_list.extend(data)
             except TransferError:
                 # Dump any pending commands
@@ -397,4 +399,4 @@ class CMSIS_DAP(Transport):
 
     def _transferBlock(self, count, request, data = [0]):
         self.flush()
-        return dapTransferBlock(self.interface, count, request, data)
+        return self.protocol.dapTransferBlock(count, request, data)

--- a/pyOCD/transport/cmsis_dap_core.py
+++ b/pyOCD/transport/cmsis_dap_core.py
@@ -104,11 +104,11 @@ class CMSIS_DAP_Protocol(object):
 
         return x.tostring()
 
-    def dapLed(interface):
+    def setLed(interface):
         #not yet implemented
         return
 
-    def dapConnect(self, mode = DAP_DEFAULT_PORT):
+    def connect(self, mode = DAP_DEFAULT_PORT):
         cmd = []
         cmd.append(COMMAND_ID['DAP_CONNECT'])
         cmd.append(mode)
@@ -129,7 +129,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp[1]
 
-    def dapDisconnect(self):
+    def disconnect(self):
         cmd = []
         cmd.append(COMMAND_ID['DAP_DISCONNECT'])
         self.interface.write(cmd)
@@ -143,7 +143,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp[1]
 
-    def dapWriteAbort(self, data, dap_index = 0):
+    def writeAbort(self, data, dap_index = 0):
         cmd = []
         cmd.append(COMMAND_ID['DAP_WRITE_ABORT'])
         cmd.append(dap_index)
@@ -162,7 +162,7 @@ class CMSIS_DAP_Protocol(object):
 
         return True
 
-    def dapResetTarget(interface):
+    def resetTarget(interface):
         cmd = []
         cmd.append(COMMAND_ID['DAP_RESET_TARGET'])
         self.interface.write(cmd)
@@ -176,7 +176,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp[1]
 
-    def dapTransferConfigure(self, idle_cycles = 0x00, wait_retry = 0x0050, match_retry = 0x0000):
+    def transferConfigure(self, idle_cycles = 0x00, wait_retry = 0x0050, match_retry = 0x0000):
         cmd = []
         cmd.append(COMMAND_ID['DAP_TRANSFER_CONFIGURE'])
         cmd.append(idle_cycles)
@@ -195,7 +195,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp[1]
 
-    def dapTransfer(self, count, request, data = [0], dap_index = 0):
+    def transfer(self, count, request, data = [0], dap_index = 0):
         cmd = []
         cmd.append(COMMAND_ID['DAP_TRANSFER'])
         cmd.append(dap_index)
@@ -227,7 +227,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp[3:3+count_write*4]
 
-    def dapTransferBlock(self, count, request, data = [0], dap_index = 0):
+    def transferBlock(self, count, request, data = [0], dap_index = 0):
         packet_count = count
         max_pending_reads = self.interface.getPacketCount()
         reads_pending = 0
@@ -289,7 +289,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp
 
-    def dapSWJClock(self, clock = 1000000):
+    def setSWJClock(self, clock = 1000000):
         cmd = []
         cmd.append(COMMAND_ID['DAP_SWJ_CLOCK'])
         cmd.append(clock & 0xff)
@@ -307,7 +307,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp[1]
 
-    def dapSWJPins(self, output, pin, wait = 0):
+    def setSWJPins(self, output, pin, wait = 0):
         cmd = []
         cmd.append(COMMAND_ID['DAP_SWJ_PINS'])
         try:
@@ -329,8 +329,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp[1]
 
-
-    def dapSWDConfigure(self, conf = 0):
+    def swdConfigure(self, conf = 0):
         cmd = []
         cmd.append(COMMAND_ID['DAP_SWD_CONFIGURE'])
         cmd.append(conf)
@@ -345,7 +344,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp[1]
 
-    def dapSWJSequence(self, data):
+    def swjSequence(self, data):
         cmd = []
         cmd.append(COMMAND_ID['DAP_SWJ_SEQUENCE'])
         cmd.append(len(data)*8)
@@ -362,7 +361,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp[1]
 
-    def dapJTAGSequence(self, info, tdi):
+    def jtagSequence(self, info, tdi):
         cmd = []
         cmd.append(COMMAND_ID['DAP_JTAG_SEQUENCE'])
         cmd.append(1)
@@ -379,7 +378,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp[2]
 
-    def dapJTAGConfigure(self, irlen, dev_num = 1):
+    def jtagConfigure(self, irlen, dev_num = 1):
         cmd = []
         cmd.append(COMMAND_ID['DAP_JTAG_CONFIGURE'])
         cmd.append(dev_num)
@@ -395,7 +394,7 @@ class CMSIS_DAP_Protocol(object):
 
         return resp[2:]
 
-    def dapJTAGIDCode(self, index = 0):
+    def jtagIDCode(self, index = 0):
         cmd = []
         cmd.append(COMMAND_ID['DAP_JTAG_IDCODE'])
         cmd.append(index)
@@ -413,7 +412,7 @@ class CMSIS_DAP_Protocol(object):
                 (resp[4] << 16) | \
                 (resp[5] << 24)
 
-    def dapVendor(self, index):
+    def vendor(self, index):
         cmd = []
         cmd.append(COMMAND_ID['DAP_VENDOR0'] + index)
         self.interface.write(cmd)

--- a/pyOCD/transport/cmsis_dap_core.py
+++ b/pyOCD/transport/cmsis_dap_core.py
@@ -74,348 +74,351 @@ DAP_TRANSFER_FAULT = 4
 
 MAX_PACKET_SIZE = 0x0E
 
-def dapInfo(interface, id_):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_INFO'])
-    cmd.append(ID_INFO[id_])
-    interface.write(cmd)
+## @brief This class implements the CMSIS-DAP wire protocol.
+class CMSIS_DAP_Protocol(object):
+    def __init__(self, interface):
+        self.interface = interface
 
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_INFO']:
-        raise ValueError('DAP_INFO response error')
-    
-    if resp[1] == 0:
+    def dapInfo(self, id_):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_INFO'])
+        cmd.append(ID_INFO[id_])
+        self.interface.write(cmd)
+
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_INFO']:
+            raise ValueError('DAP_INFO response error')
+
+        if resp[1] == 0:
+            return
+
+        # Integer values
+        if id_ in ('CAPABILITIES', 'PACKET_COUNT', 'PACKET_SIZE'):
+            if resp[1] == 1:
+                return resp[2]
+            if resp[1] == 2:
+                return (resp[3] << 8) | resp[2]
+
+        # String values
+        x = array.array('B', [i for i in resp[2:2+resp[1]]])
+
+        return x.tostring()
+
+    def dapLed(interface):
+        #not yet implemented
         return
-    
-    # Integer values
-    if id_ in ('CAPABILITIES', 'PACKET_COUNT', 'PACKET_SIZE'):
+
+    def dapConnect(self, mode = DAP_DEFAULT_PORT):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_CONNECT'])
+        cmd.append(mode)
+        self.interface.write(cmd)
+
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_CONNECT']:
+            raise ValueError('DAP_CONNECT response error')
+
+        if resp[1] == 0:
+            raise ValueError('DAP Connect failed')
+
         if resp[1] == 1:
-            return resp[2]
+            logging.info('DAP SWD MODE initialised')
+
         if resp[1] == 2:
-            return (resp[3] << 8) | resp[2]
+            logging.info('DAP JTAG MODE initialised')
 
-    # String values
-    x = array.array('B', [i for i in resp[2:2+resp[1]]])
+        return resp[1]
 
-    return x.tostring()
-    
-    
-def dapLed(interface):
-    #not yet implemented
-    return
+    def dapDisconnect(self):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_DISCONNECT'])
+        self.interface.write(cmd)
 
-def dapConnect(interface, mode = DAP_DEFAULT_PORT):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_CONNECT'])
-    cmd.append(mode)
-    interface.write(cmd)
-    
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_CONNECT']:
-        raise ValueError('DAP_CONNECT response error')
-    
-    if resp[1] == 0:
-        raise ValueError('DAP Connect failed')
-    
-    if resp[1] == 1:
-        logging.info('DAP SWD MODE initialised')
-    
-    if resp[1] == 2:
-        logging.info('DAP JTAG MODE initialised')
-    
-    return resp[1]
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_DISCONNECT']:
+            raise ValueError('DAP_DISCONNECT response error')
 
-def dapDisconnect(interface):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_DISCONNECT'])
-    interface.write(cmd)
-    
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_DISCONNECT']:
-        raise ValueError('DAP_DISCONNECT response error')
-    
-    if resp[1] != DAP_OK:
-        raise ValueError('DAP Disconnect failed')
-        
-    return resp[1]
-    
-    
-def dapWriteAbort(interface, data, dap_index = 0):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_WRITE_ABORT'])
-    cmd.append(dap_index)
-    cmd.append((data >> 0) & 0xff)
-    cmd.append((data >> 8) & 0xff)
-    cmd.append((data >> 16) & 0xff)
-    cmd.append((data >> 24) & 0xff)
-    interface.write(cmd)
-    
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_WRITE_ABORT']:
-        raise ValueError('DAP_WRITE_ABORT response error')
-    
-    if resp[1] != DAP_OK:
-        raise ValueError('DAP Write Abort failed')
-        
-    return True
+        if resp[1] != DAP_OK:
+            raise ValueError('DAP Disconnect failed')
 
-def dapResetTarget(interface):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_RESET_TARGET'])
-    interface.write(cmd)
-    
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_RESET_TARGET']:
-        raise ValueError('DAP_RESET_TARGET response error')
-    
-    if resp[1] != DAP_OK:
-        raise ValueError('DAP Reset target failed')
-        
-    return resp[1]
+        return resp[1]
 
-def dapTransferConfigure(interface, idle_cycles = 0x00, wait_retry = 0x0050, match_retry = 0x0000):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_TRANSFER_CONFIGURE'])
-    cmd.append(idle_cycles)
-    cmd.append(wait_retry & 0xff)
-    cmd.append(wait_retry >> 8)
-    cmd.append(match_retry & 0xff)
-    cmd.append(match_retry >> 8)
-    interface.write(cmd)
-    
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_TRANSFER_CONFIGURE']:
-        raise ValueError('DAP_TRANSFER_CONFIGURE response error')
-    
-    if resp[1] != DAP_OK:
-        raise ValueError('DAP Transfer Configure failed')
-        
-    return resp[1]
+    def dapWriteAbort(self, data, dap_index = 0):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_WRITE_ABORT'])
+        cmd.append(dap_index)
+        cmd.append((data >> 0) & 0xff)
+        cmd.append((data >> 8) & 0xff)
+        cmd.append((data >> 16) & 0xff)
+        cmd.append((data >> 24) & 0xff)
+        self.interface.write(cmd)
 
-def dapTransfer(interface, count, request, data = [0], dap_index = 0):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_TRANSFER'])
-    cmd.append(dap_index)
-    cmd.append(count)
-    count_write = count
-    for i in range(count):
-        cmd.append(request[i])
-        if not ( request[i] & ((1 << 1) | (1 << 4))):
-            cmd.append(data[i] & 0xff)
-            cmd.append((data[i] >> 8) & 0xff)
-            cmd.append((data[i] >> 16) & 0xff)
-            cmd.append((data[i] >> 24) & 0xff)
-            count_write -= 1
-    interface.write(cmd)
-    
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_TRANSFER']:
-        raise ValueError('DAP_TRANSFER response error')
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_WRITE_ABORT']:
+            raise ValueError('DAP_WRITE_ABORT response error')
 
-    if resp[2] != DAP_TRANSFER_OK:
-        if resp[2] == DAP_TRANSFER_FAULT:
-            raise TransferError()
-        raise ValueError('SWD Fault')
+        if resp[1] != DAP_OK:
+            raise ValueError('DAP Write Abort failed')
 
-    # Check for count mismatch after checking for DAP_TRANSFER_FAULT
-    # This allows TransferError to get thrown instead of ValueError
-    if resp[1] != count:
-        raise ValueError('Transfer not completed')
+        return True
 
-    return resp[3:3+count_write*4]
+    def dapResetTarget(interface):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_RESET_TARGET'])
+        self.interface.write(cmd)
 
-def dapTransferBlock(interface, count, request, data = [0], dap_index = 0):
-    packet_count = count
-    max_pending_reads = interface.getPacketCount()
-    reads_pending = 0
-    nb = 0
-    resp = []
-    error_transfer = False
-    error_response = False
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_RESET_TARGET']:
+            raise ValueError('DAP_RESET_TARGET response error')
 
-    # we send successfully several packets if the size is bigger than MAX_PACKET_COUNT
-    while packet_count > 0 or reads_pending > 0:
-        # Make sure the transmit buffer stays saturated
-        while packet_count > 0 and reads_pending < max_pending_reads:
-            cmd = []
-            cmd.append(COMMAND_ID['DAP_TRANSFER_BLOCK'])
-            cmd.append(dap_index)
-            packet_written = min(packet_count, MAX_PACKET_SIZE)
-            cmd.append(packet_written & 0xff)
-            cmd.append((packet_written >> 8) & 0xff)
-            cmd.append(request)
-            if not (request & ((1 << 1))):
-                for i in range(packet_written):
-                    cmd.append(data[i + nb*MAX_PACKET_SIZE] & 0xff)
-                    cmd.append((data[i + nb*MAX_PACKET_SIZE] >> 8) & 0xff)
-                    cmd.append((data[i + nb*MAX_PACKET_SIZE] >> 16) & 0xff)
-                    cmd.append((data[i + nb*MAX_PACKET_SIZE] >> 24) & 0xff)
-            interface.write(cmd)
-            packet_count = packet_count - MAX_PACKET_SIZE
-            nb = nb + 1
-            reads_pending = reads_pending + 1
+        if resp[1] != DAP_OK:
+            raise ValueError('DAP Reset target failed')
 
-        # Read data
-        if reads_pending > 0:
-            # we then read
-            tmp = interface.read()
-            if tmp[0] != COMMAND_ID['DAP_TRANSFER_BLOCK']:
-                # Error occurred - abort further writes
-                # but make sure to finish reading remaining packets
-                packet_count = 0
-                error_response = True
+        return resp[1]
 
-            if tmp[3] != DAP_TRANSFER_OK:
-                # Error occurred - abort further writes
-                # but make sure to finish reading remaining packets
-                packet_count = 0
-                if tmp[3] == DAP_TRANSFER_FAULT:
-                    error_transfer = True
-                else:
+    def dapTransferConfigure(self, idle_cycles = 0x00, wait_retry = 0x0050, match_retry = 0x0000):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_TRANSFER_CONFIGURE'])
+        cmd.append(idle_cycles)
+        cmd.append(wait_retry & 0xff)
+        cmd.append(wait_retry >> 8)
+        cmd.append(match_retry & 0xff)
+        cmd.append(match_retry >> 8)
+        self.interface.write(cmd)
+
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_TRANSFER_CONFIGURE']:
+            raise ValueError('DAP_TRANSFER_CONFIGURE response error')
+
+        if resp[1] != DAP_OK:
+            raise ValueError('DAP Transfer Configure failed')
+
+        return resp[1]
+
+    def dapTransfer(self, count, request, data = [0], dap_index = 0):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_TRANSFER'])
+        cmd.append(dap_index)
+        cmd.append(count)
+        count_write = count
+        for i in range(count):
+            cmd.append(request[i])
+            if not ( request[i] & ((1 << 1) | (1 << 4))):
+                cmd.append(data[i] & 0xff)
+                cmd.append((data[i] >> 8) & 0xff)
+                cmd.append((data[i] >> 16) & 0xff)
+                cmd.append((data[i] >> 24) & 0xff)
+                count_write -= 1
+        self.interface.write(cmd)
+
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_TRANSFER']:
+            raise ValueError('DAP_TRANSFER response error')
+
+        if resp[2] != DAP_TRANSFER_OK:
+            if resp[2] == DAP_TRANSFER_FAULT:
+                raise TransferError()
+            raise ValueError('SWD Fault')
+
+        # Check for count mismatch after checking for DAP_TRANSFER_FAULT
+        # This allows TransferError to get thrown instead of ValueError
+        if resp[1] != count:
+            raise ValueError('Transfer not completed')
+
+        return resp[3:3+count_write*4]
+
+    def dapTransferBlock(self, count, request, data = [0], dap_index = 0):
+        packet_count = count
+        max_pending_reads = self.interface.getPacketCount()
+        reads_pending = 0
+        nb = 0
+        resp = []
+        error_transfer = False
+        error_response = False
+
+        # we send successfully several packets if the size is bigger than MAX_PACKET_COUNT
+        while packet_count > 0 or reads_pending > 0:
+            # Make sure the transmit buffer stays saturated
+            while packet_count > 0 and reads_pending < max_pending_reads:
+                cmd = []
+                cmd.append(COMMAND_ID['DAP_TRANSFER_BLOCK'])
+                cmd.append(dap_index)
+                packet_written = min(packet_count, MAX_PACKET_SIZE)
+                cmd.append(packet_written & 0xff)
+                cmd.append((packet_written >> 8) & 0xff)
+                cmd.append(request)
+                if not (request & ((1 << 1))):
+                    for i in range(packet_written):
+                        cmd.append(data[i + nb*MAX_PACKET_SIZE] & 0xff)
+                        cmd.append((data[i + nb*MAX_PACKET_SIZE] >> 8) & 0xff)
+                        cmd.append((data[i + nb*MAX_PACKET_SIZE] >> 16) & 0xff)
+                        cmd.append((data[i + nb*MAX_PACKET_SIZE] >> 24) & 0xff)
+                self.interface.write(cmd)
+                packet_count = packet_count - MAX_PACKET_SIZE
+                nb = nb + 1
+                reads_pending = reads_pending + 1
+
+            # Read data
+            if reads_pending > 0:
+                # we then read
+                tmp = self.interface.read()
+                if tmp[0] != COMMAND_ID['DAP_TRANSFER_BLOCK']:
+                    # Error occurred - abort further writes
+                    # but make sure to finish reading remaining packets
+                    packet_count = 0
                     error_response = True
 
-            size_transfer = tmp[1] | (tmp[2] << 8)
-            resp.extend(tmp[4:4+size_transfer*4])
-            reads_pending = reads_pending - 1
+                if tmp[3] != DAP_TRANSFER_OK:
+                    # Error occurred - abort further writes
+                    # but make sure to finish reading remaining packets
+                    packet_count = 0
+                    if tmp[3] == DAP_TRANSFER_FAULT:
+                        error_transfer = True
+                    else:
+                        error_response = True
 
-    # Raise pending errors
-    if error_response:
-        raise ValueError('DAP_TRANSFER_BLOCK response error')
-    elif error_transfer:
-        raise TransferError()
+                size_transfer = tmp[1] | (tmp[2] << 8)
+                resp.extend(tmp[4:4+size_transfer*4])
+                reads_pending = reads_pending - 1
 
-    return resp
-    
-def dapSWJClock(interface, clock = 1000000):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_SWJ_CLOCK'])
-    cmd.append(clock & 0xff)
-    cmd.append((clock >> 8) & 0xff)
-    cmd.append((clock >> 16) & 0xff)
-    cmd.append((clock >> 24) & 0xff)
-    interface.write(cmd)
-    
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_SWJ_CLOCK']:
-            raise ValueError('DAP_SWJ_CLOCK response error')
-        
-    if resp[1] != DAP_OK:
-        raise ValueError('DAP SWJ Clock failed')
-        
-    return resp[1]
+        # Raise pending errors
+        if error_response:
+            raise ValueError('DAP_TRANSFER_BLOCK response error')
+        elif error_transfer:
+            raise TransferError()
 
-def dapSWJPins(interface, output, pin, wait = 0):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_SWJ_PINS'])
-    try:
-        p = PINS[pin]
-    except KeyError:
-            logging.error('cannot find %s pin', pin)
-            return
-    cmd.append(output & 0xff)
-    cmd.append(p)
-    cmd.append(wait & 0xff)
-    cmd.append((wait >> 8) & 0xff)
-    cmd.append((wait >> 16) & 0xff)
-    cmd.append((wait >> 24) & 0xff)
-    interface.write(cmd)
-    
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_SWJ_PINS']:
-            raise ValueError('DAP_SWJ_PINS response error')
-        
-    return resp[1]
-    
+        return resp
 
-def dapSWDConfigure(interface, conf = 0):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_SWD_CONFIGURE'])
-    cmd.append(conf)
-    interface.write(cmd)
-    
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_SWD_CONFIGURE']:
-            raise ValueError('DAP_SWD_CONFIGURE response error')
-        
-    if resp[1] != DAP_OK:
-        raise ValueError('DAP SWD Configure failed')
-        
-    return resp[1]
+    def dapSWJClock(self, clock = 1000000):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_SWJ_CLOCK'])
+        cmd.append(clock & 0xff)
+        cmd.append((clock >> 8) & 0xff)
+        cmd.append((clock >> 16) & 0xff)
+        cmd.append((clock >> 24) & 0xff)
+        self.interface.write(cmd)
 
-def dapSWJSequence(interface, data):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_SWJ_SEQUENCE'])
-    cmd.append(len(data)*8)
-    for i in range(len(data)):
-        cmd.append(data[i])
-    interface.write(cmd)
-    
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_SWJ_SEQUENCE']:
-            raise ValueError('DAP_SWJ_SEQUENCE response error')
-        
-    if resp[1] != DAP_OK:
-        raise ValueError('DAP SWJ Sequence failed')
-        
-    return resp[1]
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_SWJ_CLOCK']:
+                raise ValueError('DAP_SWJ_CLOCK response error')
 
-def dapJTAGSequence(interface, info, tdi):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_JTAG_SEQUENCE'])
-    cmd.append(1)
-    cmd.append(info)
-    cmd.append(tdi)
-    interface.write(cmd)
+        if resp[1] != DAP_OK:
+            raise ValueError('DAP SWJ Clock failed')
 
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_JTAG_SEQUENCE']:
-        raise ValueError('DAP_JTAG_SEQUENCE response error')
+        return resp[1]
 
-    if resp[1] != DAP_OK:
-        raise ValueError('DAP JTAG Sequence failed')
+    def dapSWJPins(self, output, pin, wait = 0):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_SWJ_PINS'])
+        try:
+            p = PINS[pin]
+        except KeyError:
+                logging.error('cannot find %s pin', pin)
+                return
+        cmd.append(output & 0xff)
+        cmd.append(p)
+        cmd.append(wait & 0xff)
+        cmd.append((wait >> 8) & 0xff)
+        cmd.append((wait >> 16) & 0xff)
+        cmd.append((wait >> 24) & 0xff)
+        self.interface.write(cmd)
 
-    return resp[2]
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_SWJ_PINS']:
+                raise ValueError('DAP_SWJ_PINS response error')
 
-def dapJTAGConfigure(interface, irlen, dev_num = 1):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_JTAG_CONFIGURE'])
-    cmd.append(dev_num)
-    cmd.append(irlen)
-    interface.write(cmd)
+        return resp[1]
 
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_JTAG_CONFIGURE']:
-        raise ValueError('DAP_JTAG_CONFIGURE response error')
 
-    if resp[1] != DAP_OK:
-        raise ValueError('DAP JTAG Configure failed')
+    def dapSWDConfigure(self, conf = 0):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_SWD_CONFIGURE'])
+        cmd.append(conf)
+        self.interface.write(cmd)
 
-    return resp[2:]
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_SWD_CONFIGURE']:
+                raise ValueError('DAP_SWD_CONFIGURE response error')
 
-def dapJTAGIDCode(interface, index = 0):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_JTAG_IDCODE'])
-    cmd.append(index)
-    interface.write(cmd)
+        if resp[1] != DAP_OK:
+            raise ValueError('DAP SWD Configure failed')
 
-    resp = interface.read()
-    if resp[0] != COMMAND_ID['DAP_JTAG_IDCODE']:
-        raise ValueError('DAP_JTAG_IDCODE response error')
+        return resp[1]
 
-    if resp[1] != DAP_OK:
-        raise ValueError('DAP JTAG ID code failed')
+    def dapSWJSequence(self, data):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_SWJ_SEQUENCE'])
+        cmd.append(len(data)*8)
+        for i in range(len(data)):
+            cmd.append(data[i])
+        self.interface.write(cmd)
 
-    return  (resp[2] << 0)  | \
-            (resp[3] << 8)  | \
-            (resp[4] << 16) | \
-            (resp[5] << 24)
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_SWJ_SEQUENCE']:
+                raise ValueError('DAP_SWJ_SEQUENCE response error')
 
-def dapVendor(interface, index):
-    cmd = []
-    cmd.append(COMMAND_ID['DAP_VENDOR0'] + index)
-    interface.write(cmd)
+        if resp[1] != DAP_OK:
+            raise ValueError('DAP SWJ Sequence failed')
 
-    resp = interface.read()
+        return resp[1]
 
-    if resp[0] != COMMAND_ID['DAP_VENDOR0'] + index:
-        raise ValueError('DAP_VENDOR response error')
+    def dapJTAGSequence(self, info, tdi):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_JTAG_SEQUENCE'])
+        cmd.append(1)
+        cmd.append(info)
+        cmd.append(tdi)
+        self.interface.write(cmd)
+
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_JTAG_SEQUENCE']:
+            raise ValueError('DAP_JTAG_SEQUENCE response error')
+
+        if resp[1] != DAP_OK:
+            raise ValueError('DAP JTAG Sequence failed')
+
+        return resp[2]
+
+    def dapJTAGConfigure(self, irlen, dev_num = 1):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_JTAG_CONFIGURE'])
+        cmd.append(dev_num)
+        cmd.append(irlen)
+        self.interface.write(cmd)
+
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_JTAG_CONFIGURE']:
+            raise ValueError('DAP_JTAG_CONFIGURE response error')
+
+        if resp[1] != DAP_OK:
+            raise ValueError('DAP JTAG Configure failed')
+
+        return resp[2:]
+
+    def dapJTAGIDCode(self, index = 0):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_JTAG_IDCODE'])
+        cmd.append(index)
+        self.interface.write(cmd)
+
+        resp = self.interface.read()
+        if resp[0] != COMMAND_ID['DAP_JTAG_IDCODE']:
+            raise ValueError('DAP_JTAG_IDCODE response error')
+
+        if resp[1] != DAP_OK:
+            raise ValueError('DAP JTAG ID code failed')
+
+        return  (resp[2] << 0)  | \
+                (resp[3] << 8)  | \
+                (resp[4] << 16) | \
+                (resp[5] << 24)
+
+    def dapVendor(self, index):
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_VENDOR0'] + index)
+        self.interface.write(cmd)
+
+        resp = self.interface.read()
+
+        if resp[0] != COMMAND_ID['DAP_VENDOR0'] + index:
+            raise ValueError('DAP_VENDOR response error')

--- a/pyOCD/transport/cmsis_dap_core.py
+++ b/pyOCD/transport/cmsis_dap_core.py
@@ -104,7 +104,7 @@ class CMSIS_DAP_Protocol(object):
 
         return x.tostring()
 
-    def setLed(interface):
+    def setLed(self):
         #not yet implemented
         return
 
@@ -162,7 +162,7 @@ class CMSIS_DAP_Protocol(object):
 
         return True
 
-    def resetTarget(interface):
+    def resetTarget(self):
         cmd = []
         cmd.append(COMMAND_ID['DAP_RESET_TARGET'])
         self.interface.write(cmd)


### PR DESCRIPTION
- Wrapped up `pyOCD.transport.cmsis_dap_core.dap*` functions into a `CMSIS_DAP_Protocol` class. It takes the interface in its constructor. Function names were changed to remove the common "dap" prefix.
- Updated CMSIS_DAP to create and use a protocol instance.
- Updated Maxim targets to match changes.
