### PR TITLE
avoid broken setuptools_scm versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'local_scheme': 'dirty-tag',
         'write_to': 'pyOCD/_version.py'
     },
-    setup_requires=['setuptools_scm'],
+    setup_requires=['setuptools-scm!=1.5.3,!=1.5.4'],
     description="CMSIS-DAP debugger for Python",
     long_description=open('README.rst', 'Ur').read(),
     author="samux, emilmont",


### PR DESCRIPTION
A quick fix for Python 2.x on Windows Issues.
