### PR TITLE
Remove Cython as a setup dependency for Mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@
 from setuptools import setup, find_packages
 import sys
 
-setup_requires = ['setuptools_scm!=1.5.3,!=1.5.4']
 install_requires = ['intelhex']
 if sys.platform.startswith('linux'):
     install_requires.extend([
@@ -29,9 +28,6 @@ elif sys.platform.startswith('win'):
         'pywinusb',
     ])
 elif sys.platform.startswith('darwin'):
-    setup_requires.extend([
-        'cython',
-    ])
     install_requires.extend([
         'hidapi',
     ])
@@ -42,7 +38,7 @@ setup(
         'local_scheme': 'dirty-tag',
         'write_to': 'pyOCD/_version.py'
     },
-    setup_requires=setup_requires,
+    setup_requires=['setuptools_scm!=1.5.3,!=1.5.4'],
     description="CMSIS-DAP debugger for Python",
     long_description=open('README.rst', 'Ur').read(),
     author="Martin Kojtal, Russ Butler",


### PR DESCRIPTION
The package cython was added as a dependency in pyOCD to fix a missing
dependency in hidpi.  This dependency has been properly added to
hidapi so this workaround can be removed.

This patch reverts the following commit:
712ad33d780bc41a02ee67a8b49d4829b4b74ac8 -
"Adding Cython as a setup dependency for Mac"