### PR TITLE
Fix pyusb dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import sys
 install_requires = ['intelhex']
 if sys.platform.startswith('linux'):
     install_requires.extend([
-        'pyusb',
+        'pyusb>=1.0.0b2',
     ])
 elif sys.platform.startswith('win'):
     install_requires.extend([


### PR DESCRIPTION
Installation of pyOCD fails at the time of this patch on platforms that
use pyusb, like Linux.  This is because the only released versions
of pyusb are alpha or beta, which pip does not install by default.
This patch sets the minimum version to the latest beta so pyusb
can be installed.