### PR TITLE
gdbserver options for outputting JSON board and target lists

### DIFF
--- a/pyOCD/board/board.py
+++ b/pyOCD/board/board.py
@@ -88,7 +88,13 @@ class Board(object):
             traceback.print_exc()
 
     def getInfo(self):
-        return self.interface.getInfo()
+        # If the product name starts with the vendor name, we don't want to duplicate
+        # the vendor name, so just return the product name. Otherwise combined the two.
+        if self.interface.product_name.startswith(self.interface.vendor_name):
+            info = self.interface.product_name
+        else:
+            info = self.interface.vendor_name + " " + self.interface.product_name
+        return info
 
     def getPacketCount(self):
         """

--- a/pyOCD/board/mbed_board.py
+++ b/pyOCD/board/mbed_board.py
@@ -111,7 +111,7 @@ class MbedBoard(Board):
         """
         Return board name
         """
-        return self.board_name
+        return self.name
 
     def getInfo(self):
         """

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -162,7 +162,7 @@ class GDBServerTool(object):
             boards = []
             obj = {
                 'pyocd_version' : __version__,
-                'version' : 1,
+                'version' : { 'major' : 1, 'minor' : 0 },
                 'status' : status,
                 'boards' : boards,
                 }
@@ -173,9 +173,11 @@ class GDBServerTool(object):
             for mbed in all_mbeds:
                 d = {
                     'unique_id' : mbed.unique_id,
-                    'info' : mbed.getInfo().encode('ascii', 'ignore'),
+                    'info' : mbed.getInfo(),
                     'board_name' : mbed.getBoardName(),
-                    'target' : mbed.getTargetType()
+                    'target' : mbed.getTargetType(),
+                    'vendor_name' : mbed.interface.vendor_name,
+                    'product_name' : mbed.interface.product_name,
                     }
                 boards.append(d)
 
@@ -196,7 +198,7 @@ class GDBServerTool(object):
             targets = []
             obj = {
                 'pyocd_version' : __version__,
-                'version' : 1,
+                'version' : { 'major' : 1, 'minor' : 0 },
                 'status' : 0,
                 'targets' : targets
                 }

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -141,7 +141,12 @@ class GDBServerTool(object):
             print >> sys.stderr, self.echo_msg
             sys.stderr.flush()
 
+    def disable_logging(self):
+        logging.getLogger().setLevel(logging.FATAL)
+
     def list_boards(self):
+        self.disable_logging()
+
         all_mbeds = MbedBoard.getAllConnectedBoards(close=True, blocking=False)
 
         if self.args.output_json:
@@ -171,6 +176,8 @@ class GDBServerTool(object):
                 print("No available boards are connected")
 
     def list_targets(self):
