### PR TITLE
Removed reference to non-existent "chooseInterface" 

### DIFF
--- a/pyOCD/board/board.py
+++ b/pyOCD/board/board.py
@@ -29,10 +29,7 @@ class Board(object):
     to create a board
     """
     def __init__(self, target, flash, interface, transport="cmsis_dap", frequency=1000000):
-        if isinstance(interface, str) == False:
-            self.interface = interface
-        else:
-            self.interface = INTERFACE[interface].chooseInterface(INTERFACE[interface])
+        self.interface = interface
         self.transport = TRANSPORT[transport](self.interface)
         self.target = TARGET[target](self.transport)
         self.flash = FLASH[flash](self.target)


### PR DESCRIPTION
It doesn't seem easily possible to auto-initialize an `Interface` (interface initialization parameters are currently set inside the `getAllConnectedInterface` function inside the usb backend) so I decided to simply remove the auto-initialization code for the `interface` inside `Board.__init__`.

Closes #192  