### PR TITLE
Adding Cython as a setup dependency for Mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 from setuptools import setup, find_packages
 import sys
 
+setup_requires=['setuptools_scm!=1.5.3,!=1.5.4']
 install_requires = ['intelhex']
 if sys.platform.startswith('linux'):
     install_requires.extend([
@@ -28,6 +29,9 @@ elif sys.platform.startswith('win'):
         'pywinusb',
     ])
 elif sys.platform.startswith('darwin'):
+    setup_requires.extend([
+        'cython',
+    ])
     install_requires.extend([
         'hidapi',
     ])
@@ -38,7 +42,7 @@ setup(
         'local_scheme': 'dirty-tag',
         'write_to': 'pyOCD/_version.py'
     },
-    setup_requires=['setuptools_scm!=1.5.3,!=1.5.4'],
+    setup_requires=setup_requires,
     description="CMSIS-DAP debugger for Python",
     long_description=open('README.rst', 'Ur').read(),
     author="samux, emilmont",


### PR DESCRIPTION
Adds Cython as a setup_requires dependency on Mac, solving some dependency issues.