+        self.disable_logging()
+
         if self.args.output_json:
             targets = []
             obj = {

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -147,14 +147,28 @@ class GDBServerTool(object):
     def list_boards(self):
         self.disable_logging()
 
-        all_mbeds = MbedBoard.getAllConnectedBoards(close=True, blocking=False)
+        try:
+            all_mbeds = MbedBoard.getAllConnectedBoards(close=True, blocking=False)
+            status = 0
+            error = ""
+        except Exception as e:
+            all_mbeds = []
+            status = 1
+            error = str(e)
+            if not self.args.output_json:
+                raise
 
         if self.args.output_json:
             boards = []
             obj = {
-                'version' : __version__,
-                'boards' : boards
+                'pyocd_version' : __version__,
+                'version' : 1,
+                'status' : status,
+                'boards' : boards,
                 }
+
+            if status != 0:
+                obj['error'] = error
 
             for mbed in all_mbeds:
                 d = {
@@ -181,7 +195,9 @@ class GDBServerTool(object):
         if self.args.output_json:
             targets = []
             obj = {
-                'version' : __version__,
+                'pyocd_version' : __version__,
+                'version' : 1,
+                'status' : 0,
                 'targets' : targets
                 }
 

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -20,6 +20,8 @@ import sys
 import logging
 import traceback
 import argparse
+import json
+import pkg_resources
 
 import pyOCD.board.mbed_board
 from pyOCD import __version__
@@ -53,6 +55,8 @@ class GDBServerTool(object):
         parser.add_argument("-T", "--telnet-port", dest="telnet_port", type=int, default=4444, help="Specify the telnet port for semihosting.")
         parser.add_argument("-b", "--board", dest="board_id", default=None, help="Connect to board by board id.  Use -l to list all connected boards.")
         parser.add_argument("-l", "--list", action="store_true", dest="list_all", default=False, help="List all connected boards.")
+        parser.add_argument("--list-targets", action="store_true", dest="list_targets", default=False, help="List all available targets.")
+        parser.add_argument("--json", action="store_true", dest="output_json", default=False, help="Output lists in JSON format. Only applies to --list and --list-targets.")
         parser.add_argument("-d", "--debug", dest="debug_level", choices=debug_levels, default='info', help="Set the level of system logging output. Supported choices are: " + ", ".join(debug_levels), metavar="LEVEL")
         parser.add_argument("-t", "--target", dest="target_override", choices=supported_targets, default=None, help="Override target to debug.  Supported targets are: " + ", ".join(supported_targets), metavar="TARGET")
         parser.add_argument("-n", "--nobreak", dest="break_at_hardfault", default=True, action="store_false", help="Disable halt at hardfault handler.")
@@ -137,6 +141,56 @@ class GDBServerTool(object):
             print >> sys.stderr, self.echo_msg
             sys.stderr.flush()
 
+    def list_boards(self):
+        all_mbeds = MbedBoard.getAllConnectedBoards(close=True, blocking=False)
+
+        if self.args.output_json:
+            boards = []
+            obj = {
+                'version' : __version__,
+                'boards' : boards
+                }
+
+            for mbed in all_mbeds:
+                d = {
+                    'unique_id' : mbed.unique_id,
+                    'info' : mbed.getInfo().encode('ascii', 'ignore'),
+                    'board_name' : mbed.getBoardName(),
+                    'target' : mbed.getTargetType()
+                    }
+                boards.append(d)
+
+            print json.dumps(obj, indent=4) #, sys.stdout)
+        else:
+            index = 0
+            if len(all_mbeds) > 0:
+                for mbed in all_mbeds:
+                    print("%d => %s boardId => %s" % (index, mbed.getInfo().encode('ascii', 'ignore'), mbed.unique_id))
+                    index += 1
+            else:
+                print("No available boards are connected")
+
+    def list_targets(self):
+        if self.args.output_json:
+            targets = []
+            obj = {
+                'version' : __version__,
+                'targets' : targets
+                }
+
+            for name in supported_targets:
+                t = pyOCD.target.TARGET[name](None)
+                d = {
+                    'name' : name,
+                    'part_number' : t.part_number,
+                    }
+                targets.append(d)
+
+            print json.dumps(obj, indent=4) #, sys.stdout)
+        else:
+            for t in supported_targets:
+                print t
+
     def run(self, args=None):
         self.args = self.build_parser().parse_args(args)
         self.gdb_server_settings = self.get_gdb_server_settings(self.args)
@@ -146,7 +200,9 @@ class GDBServerTool(object):
 
         gdb = None
         if self.args.list_all == True:
-            MbedBoard.listConnectedBoards()
+            self.list_boards()
+        elif self.args.list_targets == True:
+            self.list_targets()
         else:
             try:
                 board_selected = MbedBoard.chooseBoard(


### PR DESCRIPTION
Added `--list-targets` and `--json` options to pyocd-gdbserver.

`--list-targets` will write the list of supported target names to output and quit, similar to `--list`. `--json` causes `--list` and `--list-targets` to output data in JSON format.

Also fixes a bug in MbedBoard.getBoardName(). And improves Board.getInfo() so it won't include the vendor name if the product name is prefixed with the vendor name, to fix the "MBED MBED CMSIS-DAP" descriptions currently printed for many boards.

These changes are necessary to properly support the Eclipse launch config plugin.

Example of output from `--list --json`:
~~~~~(.json)
{
    "status": 0, 
    "version": {
        "major": 1, 
        "minor": 0
    }, 
    "pyocd_version": "0.5.2.dev35+dirty", 
    "boards": [
        {
            "info": "MBED CMSIS-DAP [kl28z]", 
            "target": "kl28z", 
            "board_name": "FRDM-KL28Z", 
            "vendor_name": "MBED", 
            "product_name": "MBED CMSIS-DAP", 
            "unique_id": "02900203C3153E630000000000000000000000003EE9C30B"
        }, 
        {
            "info": "MBED CMSIS-DAP [k22f]", 
            "target": "k22f", 
            "board_name": "FRDM-K22F", 
            "vendor_name": "MBED", 
            "product_name": "MBED CMSIS-DAP", 
            "unique_id": "02310201E7DFCE7F1A2133B6"
        }
    ]
}
~~~~~