### PR TITLE
gdb server non-stop mode support

### DIFF
--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -1253,16 +1253,14 @@ class CortexM(Target):
             logging.debug("GDB reg: %s = 0x%X", regName, regValue)
         return resp
 
-    def getTResponse(self, gdbInterrupt = False, forceSignal0=False):
+    def getTResponse(self, forceSignal=None):
         """
         Returns a GDB T response string.  This includes:
             The signal encountered.
             The current value of the important registers (sp, lr, pc).
         """
-        if forceSignal0:
-            response = 'T00'
-        elif gdbInterrupt:
-            response = 'T' + conversion.byteToHex2(signals.SIGINT)
+        if forceSignal is not None:
+            response = 'T' + conversion.byteToHex2(forceSignal)
         else:
             response = 'T' + conversion.byteToHex2(self.getSignalValue())
 

--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -1253,19 +1253,24 @@ class CortexM(Target):
             logging.debug("GDB reg: %s = 0x%X", regName, regValue)
         return resp
 
-    def getTResponse(self, gdbInterrupt = False):
+    def getTResponse(self, gdbInterrupt = False, forceSignal0=False):
         """
         Returns a GDB T response string.  This includes:
             The signal encountered.
             The current value of the important registers (sp, lr, pc).
         """
-        if gdbInterrupt:
+        if forceSignal0:
+            response = 'T00'
+        elif gdbInterrupt:
             response = 'T' + conversion.byteToHex2(signals.SIGINT)
         else:
             response = 'T' + conversion.byteToHex2(self.getSignalValue())
 
         # Append fp(r7), sp(r13), lr(r14), pc(r15)
         response += self.getRegIndexValuePairs([7, 13, 14, 15])
+
+        # Append thread and core
+        response += "thread:1;core:0;"
 
         return response
 

--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -1298,3 +1298,10 @@ class CortexM(Target):
             str += conversion.byteToHex2(regIndex) + ':' + conversion.u32beToHex8le(reg) + ';'
         return str
 
+    def getThreadsXML(self):
+        root = Element('threads')
+        t = SubElement(root, 'thread', id="1", core="0")
+        t.text = "Thread mode"
+        return '<?xml version="1.0"?><!DOCTYPE feature SYSTEM "threads.dtd">' + tostring(root)
+
+

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -133,8 +133,9 @@ class GDBServerTool(object):
                 pass
 
     def server_listening(self, server):
-        print >>sys.stderr, self.echo_msg
-        sys.stderr.flush()
+        if self.echo_msg is not None:
+            print >>sys.stderr, self.echo_msg
+            sys.stderr.flush()
 
     def run(self):
         self.args = self.build_parser().parse_args()


### PR DESCRIPTION
This PR adds support for [non-stop mode](https://sourceware.org/gdb/current/onlinedocs/gdb/Remote-Non_002dStop.html#Remote-Non_002dStop). This feature allows for accessing memory while the target is running.

These changes were tested with command-line arm-none-eabi-gdb version 7.8.0.20150604 from GNU ARM Embedded 2015q2. To enable non-stop mode, issue the `set non-stop on` command before connecting to the gdb server. Note that you need to use `continue&` to run the target and still have gdb command access.

Eclipse supposedly has [support for non-stop mode](http://help.eclipse.org/luna/index.jsp?topic=%2Forg.eclipse.cdt.doc.user%2Freference%2Fcdt_u_dsfgdb.htm). However, it doesn't seem to work at all. Setting this preference doesn't actually cause non-stop mode to be requested to the gdb server. 