### PR TITLE
tests: add initial unittests and related infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ html
 #PyCharm project files
 .idea
 
+# Coverage
+cover
+
 # Common virtualenv environment names
 /env
 /env3

--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,15 @@ dependencies for the current platform by doing the following:
 On Windows, the virtualenv would be activated by executing
 ``env\Scripts\activate``.
 
+To run the unittests, you can execute the following.  Because of how
+nose searches for tests, specifying the directory is important as it
+will otherwise attempt to run non-unit tests as well (which will
+hang).
+
+.. code:: console
+
+    $ nosetest pyOCD/tests
+
 Examples
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,14 @@ hang).
 
 .. code:: console
 
-    $ nosetest pyOCD/tests
+    $ nosetests pyOCD/tests
+
+To get code coverage results, do the following:
+
+.. code:: console
+
+    $ nosetests --with-coverage --cover-html --cover-package=pyOCD pyOCD/tests
+    $ firefox cover/index.html
 
 Examples
 --------

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,4 @@
 # install pyOCD itself (and dependencies) as editable
 --editable .
+
+nose

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@
 --editable .
 
 nose
+coverage

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -18,7 +18,7 @@
 import logging, threading, socket
 from ..target.target import TARGET_HALTED, WATCHPOINT_READ, WATCHPOINT_WRITE, WATCHPOINT_READ_WRITE
 from ..transport import TransferError
-from ..utility.conversion import hexStringToIntList, hexEncode, hexDecode
+from ..utility.conversion import hexToByteList, hexEncode, hexDecode
 from struct import unpack
 from time import sleep, time
 import sys
@@ -488,7 +488,7 @@ class GDBServer(threading.Thread):
         length = int(split[0], 16)
 
         split = split[1].split('#')
-        data = hexStringToIntList(split[0])
+        data = hexToByteList(split[0])
 
         if LOG_MEM:
             logging.debug("GDB writeMemHex: addr=%x len=%x", addr, length)

--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -567,7 +567,7 @@ class CortexM(Target):
         if (size >= 4):
             #logging.debug("read blocks aligned at 0x%X, size: 0x%X", addr, (size/4)*4)
             mem = self.readBlockMemoryAligned32(addr, size/4)
-            res += conversion.word2byte(mem)
+            res += conversion.u32leListToBytelist(mem)
             size -= 4*len(mem)
             addr += 4*len(mem)
 
@@ -615,7 +615,7 @@ class CortexM(Target):
         # write aligned block of 32 bits
         if (size >= 4):
             #logging.debug("write blocks aligned at 0x%X, size: 0x%X", addr, (size/4)*4)
-            data32 = conversion.byte2word(data[idx:idx + (size & ~0x03)])
+            data32 = conversion.byteListToLittleEndianU32List(data[idx:idx + (size & ~0x03)])
             self.writeBlockMemoryAligned32(addr, data32)
             addr += size & ~0x03
             idx += size & ~0x03

--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -567,7 +567,7 @@ class CortexM(Target):
         if (size >= 4):
             #logging.debug("read blocks aligned at 0x%X, size: 0x%X", addr, (size/4)*4)
             mem = self.readBlockMemoryAligned32(addr, size/4)
-            res += conversion.u32leListToBytelist(mem)
+            res += conversion.u32leListToByteList(mem)
             size -= 4*len(mem)
             addr += 4*len(mem)
 
@@ -615,7 +615,7 @@ class CortexM(Target):
         # write aligned block of 32 bits
         if (size >= 4):
             #logging.debug("write blocks aligned at 0x%X, size: 0x%X", addr, (size/4)*4)
-            data32 = conversion.byteListToLittleEndianU32List(data[idx:idx + (size & ~0x03)])
+            data32 = conversion.byteListToU32leList(data[idx:idx + (size & ~0x03)])
             self.writeBlockMemoryAligned32(addr, data32)
             addr += size & ~0x03
             idx += size & ~0x03
