### PR TITLE
Fixed pyocd-tool merge ident issues, added basic command test script.

### DIFF
--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -376,7 +376,7 @@ class PyOCDTool(object):
             self.board = MbedBoard.chooseBoard(board_id=self.args.board, target_override=self.args.target, init_board=False, frequency=(self.args.clock * 1000))
             self.board.target.setAutoUnlock(False)
             self.board.target.setHaltOnConnect(False)
-        try:
+            try:
                 self.board.init()
             except Exception as e:
                 print "Exception while initing board:", e
@@ -433,7 +433,7 @@ class PyOCDTool(object):
         return self.exitCode
 
     def handle_list(self, args):
-                MbedBoard.listConnectedBoards()
+        MbedBoard.listConnectedBoards()
 
     def handle_info(self, args):
         print "Target:    %s" % self.target.part_number
@@ -481,7 +481,7 @@ class PyOCDTool(object):
 
     @cmdoptions([make_option('-h', "--halt", action="store_true")])
     def handle_reset(self, args, other):
-                print "Resetting target"
+        print "Resetting target"
         if args.halt:
             self.target.resetStopOnReset()
 
@@ -545,7 +545,7 @@ class PyOCDTool(object):
         addr = self.convert_value(args[0])
         if len(args) < 2:
             count = 4
-                else:
+        else:
             count = self.convert_value(args[1])
 
         if self.args.width == 8:
@@ -586,7 +586,7 @@ class PyOCDTool(object):
         self.flash.eraseAll()
 
     def handle_unlock(self, args):
-                # Currently the same as erase.
+        # Currently the same as erase.
         if not self.didErase:
             self.target.massErase()
 

--- a/test/test_pyocd_tool.sh
+++ b/test/test_pyocd_tool.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Run through all pyocd-tool commands.
+pyocd-tool <<EOF
+help
+clock 1000
+disasm 0x410 16
+reset -h
+disasm -c pc 16
+go
+halt
+info
+log debug
+read 0 16
+read16 0 16
+read32 0 16
+reg
+stat
+reset
+reset -h
+pc
+step
+pc
+step
+pc
+write 0x20000000 0xaa
+read 0x20000000 1
+write16 0x20000000 0xabcd
+read16 0x20000000 2
+write32 0x20000000 0x01020304
+read32 0x20000000 4
+wreg r0 0xabcd1234
+r0
+reset -h
+stat
+reg
+EOF
+


### PR DESCRIPTION
Fixes some indent issues caused by merging.

A very basic test script is added that executes most of the pyocd-tool commands (except 'erase' and 'unlock'). The addresses in the script are currently hard coded to valid Kinetis addresses. This needs to be improved by adding a real test suite.

Signed-off-by: Chris Reed <creed@freescale.com>