### PR TITLE
Add support for the nrf52

### DIFF
--- a/pyOCD/flash/__init__.py
+++ b/pyOCD/flash/__init__.py
@@ -26,6 +26,7 @@ from flash_lpc11u24 import Flash_lpc11u24
 from flash_lpc1768 import Flash_lpc1768
 from flash_lpc4330 import Flash_lpc4330
 from flash_nrf51 import Flash_nrf51
+from flash_nrf52 import Flash_nrf52
 from flash_stm32f103rc import Flash_stm32f103rc
 from flash_stm32f051 import Flash_stm32f051
 from flash_maxwsnenv import Flash_maxwsnenv
@@ -49,6 +50,7 @@ FLASH = {
          'lpc1768':  Flash_lpc1768,
          'lpc4330':  Flash_lpc4330,
          'nrf51': Flash_nrf51,
+         'nrf52': Flash_nrf52,
          'stm32f103rc': Flash_stm32f103rc,
          'stm32f051': Flash_stm32f051,
          'maxwsnenv': Flash_maxwsnenv,

--- a/pyOCD/flash/flash_nrf52.py
+++ b/pyOCD/flash/flash_nrf52.py
@@ -1,0 +1,47 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2006-2015 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from flash import Flash
+import logging
+
+flash_algo = { 'load_address' : 0x20000000,
+               'instructions' : [
+                                0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,
+                                0x47702000, 0x47702000, 0x4c26b570, 0x60602002, 0x60e02001, 0x68284d24, 0xd00207c0, 0x60602000,
+                                0xf000bd70, 0xe7f6f82c, 0x4c1eb570, 0x60612102, 0x4288491e, 0x2001d302, 0xe0006160, 0x4d1a60a0,
+                                0xf81df000, 0x07c06828, 0x2000d0fa, 0xbd706060, 0x4605b5f8, 0x4813088e, 0x46142101, 0x4f126041,
+                                0xc501cc01, 0x07c06838, 0x1e76d006, 0x480dd1f8, 0x60412100, 0xbdf84608, 0xf801f000, 0x480ce7f2,
+                                0x06006840, 0xd00b0e00, 0x6849490a, 0xd0072900, 0x4a0a4909, 0xd00007c3, 0x1d09600a, 0xd1f90840,
+                                0x00004770, 0x4001e500, 0x4001e400, 0x10001000, 0x40010400, 0x40010500, 0x40010600, 0x6e524635,
+                                0x00000000, ],
+               'pc_init'          : 0x20000021,
+               'pc_eraseAll'      : 0x20000029,
+               'pc_erase_sector'  : 0x20000049,
+               'pc_program_page'  : 0x20000071,
+               'begin_data'       : 0x20002000, # Analyzer uses a max of 0.5 KB data (128 pages * 4 bytes / page)
+               'page_buffers'    : [0x20002000, 0x20003000],   # Enable double buffering
+               'begin_stack'      : 0x20001000,
+               'static_base'      : 0x20000170,
+               'min_program_length' : 4,
+               'analyzer_supported' : True,
+               'analyzer_address' : 0x20004000  # Analyzer 0x20004000..0x20004600
+              }
+
+class Flash_nrf52(Flash):
+
+    def __init__(self, target):
+        super(Flash_nrf52, self).__init__(target, flash_algo)

--- a/pyOCD/target/__init__.py
+++ b/pyOCD/target/__init__.py
@@ -31,6 +31,7 @@ import target_lpc11u24
 import target_lpc1768
 import target_lpc4330
 import target_nrf51
+import target_nrf52
 import target_stm32f103rc
 import target_stm32f051
 import target_maxwsnenv
@@ -55,6 +56,7 @@ TARGET = {
           'lpc1768': target_lpc1768.LPC1768,
           'lpc4330': target_lpc4330.LPC4330,
           'nrf51': target_nrf51.NRF51,
+          'nrf52' : target_nrf52.NRF52,
           'stm32f103rc': target_stm32f103rc.STM32F103RC,
           'stm32f051': target_stm32f051.STM32F051,
           'maxwsnenv': target_maxwsnenv.MAXWSNENV,

--- a/pyOCD/target/target_nrf52.py
+++ b/pyOCD/target/target_nrf52.py
@@ -1,0 +1,46 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2006-2013 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from cortex_m import CortexM
+from .memory_map import (FlashRegion, RamRegion, MemoryMap)
+import logging
+
+# NRF52 specific registers
+RESET = 0x40000544
+RESET_ENABLE = (1 << 0)
+
+class NRF52(CortexM):
+
+    memoryMap = MemoryMap(
+        FlashRegion(    start=0x0,         length=0x80000,      blocksize=0x1000, isBootMemory=True),
+        RamRegion(      start=0x20000000,  length=0x10000)
+        )
+
+    def __init__(self, transport):
+        super(NRF52, self).__init__(transport, self.memoryMap)
+
+    def resetn(self):
+        """
+        reset a core. After a call to this function, the core
+        is running
+        """
+        #Regular reset will kick NRF out of DBG mode
+        logging.debug("target_nrf52.reset: enable reset pin")
+        self.writeMemory(RESET, RESET_ENABLE)
+        #reset
+        logging.debug("target_nrf52.reset: trigger nRST pin")
+        CortexM.reset(self)


### PR DESCRIPTION
Add support for the nrf52.  The nrf52 shares the same flash algorithm
and has many of the same registers of the nrf51.  Some differences
include rom size, ram size and block size.