@@ -799,7 +799,7 @@ class CortexM(Target):
         regValue = self.readCoreRegisterRaw(regIndex)
         # Convert int to float.
         if regIndex >= 0x40:
-            regValue = conversion.int2float(regValue)
+            regValue = conversion.u32BEToFloat32BE(regValue)
         return regValue
 
     def registerNameToIndex(self, reg):
@@ -882,7 +882,7 @@ class CortexM(Target):
         regIndex = self.registerNameToIndex(reg)
         # Convert float to int.
         if regIndex >= 0x40:
-            data = conversion.float2int(data)
+            data = conversion.float32beToU32be(data)
         self.writeCoreRegisterRaw(regIndex, data)
 
     def writeCoreRegisterRaw(self, reg, data):
@@ -1095,7 +1095,7 @@ class CortexM(Target):
         vals = self.readCoreRegistersRaw(reg_num_list)
         #print("Vals: %s" % vals)
         for reg, regValue in zip(self.register_list, vals):
-            resp += conversion.intToHex8(regValue)
+            resp += conversion.u32beToHex8le(regValue)
             logging.debug("GDB reg: %s = 0x%X", reg.name, regValue)
 
         return resp
@@ -1108,7 +1108,7 @@ class CortexM(Target):
         reg_num_list = []
         reg_data_list = []
         for reg in self.register_list:
-            regValue = conversion.hex8ToInt(data)
+            regValue = conversion.hex8leToU32be(data)
             reg_num_list.append(reg.reg_num)
             reg_data_list.append(regValue)
             logging.debug("GDB reg: %s = 0x%X", reg.name, regValue)
@@ -1124,7 +1124,7 @@ class CortexM(Target):
             return
         elif reg < len(self.register_list):
             regName = self.register_list[reg].name
-            value = conversion.hex8ToInt(data)
+            value = conversion.hex8leToU32be(data)
             logging.debug("GDB: write reg %s: 0x%X", regName, value)
             self.writeCoreRegisterRaw(regName, value)
 
@@ -1133,7 +1133,7 @@ class CortexM(Target):
         if reg < len(self.register_list):
             regName = self.register_list[reg].name
             regValue = self.readCoreRegisterRaw(regName)
-            resp = conversion.intToHex8(regValue)
+            resp = conversion.u32beToHex8le(regValue)
             logging.debug("GDB reg: %s = 0x%X", regName, regValue)
         return resp
 
