### PR TITLE
tools/pyocd: fixed -H option

### DIFF
--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -390,7 +390,7 @@ class PyOCDTool(object):
 
             # Halt if requested.
             if self.args.halt:
-                self.handle_halt()
+                self.handle_halt([])
 
             # Handle a device with flash security enabled.
             self.didErase = False


### PR DESCRIPTION
The tools/pyocd.py program crashes when passing the -H option since there were some arguments missing from a function call to `handle_halt`. I simply added the `self.args` to the call. I wasn't sure whether I should open an issue first but I figured since this is such a small bug a direct PR would be ok.