### PR TITLE
Fixed error in MemoryRegion.containsRange() function.

### DIFF
--- a/pyOCD/target/memory_map.py
+++ b/pyOCD/target/memory_map.py
@@ -89,6 +89,8 @@ class MemoryRegion(object):
 
     def containsRange(self, start, end=None, length=None):
         if end is None:
+            if length is None:
+                raise ValueError("both end and length parameters are None")
             end = start + length - 1
         return self.containsAddress(start) and self.containsAddress(end)
 

--- a/pyOCD/target/memory_map.py
+++ b/pyOCD/target/memory_map.py
@@ -88,9 +88,8 @@ class MemoryRegion(object):
         return (address >= self.start) and (address <= self.end)
 
     def containsRange(self, start, end=None, length=None):
+        assert (end is not None) ^ (length is not None)
         if end is None:
-            if length is None:
-                raise ValueError("both end and length parameters are None")
             end = start + length - 1
         return self.containsAddress(start) and self.containsAddress(end)
 


### PR DESCRIPTION
Fixed error. When both end and length parameters to MemoryRegion.containsRange() are not given, None was used in an arithmetic expression.