@@ -1144,9 +1144,9 @@ class CortexM(Target):
             The current value of the important registers (sp, lr, pc).
         """
         if gdbInterrupt:
-            response = 'T' + conversion.intToHex2(signals.SIGINT)
+            response = 'T' + conversion.byteToHex2(signals.SIGINT)
         else:
-            response = 'T' + conversion.intToHex2(self.getSignalValue())
+            response = 'T' + conversion.byteToHex2(self.getSignalValue())
 
         # Append fp(r7), sp(r13), lr(r14), pc(r15)
         response += self.getRegIndexValuePairs([7, 13, 14, 15])
@@ -1179,6 +1179,6 @@ class CortexM(Target):
         str = ''
         regList = self.readCoreRegistersRaw(regIndexList)
         for regIndex, reg in zip(regIndexList, regList):
-            str += conversion.intToHex2(regIndex) + ':' + conversion.intToHex8(reg) + ';'
+            str += conversion.byteToHex2(regIndex) + ':' + conversion.u32beToHex8le(reg) + ';'
         return str
 

--- a/pyOCD/test/__init__.py
+++ b/pyOCD/test/__init__.py
@@ -1,0 +1,14 @@
+# mbed CMSIS-DAP debugger
+# Copyright (c) 2015 Paul Osborne <osbpau@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/pyOCD/test/test_utility/__init__.py
+++ b/pyOCD/test/test_utility/__init__.py
@@ -1,0 +1,14 @@
+# mbed CMSIS-DAP debugger
+# Copyright (c) 2015 Paul Osborne <osbpau@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/pyOCD/test/test_utility/test_conversion.py
+++ b/pyOCD/test/test_utility/test_conversion.py
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from pyOCD.utility.conversion import byteListToLittleEndianU32List, u32leListToBytelist, u16leListToByteList, \
-    byteListToU16leList, int2float, float2int, intToHex8, hex8ToInt, intToHex2, hexStringToIntList, hexDecode, hexEncode
+from pyOCD.utility.conversion import byteListToU32leList, u32leListToByteList, u16leListToByteList, \
+    byteListToU16leList, u32BEToFloat32BE, float32beToU32be, u32beToHex8le, hex8leToU32be, byteToHex2, hexToByteList, \
+    hexDecode, hexEncode
 
 
 class TestConversionUtilities(unittest.TestCase):
-
-    def test_byteListToLittleEndianU32List(self):
+    def test_byteListToU32leList(self):
         data = range(32)
-        self.assertEqual(byteListToLittleEndianU32List(data), [
+        self.assertEqual(byteListToU32leList(data), [
             0x03020100,
             0x07060504,
             0x0B0A0908,
@@ -43,9 +43,9 @@ class TestConversionUtilities(unittest.TestCase):
             0x1B1A1918,
             0x1F1E1D1C,
         ]
-        self.assertEqual(u32leListToBytelist(data), range(32))
+        self.assertEqual(u32leListToByteList(data), range(32))
 
-    def test_byteListToNibbleList(self):
+    def test_u16leListToByteList(self):
         data = [0x3412, 0xFEAB]
         self.assertEqual(u16leListToByteList(data), [
             0x12,
@@ -55,29 +55,29 @@ class TestConversionUtilities(unittest.TestCase):
         ])
 
     def test_byteListToU16leList(self):
-        data = [0x01, 0x00, 0xAB, 0xCD,]
+        data = [0x01, 0x00, 0xAB, 0xCD, ]
         self.assertEqual(byteListToU16leList(data), [
             0x0001,
             0xCDAB,
         ])
 
-    def test_int2float(self):
-        self.assertEqual(int2float(0x012345678), 5.690456613903524e-28)
+    def test_u32BEToFloat32BE(self):
+        self.assertEqual(u32BEToFloat32BE(0x012345678), 5.690456613903524e-28)
 
-    def test_float2int(self):
-        self.assertEqual(float2int(5.690456613903524e-28), 0x012345678)
+    def test_float32beToU32be(self):
+        self.assertEqual(float32beToU32be(5.690456613903524e-28), 0x012345678)
 
-    def test_intToHex8(self):
-        self.assertEqual(intToHex8(0x0102ABCD), "0102ABCD")
+    def test_u32beToHex8le(self):
+        self.assertEqual(u32beToHex8le(0x0102ABCD), "cdab0201")
 
-    def test_hex8ToInt(self):
-        self.assertEqual(hex8ToInt("0102ABCD"), 0xCDAB0201)
+    def test_hex8leToU32be(self):
+        self.assertEqual(hex8leToU32be("0102ABCD"), 0xCDAB0201)
 
-    def test_intToHex2(self):
-        self.assertEqual(intToHex2(0xC3), "c3")
+    def test_byteToHex2(self):
+        self.assertEqual(byteToHex2(0xC3), "c3")
 
-    def test_hexStringToIntList(self):
-        self.assertEqual(hexStringToIntList("ABCDEF1234"),
+    def test_hexToByteList(self):
+        self.assertEqual(hexToByteList("ABCDEF1234"),
                          [0xAB, 0xCD, 0xEF, 0x12, 0x34])
 
     def test_hexDecode(self):

--- a/pyOCD/test/test_utility/test_conversion.py
+++ b/pyOCD/test/test_utility/test_conversion.py
@@ -1,0 +1,89 @@
+# mbed CMSIS-DAP debugger
+# Copyright (c) 2015 Paul Osborne <osbpau@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from pyOCD.utility.conversion import byteListToLittleEndianU32List, u32leListToBytelist, u16leListToByteList, \
+    byteListToU16leList, int2float, float2int, intToHex8, hex8ToInt, intToHex2, hexStringToIntList, hexDecode, hexEncode
+
+
+class TestConversionUtilities(unittest.TestCase):
+
+    def test_byteListToLittleEndianU32List(self):
+        data = range(32)
+        self.assertEqual(byteListToLittleEndianU32List(data), [
+            0x03020100,
+            0x07060504,
+            0x0B0A0908,
+            0x0F0E0D0C,
+            0x13121110,
+            0x17161514,
+            0x1B1A1918,
+            0x1F1E1D1C,
+        ])
+
+    def test_u32leListToByteList(self):
+        data = [
+            0x03020100,
+            0x07060504,
+            0x0B0A0908,
+            0x0F0E0D0C,
+            0x13121110,
+            0x17161514,
+            0x1B1A1918,
+            0x1F1E1D1C,
+        ]
+        self.assertEqual(u32leListToBytelist(data), range(32))
+
+    def test_byteListToNibbleList(self):
+        data = [0x3412, 0xFEAB]
+        self.assertEqual(u16leListToByteList(data), [
+            0x12,
+            0x34,
+            0xAB,
+            0xFE
+        ])
+
+    def test_byteListToU16leList(self):
+        data = [0x01, 0x00, 0xAB, 0xCD,]
+        self.assertEqual(byteListToU16leList(data), [
+            0x0001,
+            0xCDAB,
+        ])
+
+    def test_int2float(self):
+        self.assertEqual(int2float(0x012345678), 5.690456613903524e-28)
+
+    def test_float2int(self):
+        self.assertEqual(float2int(5.690456613903524e-28), 0x012345678)
+
+    def test_intToHex8(self):
+        self.assertEqual(intToHex8(0x0102ABCD), "0102ABCD")
+
+    def test_hex8ToInt(self):
+        self.assertEqual(hex8ToInt("0102ABCD"), 0xCDAB0201)
+
+    def test_intToHex2(self):
+        self.assertEqual(intToHex2(0xC3), "c3")
+
+    def test_hexStringToIntList(self):
+        self.assertEqual(hexStringToIntList("ABCDEF1234"),
+                         [0xAB, 0xCD, 0xEF, 0x12, 0x34])
+
+    def test_hexDecode(self):
+        self.assertEqual(hexDecode('ABCDEF1234'),
+                         '\xab\xcd\xef\x12\x34')
+
+    def test_hexEncode(self):
+        self.assertEqual(hexEncode('\xab\xcd\xef\x12\x34'),
+                         'abcdef1234')

--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -545,7 +545,7 @@ class PyOCDTool(object):
         addr = self.convert_value(args[0])
         if len(args) < 2:
             count = 4
-                else:
+        else:
             count = self.convert_value(args[1])
 
         if self.args.width == 8:
@@ -553,10 +553,10 @@ class PyOCDTool(object):
             byteData = data
         elif self.args.width == 16:
             byteData = self.target.readBlockMemoryUnaligned8(addr, count)
-            data = pyOCD.utility.conversion.byte2half(byteData)
+            data = pyOCD.utility.conversion.byteListToU16leList(byteData)
         elif self.args.width == 32:
             byteData = self.target.readBlockMemoryUnaligned8(addr, count)
-            data = pyOCD.utility.conversion.byte2word(byteData)
+            data = pyOCD.utility.conversion.byteListToLittleEndianU32List(byteData)
 
         # Print hex dump of output.
         dumpHexData(data, addr, width=self.args.width)
@@ -575,9 +575,9 @@ class PyOCDTool(object):
         if self.args.width == 8:
             pass
         elif self.args.width == 16:
-            data = pyOCD.utility.conversion.half2byte(data)
+            data = pyOCD.utility.conversion.u16leListToByteList(data)
         elif self.args.width == 32:
-            data = pyOCD.utility.conversion.word2byte(data)
+            data = pyOCD.utility.conversion.u32leListToBytelist(data)
 
         self.target.writeBlockMemoryUnaligned8(addr, data)
 
@@ -673,7 +673,7 @@ class PyOCDTool(object):
             value = int(arg, base=0)
 
         if deref:
-            value = pyOCD.utility.conversion.byte2word(self.target.readBlockMemoryUnaligned8(value + offset, 4))[0]
+            value = pyOCD.utility.conversion.byteListToLittleEndianU32List(self.target.readBlockMemoryUnaligned8(value + offset, 4))[0]
             print "[%s,%d] = 0x%08x" % (arg, offset, value)
 
         return value

--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -556,7 +556,7 @@ class PyOCDTool(object):
             data = pyOCD.utility.conversion.byteListToU16leList(byteData)
         elif self.args.width == 32:
             byteData = self.target.readBlockMemoryUnaligned8(addr, count)
-            data = pyOCD.utility.conversion.byteListToLittleEndianU32List(byteData)
+            data = pyOCD.utility.conversion.byteListToU32leList(byteData)
 
         # Print hex dump of output.
         dumpHexData(data, addr, width=self.args.width)
@@ -577,7 +577,7 @@ class PyOCDTool(object):
         elif self.args.width == 16:
             data = pyOCD.utility.conversion.u16leListToByteList(data)
         elif self.args.width == 32:
-            data = pyOCD.utility.conversion.u32leListToBytelist(data)
+            data = pyOCD.utility.conversion.u32leListToByteList(data)
 
         self.target.writeBlockMemoryUnaligned8(addr, data)
 
@@ -673,7 +673,7 @@ class PyOCDTool(object):
             value = int(arg, base=0)
 
         if deref:
-            value = pyOCD.utility.conversion.byteListToLittleEndianU32List(self.target.readBlockMemoryUnaligned8(value + offset, 4))[0]
+            value = pyOCD.utility.conversion.byteListToU32leList(self.target.readBlockMemoryUnaligned8(value + offset, 4))[0]
             print "[%s,%d] = 0x%08x" % (arg, offset, value)
 
         return value

--- a/pyOCD/utility/conversion.py
+++ b/pyOCD/utility/conversion.py
@@ -18,8 +18,9 @@
 import struct
 import binascii
 
-## @brief Convert a list of bytes to a list of 32-bit integers (little endian)
-def byteListToLittleEndianU32List(data):
+
+def byteListToU32leList(data):
+    """Convert a list of bytes to a list of 32-bit integers (little endian)"""
     res = []
     for i in range(len(data) / 4):
         res.append(data[i * 4 + 0] |
@@ -28,8 +29,9 @@ def byteListToLittleEndianU32List(data):
                    data[i * 4 + 3] << 24)
     return res
 
-## @brief Convert a word array into a byte array.
-def u32leListToBytelist(data):
+
+def u32leListToByteList(data):
+    """Convert a word array into a byte array"""
     res = []
     for x in data:
         res.append((x >> 0) & 0xff)
@@ -38,49 +40,63 @@ def u32leListToBytelist(data):
         res.append((x >> 24) & 0xff)
     return res
 
-## @brief Convert a halfword array into a byte array
+
 def u16leListToByteList(data):
+    """Convert a halfword array into a byte array"""
     byteData = []
     for h in data:
         byteData.extend([h & 0xff, (h >> 8) & 0xff])
     return byteData
 
-## @brief Convert a byte array into a halfword array.
+
 def byteListToU16leList(byteData):
+    """Convert a byte array into a halfword array"""
     data = []
     for i in range(0, len(byteData), 2):
-        data.append(byteData[i] | (byteData[i+1] << 8))
+        data.append(byteData[i] | (byteData[i + 1] << 8))
     return data
 
-## @brief Convert a 32-bit int to an IEEE754 float.
-def int2float(data):
-    d = struct.pack("@I", data)
-    return struct.unpack("@f", d)[0]
 
-## @brief Convert an IEEE754 float to a 32-bit int.
-def float2int(data):
-    d = struct.pack("@f", data)
-    return struct.unpack("@I", d)[0]
+def u32BEToFloat32BE(data):
+    """Convert a 32-bit int to an IEEE754 float"""
+    d = struct.pack(">I", data)
+    return struct.unpack(">f", d)[0]
 
-## @brief create 8-digit hexadecimal string from 32-bit register value.
-def intToHex8(val):
-    return "%08X" % int(val)
 
-## @brief Build 32-bit register value from little-endian 8-digit hexadecimal string.
-def hex8ToInt(data):
+def float32beToU32be(data):
+    """Convert an IEEE754 float to a 32-bit int"""
+    d = struct.pack(">f", data)
+    return struct.unpack(">I", d)[0]
+
+
+def u32beToHex8le(val):
+    """Create 8-digit hexadecimal string from 32-bit register value"""
+    return ''.join("%02x" % (x & 0xFF) for x in (
+        val,
+        val >> 8,
+        val >> 16,
+        val >> 24,
+    ))
+
+
+def hex8leToU32be(data):
+    """Build 32-bit register value from little-endian 8-digit hexadecimal string"""
     return int(data[6:8] + data[4:6] + data[2:4] + data[0:2], 16)
 
-## @brief Create 2-digit hexadecimal string from 8-bit value.
-def intToHex2(val):
+
+def byteToHex2(val):
+    """Create 2-digit hexadecimal string from 8-bit value"""
     return "%02x" % int(val)
 
-## @brief Convert string of hex bytes to list of integers.
-def hexStringToIntList(data):
+
+def hexToByteList(data):
+    """Convert string of hex bytes to list of integers"""
     return [ord(i) for i in binascii.unhexlify(data)]
+
 
 def hexDecode(cmd):
     return binascii.unhexlify(cmd)
 
+
 def hexEncode(string):
     return binascii.hexlify(string)
-

--- a/pyOCD/utility/conversion.py
+++ b/pyOCD/utility/conversion.py
@@ -18,18 +18,18 @@
 import struct
 import binascii
 
-## @brief Convert a byte array into a word array.
-def byte2word(data):
+## @brief Convert a list of bytes to a list of 32-bit integers (little endian)
+def byteListToLittleEndianU32List(data):
     res = []
-    for i in range(len(data)/4):
-        res.append(data[i*4 + 0] << 0  |
-                   data[i*4 + 1] << 8  |
-                   data[i*4 + 2] << 16 |
-                   data[i*4 + 3] << 24)
+    for i in range(len(data) / 4):
+        res.append(data[i * 4 + 0] |
+                   data[i * 4 + 1] << 8 |
+                   data[i * 4 + 2] << 16 |
+                   data[i * 4 + 3] << 24)
     return res
 
 ## @brief Convert a word array into a byte array.
-def word2byte(data):
+def u32leListToBytelist(data):
     res = []
     for x in data:
         res.append((x >> 0) & 0xff)
@@ -39,14 +39,14 @@ def word2byte(data):
     return res
 
 ## @brief Convert a halfword array into a byte array
-def half2byte(data):
+def u16leListToByteList(data):
     byteData = []
     for h in data:
         byteData.extend([h & 0xff, (h >> 8) & 0xff])
     return byteData
 
 ## @brief Convert a byte array into a halfword array.
-def byte2half(byteData):
+def byteListToU16leList(byteData):
     data = []
     for i in range(0, len(byteData), 2):
         data.append(byteData[i] | (byteData[i+1] << 8))
@@ -64,18 +64,7 @@ def float2int(data):
 
 ## @brief create 8-digit hexadecimal string from 32-bit register value.
 def intToHex8(val):
-    val = hex(int(val))[2:]
-    size = len(val)
-    r = ''
-    for i in range(8-size):
-        r += '0'
-    r += str(val)
-
-    resp = ''
-    for i in range(4):
-        resp += r[8 - 2*i - 2: 8 - 2*i]
-
-    return resp
+    return "%08X" % int(val)
 
 ## @brief Build 32-bit register value from little-endian 8-digit hexadecimal string.
 def hex8ToInt(data):
@@ -83,11 +72,7 @@ def hex8ToInt(data):
 
 ## @brief Create 2-digit hexadecimal string from 8-bit value.
 def intToHex2(val):
-    val = hex(int(val))[2:]
-    if len(val) < 2:
-        return '0' + val
-    else:
-        return val
+    return "%02x" % int(val)
 
 ## @brief Convert string of hex bytes to list of integers.
 def hexStringToIntList(data):

--- a/test/automated_test.py
+++ b/test/automated_test.py
@@ -22,7 +22,7 @@ sys.path.insert(0, parentdir)
 
 import pyOCD
 from pyOCD.board import MbedBoard
-from pyOCD.utility.conversion import float2int
+from pyOCD.utility.conversion import float32beToU32be
 import logging
 from time import time
 from test_util import TestResult, Test, Logger

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -25,7 +25,7 @@ sys.path.insert(0, parentdir)
 
 import pyOCD
 from pyOCD.board import MbedBoard
-from pyOCD.utility.conversion import float2int
+from pyOCD.utility.conversion import float32beToU32be
 import logging
 
 def basic_test(board_id, file):
@@ -146,13 +146,13 @@ def basic_test(board_id, file):
         
         if target.has_fpu:
             s0 = target.readCoreRegister('s0')
-            print "S0 = %g (0x%08x)" % (s0,float2int(s0))
+            print "S0 = %g (0x%08x)" % (s0,float32beToU32be(s0))
             target.writeCoreRegister('s0', math.pi)
             newS0 = target.readCoreRegister('s0')
-            print "New S0 = %g (0x%08x)" % (newS0, float2int(newS0))
+            print "New S0 = %g (0x%08x)" % (newS0, float32beToU32be(newS0))
             target.writeCoreRegister('s0', s0)
             newS0 = target.readCoreRegister('s0')
-            print "Restored S0 = %g (0x%08x)" % (newS0, float2int(newS0))
+            print "Restored S0 = %g (0x%08x)" % (newS0, float32beToU32be(newS0))
         
         
         print "\r\n\r\n------ TEST HALT / RESUME ------"

--- a/test/cortex_test.py
+++ b/test/cortex_test.py
@@ -26,7 +26,7 @@ sys.path.insert(0, parentdir)
 
 import pyOCD
 from pyOCD.board import MbedBoard
-from pyOCD.utility.conversion import float2int
+from pyOCD.utility.conversion import float32beToU32be
 from pyOCD.transport import TransferError
 from test_util import Test, TestResult
 import logging

--- a/test/flash_test.py
+++ b/test/flash_test.py
@@ -28,7 +28,7 @@ sys.path.insert(0, parentdir)
 
 import pyOCD
 from pyOCD.board import MbedBoard
-from pyOCD.utility.conversion import float2int
+from pyOCD.utility.conversion import float32beToU32be
 from pyOCD.flash.flash import FLASH_PAGE_ERASE, FLASH_CHIP_ERASE
 from test_util import Test, TestResult
 


### PR DESCRIPTION
These changes add tests for some functions for the conversion
utilities.  Since some of the names for these functions were
not very good, those were also updated to be more meaningful.
Finally,  the implementation for intToHex8 was modified to be
much simpler (after writing a test that covered the code with
the existing implementation).

Signed-off-by: Paul Osborne <osbpau@gmail.com>