### PR TITLE
Fix TabError

### DIFF
--- a/pyOCD/target/target_stm32f103rc.py
+++ b/pyOCD/target/target_stm32f103rc.py
@@ -35,7 +35,7 @@ class STM32F103RC(CortexM):
         super(STM32F103RC, self).__init__(transport, self.memoryMap)
 
     def init(self):
-    	logging.debug('stm32f103rc init')
+        logging.debug('stm32f103rc init')
         CortexM.init(self)
         self.writeMemory(DBGMCU_CR, DBGMCU_VAL);
 


### PR DESCRIPTION
Replaced a rogue tab mixed in with spaces in target_stm32f103rc.py. Mixing whitespace is bad in general, but it also produces a TabError when running on Python 3.