### PR TITLE
Software breakpoints

### DIFF
--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -1007,7 +1007,7 @@ class CortexM(Target):
             # Remove bp by type.
             if bp.type == BREAKPOINT_SW:
                 self.removeSoftwareBreakpoint(bp)
-            elif bp.type == BREAKPOINT_SW:
+            elif bp.type == BREAKPOINT_HW:
                 self.removeHardwareBreakpoint(bp.addr)
             else:
                 raise RuntimeError("Unknown breakpoint type %d" % bp.type)

--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -956,6 +956,13 @@ class CortexM(Target):
         # Clear Thumb bit in case it is set.
         addr = addr & ~1
 
+        # Check for an existing breakpoint at this address.
+        bp = self.findBreakpoint(addr)
+        if bp is not None:
+            return True
+
+        # Look up the memory region for the requested address. If there is no region,
+        # then we can't set a breakpoint.
         region = self.memory_map.getRegionForAddress(addr)
         if region is None:
             return False

--- a/pyOCD/target/target.py
+++ b/pyOCD/target/target.py
@@ -18,6 +18,13 @@
 TARGET_RUNNING = (1 << 0)
 TARGET_HALTED = (1 << 1)
 
+# Types of breakpoints.
+#
+# Auto will select the best type given the address and available breakpoints.
+BREAKPOINT_HW = 1
+BREAKPOINT_SW = 2
+BREAKPOINT_AUTO = 3
+
 WATCHPOINT_READ = 1
 WATCHPOINT_WRITE = 2
 WATCHPOINT_READ_WRITE = 3
@@ -85,7 +92,10 @@ class Target(object):
     def writeCoreRegister(self, id):
         return
 
-    def setBreakpoint(self, addr):
+    def setBreakpoint(self, addr, type=BREAKPOINT_AUTO):
+        return
+
+    def getBreakpointType(self, addr):
         return
 
     def removeBreakpoint(self, addr):


### PR DESCRIPTION
Support for setting software breakpoints added to `CortexM` and `GDBServer` classes. The `setBreakpoint()` method of `CortexM` accepts a new parameter that lets you specify the desired breakpoint type, one of hardware, software, or auto.

All tests pass, and sw breakpoints tested successfully with gdb.