### PR TITLE
Add return values for continuous integration

### DIFF
--- a/test/automated_test.py
+++ b/test/automated_test.py
@@ -87,7 +87,9 @@ if __name__ == "__main__":
     print("Test Time: %s" % (stop - start))
     if Test.all_tests_pass(result_list):
         print("All tests passed")
+        exit(0)
     else:
         print("One or more tests has failed!")
+        exit(-1)
 
     #TODO - check if any threads are still running?


### PR DESCRIPTION
Return -1 on failure to allow continuous integration testing to
correctly detect errors.