### PR TITLE
Fix windows usb problems

### DIFF
--- a/pyOCD/interface/__init__.py
+++ b/pyOCD/interface/__init__.py
@@ -43,10 +43,14 @@ if not usb_backend:
             usb_backend = "hidapiusb"
         elif PyWinUSB.isAvailable:
             usb_backend = "pywinusb"
+        else:
+            raise Exception("No USB backend found")
     elif os.name == "posix":
         # Select hidapi for OS X and pyUSB for Linux.
         if os.uname()[0] == 'Darwin':
             usb_backend = "hidapiusb"
         else:
             usb_backend = "pyusb"
+    else:
+        raise Exception("No USB backend found")
 

--- a/pyOCD/interface/pywinusb_backend.py
+++ b/pyOCD/interface/pywinusb_backend.py
@@ -57,7 +57,7 @@ class PyWinUSB(Interface):
 
     def open(self):
         self.device.set_raw_data_handler(self.rx_handler)
-        self.device.open()
+        self.device.open(shared=False)
 
     @staticmethod
     def getAllConnectedInterface(vid, pid):
@@ -80,7 +80,7 @@ class PyWinUSB(Interface):
         boards = []
         for dev in all_mbed_devices:
             try:
-                dev.open()
+                dev.open(shared=False)
                 report = dev.find_output_reports()
                 if (len(report) == 1):
                     new_board = PyWinUSB()

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if sys.platform.startswith('linux'):
     ])
 elif sys.platform.startswith('win'):
     install_requires.extend([
-        'pywinusb',
+        'pywinusb>=0.4.0',
     ])
 elif sys.platform.startswith('darwin'):
     install_requires.extend([


### PR DESCRIPTION
Switch to the latest pywinusb to bring in the following fixes:
-Fix intermittent python.exe crash on some usb operations
-Prevent multiple scripts from accessing the same board, since
    this leads to one of the scripts raising an exception.

Also, raise an exception when the USB backend is missing.  This prevents
the current script from crashing at some future point with a less
understandable error message.