### PR TITLE
Deleted use of non-existing RESET register. Only present in nRF51 dev…

### DIFF
--- a/pyOCD/target/target_nrf52.py
+++ b/pyOCD/target/target_nrf52.py
@@ -19,10 +19,6 @@ from cortex_m import CortexM
 from .memory_map import (FlashRegion, RamRegion, MemoryMap)
 import logging
 
-# NRF52 specific registers
-RESET = 0x40000544
-RESET_ENABLE = (1 << 0)
-
 class NRF52(CortexM):
 
     memoryMap = MemoryMap(
@@ -38,9 +34,6 @@ class NRF52(CortexM):
         reset a core. After a call to this function, the core
         is running
         """
-        #Regular reset will kick NRF out of DBG mode
-        logging.debug("target_nrf52.reset: enable reset pin")
-        self.writeMemory(RESET, RESET_ENABLE)
         #reset
         logging.debug("target_nrf52.reset: trigger nRST pin")
         CortexM.reset(self)


### PR DESCRIPTION
As can be seen in the nRF52 specifications (can be found at http://infocenter.nordicsemi.com/index.jsp) POWER.RESET register does not exist in nRF52.