### PR TITLE
added 'init' and 'reset' functionality to gdbserver

### DIFF
--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -948,7 +948,6 @@ class GDBServer(threading.Thread):
         }
 
         resp = 'OK'
-        cmdList = cmd.split()
         if cmd == 'help':
             resp = ''.join(['%s\t%s\n' % (k, v[0]) for k, v in safecmd.items()])
             resp = hexEncode(resp)
@@ -957,6 +956,7 @@ class GDBServer(threading.Thread):
             logging.info("Semihosting %s", ('enabled' if self.enable_semihosting else 'disabled'))
         else:
             resultMask = 0x00
+            cmdList = cmd.split()
             if cmdList[0] == 'help':
                 # a 'help' is only valid as the first cmd, and only
                 # gives info on the second cmd if it is valid

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -940,9 +940,9 @@ class GDBServer(threading.Thread):
 
         safecmd = {
             'init'  : ['Init reset sequence', 0x1],
-            'reset' : ['Reset target', 0x2],
+            'reset' : ['Reset and halt the target', 0x2],
             'halt'  : ['Halt target', 0x4],
-            'resume': ['Resume target', 0x8],
+            # 'resume': ['Resume target', 0x8],
             'help'  : ['Display this help', 0x80],
         }
 
@@ -981,16 +981,13 @@ class GDBServer(threading.Thread):
             if (resultMask & 0x6) == 0x6:
                 self.target.resetStopOnReset()
             elif resultMask & 0x2:
-                self.target.reset()
+                # on 'reset' still do a reset halt
+                self.target.resetStopOnReset()                
+                # self.target.reset()
             elif resultMask & 0x4:
                 self.target.halt()
-            if resultMask & 0x8:
-                self.target.resume()
-
-            if self.target.getState() != Target.TARGET_HALTED:
-                logging.error("Remote command left target running!")
-                logging.error("Forcing target to halt")
-                self.target.halt()
+            # if resultMask & 0x8:
+            #     self.target.resume()
 
         return self.createRSPPacket(resp)
 

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -939,58 +939,54 @@ class GDBServer(threading.Thread):
         logging.debug('Remote command: %s', cmd)
 
         safecmd = {
-            'reset' : ['Reset target', 0x1],
-            'halt'  : ['Halt target', 0x2],
-            'resume': ['Resume target', 0x4],
+            'init'  : ['Init reset sequence', 0x1],
+            'reset' : ['Reset target', 0x2],
+            'halt'  : ['Halt target', 0x4],
+            'resume': ['Resume target', 0x8],
             'help'  : ['Display this help', 0x80],
-            'reg'   : ['Show registers', 0],
-            'init'  : ['Init reset sequence', 0]
+            # 'reg'   : ['Show registers', 0], # disabled for now
         }
-        resultMask = 0x00
+
         resp = 'OK'
+        cmdList = cmd.split()
         if cmd == 'help':
-            resp = ''
-            for k, v in safecmd.items():
-                resp += '%s\t%s\n' % (k, v[0])
+            resp = ''.join(['%s\t%s\n' % (k, v[0]) for k, v in safecmd.items()])
             resp = hexEncode(resp)
         elif cmd.startswith('arm semihosting'):
             self.enable_semihosting = 'enable' in cmd
             logging.info("Semihosting %s", ('enabled' if self.enable_semihosting else 'disabled'))
         else:
-            cmdList = cmd.split(' ')
-            #check whether all the cmds is valid cmd for monitor
+            resultMask = 0x00
+            if cmdList[0] == 'help':
+                # a 'help' is only valid as the first cmd, and only
+                # gives info on the second cmd if it is valid
+                resultMask |= 0x80
+                del cmdList[0]
+
             for cmd_sub in cmdList:
-                if not cmd_sub in safecmd:
-                    #error cmd for monitor
-                    logging.warning("Invalid mon command '%s'", cmd)
-                    resp = 'Invalid Command: "%s"\n' % cmd
+                if cmd_sub not in safecmd:
+                    logging.warning("Invalid mon command '%s'", cmd_sub)
+                    resp = 'Invalid Command: "%s"\n' % cmd_sub
                     resp = hexEncode(resp)
                     return self.createRSPPacket(resp)
-                else:
-                    resultMask = resultMask | safecmd[cmd_sub][1]
-            #10000001 for help reset, so output reset cmd help information
-            if resultMask == 0x81:
-                resp = 'Reset the target\n'
-                resp = hexEncode(resp)
-            #10000010 for help halt, so output halt cmd help information
-            elif resultMask == 0x82:
-                resp = 'Halt the target\n'
-                resp = hexEncode(resp)
-            #10000100 for help resume, so output resume cmd help information
-            elif resultMask == 0x84:
-                resp = 'Resume the target\n'
-                resp = hexEncode(resp)
-            #11 for reset halt cmd, so launch self.target.resetStopOnReset()
-            elif resultMask == 0x3:
+                elif resultMask == 0x80:
+                    # if the first command was a 'help', we only need
+                    # to return info about the first cmd after it
+                    resp = hexEncode(safecmd[cmd_sub][0]+'\n')
+                    return self.createRSPPacket(resp)                    
+                resultMask |= safecmd[cmd_sub][1]
+
+            # Run cmds in proper order
+            if resultMask & 0x1:
+                self.target.init()
+            if (resultMask & 0x6) == 0x6:
                 self.target.resetStopOnReset()
-            #111 for reset halt resume cmd, so launch self.target.resetStopOnReset() and self.target.resume()
-            elif resultMask == 0x7:
-                self.target.resetStopOnReset()
-                self.target.resume()
-            elif resultMask == 0x1:
+            elif resultMask & 0x2:
                 self.target.reset()
-            elif resultMask == 0x2:
+            elif resultMask & 0x4:
                 self.target.halt()
+            if resultMask & 0x8:
+                self.target.resume()
 
             if self.target.getState() != Target.TARGET_HALTED:
                 logging.error("Remote command left target running!")

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -944,7 +944,6 @@ class GDBServer(threading.Thread):
             'halt'  : ['Halt target', 0x4],
             'resume': ['Resume target', 0x8],
             'help'  : ['Display this help', 0x80],
-            # 'reg'   : ['Show registers', 0], # disabled for now
         }
 
         resp = 'OK'

--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -498,8 +498,7 @@ class CortexM(Target):
         """
         return the IDCODE of the core
         """
-        if self.idcode == 0:
-            self.idcode = self.dap.readDP(DP_REG['IDCODE'])
+        self.idcode = self.dap.readDP(DP_REG['IDCODE'])
         return self.idcode
 
     def writeMemory(self, addr, value, transfer_size=32):


### PR DESCRIPTION
I've **not** tested this with the new pyDAP framework so I'd like to do that before this gets merged but it seems to work fine with the non-pyDAP version.

I also restructured the handleRemoteCommand a little bit: 
+ removed comments that were redundant/already clear from the code
+ reordered commands so ``init`` is now 0x1 and the rest of the cmd codes are shifted by 1
+ logic is slightly different so that ``help`` must be entered first for the help command to succeed - anything else is considered malformed

Question: Why do you force the target to halt after running the commands? Seems to defeat the purpose of having a ``resume`` command.