### PR TITLE
Disable remote TCP/IP connections by default

### DIFF
--- a/pyOCD/gdbserver/gdb_socket.py
+++ b/pyOCD/gdbserver/gdb_socket.py
@@ -23,12 +23,12 @@ class GDBSocket(object):
         self.s = None
         self.conn = None
         self.port = port
-        return
+        self.host = ''
 
     def init(self):
         self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.s.bind(('', self.port))
+        self.s.bind((self.host, self.port))
         self.s.listen(5)
 
     def connect(self):

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -235,6 +235,7 @@ class GDBServer(threading.Thread):
         self.telnet_port = options.get('telnet_port', 4444)
         self.semihost_use_syscalls = options.get('semihost_use_syscalls', False)
         self.server_listening_callback = options.get('server_listening_callback', None)
+        self.serve_local_only = options.get('serve_local_only', True)
         self.packet_size = 2048
         self.packet_io = None
         self.gdb_features = []
@@ -246,6 +247,9 @@ class GDBServer(threading.Thread):
         self.detach_event = threading.Event()
         if self.wss_server == None:
             self.abstract_socket = GDBSocket(self.port, self.packet_size)
+            if self.serve_local_only:
+                import socket
+                self.abstract_socket.host = 'localhost'
         else:
             self.abstract_socket = GDBWebSocket(self.wss_server)
 
@@ -255,7 +259,7 @@ class GDBServer(threading.Thread):
         else:
             # Use internal IO handler.
             semihost_io_handler = semihost.InternalSemihostIOHandler()
-        self.telnet_console = semihost.TelnetSemihostIOHandler(self.telnet_port)
+        self.telnet_console = semihost.TelnetSemihostIOHandler(self.telnet_port, self.serve_local_only)
         self.semihost = semihost.SemihostAgent(self.target, io_handler=semihost_io_handler, console=self.telnet_console)
 
         self.setDaemon(True)

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -248,7 +248,6 @@ class GDBServer(threading.Thread):
         if self.wss_server == None:
             self.abstract_socket = GDBSocket(self.port, self.packet_size)
             if self.serve_local_only:
-                import socket
                 self.abstract_socket.host = 'localhost'
         else:
             self.abstract_socket = GDBWebSocket(self.wss_server)

--- a/pyOCD/target/semihost.py
+++ b/pyOCD/target/semihost.py
@@ -293,7 +293,7 @@ class InternalSemihostIOHandler(SemihostIOHandler):
 # The server thread will automatically be started by the constructor. To shut down the
 # server and its thread, call the stop() method.
 class TelnetSemihostIOHandler(SemihostIOHandler):
-    def __init__(self, port_or_url):
+    def __init__(self, port_or_url, serve_local_only=True):
         super(TelnetSemihostIOHandler, self).__init__()
         self._abstract_socket = None
         self._wss_server = None
@@ -304,6 +304,8 @@ class TelnetSemihostIOHandler(SemihostIOHandler):
         else:
             self._port = port_or_url
             self._abstract_socket = GDBSocket(self._port, 4096)
+            if serve_local_only:
+                self._abstract_socket.host = 'localhost'
         self._buffer = bytearray()
         self._buffer_lock = threading.Lock()
         self.connected = None

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -51,6 +51,7 @@ class GDBServerTool(object):
         parser.add_argument('--version', action='version', version=__version__)
         parser.add_argument("-p", "--port", dest="port_number", type=int, default=3333, help="Write the port number that GDB server will open.")
         parser.add_argument("-T", "--telnet-port", dest="telnet_port", type=int, default=4444, help="Specify the telnet port for semihosting.")
+        parser.add_argument("--allow-remote", dest="serve_local_only", default=True, action="store_false", help="Allow remote TCP/IP connections (default is no).")
         parser.add_argument("-b", "--board", dest="board_id", default=None, help="Connect to board by board id.  Use -l to list all connected boards.")
         parser.add_argument("-l", "--list", action="store_true", dest="list_all", default=False, help="List all connected boards.")
         parser.add_argument("-d", "--debug", dest="debug_level", choices=debug_levels, default='info', help="Set the level of system logging output. Supported choices are: " + ", ".join(debug_levels), metavar="LEVEL")
@@ -100,6 +101,7 @@ class GDBServerTool(object):
             'enable_semihosting' : args.enable_semihosting,
             'telnet_port' : args.telnet_port,
             'semihost_use_syscalls' : args.semihost_use_syscalls,
+            'serve_local_only' : args.serve_local_only,
         }
 
 


### PR DESCRIPTION
By default the GDB and semihosting servers bind only to localhost. A new `--allow-remote` option for pyocd-gdbserver allows you to enable remote connections.

The setting is passed to the GDBServer class via an `serve_local_only` option. GDBServer then passes this to the `TelnetSemihostIOHandler`.