### PR TITLE
Fix some misc bugs

### DIFF
--- a/pyOCD/pyDAPAccess/cmsis_dap_core.py
+++ b/pyOCD/pyDAPAccess/cmsis_dap_core.py
@@ -18,6 +18,7 @@
 import logging
 import array
 from .dap_access_api import DAPAccessIntf
+import six
 
 COMMAND_ID = {'DAP_INFO': 0x00,
               'DAP_LED': 0x01,
@@ -82,7 +83,9 @@ class CMSIS_DAP_Protocol(object):
     def dapInfo(self, id_):
         cmd = []
         cmd.append(COMMAND_ID['DAP_INFO'])
-        cmd.append(ID_INFO[id_])
+        if not type(id_) in (six.integer_types):
+            id_ = ID_INFO[id_]
+        cmd.append(id_)
         self.interface.write(cmd)
 
         resp = self.interface.read()
@@ -100,10 +103,12 @@ class CMSIS_DAP_Protocol(object):
             if resp[1] == 2:
                 return (resp[3] << 8) | resp[2]
 
-        # String values
-        x = array.array('B', [i for i in resp[2:2 + resp[1]]])
+        # String values. They are sent as C strings with a terminating null char, so we strip it out.
+        x = array.array('B', [i for i in resp[2:2 + resp[1]]]).tostring()
+        if x[-1] == '\x00':
+            x = x[0:-1]
+        return x
 
-        return x.tostring()
 
     def setLed(self):
         #not yet implemented

--- a/pyOCD/pyDAPAccess/cmsis_dap_core.py
+++ b/pyOCD/pyDAPAccess/cmsis_dap_core.py
@@ -81,10 +81,10 @@ class CMSIS_DAP_Protocol(object):
         self.interface = interface
 
     def dapInfo(self, id_):
-        cmd = []
-        cmd.append(COMMAND_ID['DAP_INFO'])
         if not type(id_) in (six.integer_types):
             id_ = ID_INFO[id_]
+        cmd = []
+        cmd.append(COMMAND_ID['DAP_INFO'])
         cmd.append(id_)
         self.interface.write(cmd)
 
@@ -97,7 +97,7 @@ class CMSIS_DAP_Protocol(object):
             return
 
         # Integer values
-        if id_ in ('CAPABILITIES', 'PACKET_COUNT', 'PACKET_SIZE'):
+        if id_ in (ID_INFO['CAPABILITIES'], ID_INFO['PACKET_COUNT'], ID_INFO['PACKET_SIZE']):
             if resp[1] == 1:
                 return resp[2]
             if resp[1] == 2:
@@ -108,7 +108,6 @@ class CMSIS_DAP_Protocol(object):
         if x[-1] == '\x00':
             x = x[0:-1]
         return x
-
 
     def setLed(self):
         #not yet implemented

--- a/pyOCD/pyDAPAccess/dap_access_api.py
+++ b/pyOCD/pyDAPAccess/dap_access_api.py
@@ -43,7 +43,7 @@ class DAPAccessIntf(object):
         VENDOR = 1
         PRODUCT = 2
         SER_NUM = 3
-        FW_VAR = 4
+        FW_VER = 4
         DEVICE_VENDOR = 5
         DEVICE_NAME = 6
 

--- a/pyOCD/pyDAPAccess/dap_access_usb.py
+++ b/pyOCD/pyDAPAccess/dap_access_usb.py
@@ -39,7 +39,7 @@ MBED_PID = 0x0204
 
 
 def _get_interfaces():
-    """Get the commected USB devices"""
+    """Get the connected USB devices"""
     return INTERFACE[usb_backend].getAllConnectedInterface(MBED_VID, MBED_PID)
 
 

--- a/pyOCD/pyDAPAccess/interface/hidapi_backend.py
+++ b/pyOCD/pyDAPAccess/interface/hidapi_backend.py
@@ -63,7 +63,8 @@ class HidApiUSB(Interface):
 
         for deviceInfo in devices:
             try:
-                dev = hid.device(vendor_id=vid, product_id=pid, path=deviceInfo['path'])
+                dev = hid.device(vendor_id=deviceInfo['vendor_id'], product_id=deviceInfo['product_id'],
+                    path=deviceInfo['path'])
             except IOError:
                 logging.debug("Failed to open Mbed device")
                 return
@@ -74,11 +75,15 @@ class HidApiUSB(Interface):
             new_board.product_name = deviceInfo['product_string']
             new_board.vid = deviceInfo['vendor_id']
             new_board.pid = deviceInfo['product_id']
+            new_board.device_info = deviceInfo
             new_board.device = dev
             try:
-                dev.open(vid, pid)
+                dev.open_path(deviceInfo['path'])
             except AttributeError:
                 pass
+            except IOError:
+                # Ignore failure to open a device by skipping the device.
+                continue
 
             boards.append(new_board)
 

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -28,6 +28,7 @@ from pyOCD import __version__
 from pyOCD.gdbserver import GDBServer
 from pyOCD.board import MbedBoard
 from pyOCD.utility.cmdline import split_command_line
+from pyOCD.pyDAPAccess.dap_access_usb import DAPAccessUSB
 import pyOCD.board.mbed_board
 
 LEVELS = {
@@ -178,9 +179,20 @@ class GDBServerTool(object):
                     'info' : mbed.getInfo(),
                     'board_name' : mbed.getBoardName(),
                     'target' : mbed.getTargetType(),
-                    'vendor_name' : mbed.interface.vendor_name,
-                    'product_name' : mbed.interface.product_name,
+                    'vendor_name' : '',
+                    'product_name' : '',
                     }
+
+                # Reopen the link so we can access the USB vendor and product names from the inteface.
+                # If it's not a USB based link, then we don't attempt this.
+                if isinstance(mbed.link, DAPAccessUSB):
+                    try:
+                        mbed.link.open()
+                        d['vendor_name'] = mbed.link._interface.vendor_name
+                        d['product_name'] = mbed.link._interface.product_name
+                        mbed.link.close()
+                    except Exception:
+                        pass
                 boards.append(d)
 
             print json.dumps(obj, indent=4) #, sys.stdout)

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,5 @@
+output.txt
+gdb_test_raw.txt
+test_params.txt
+test_results.txt
+

--- a/test/automated_test.py
+++ b/test/automated_test.py
@@ -33,6 +33,7 @@ from speed_test import SpeedTest
 from cortex_test import CortexTest
 from flash_test import FlashTest
 from gdb_test import GdbTest
+from gdb_server_json_test import GdbServerJsonTest
 
 
 if __name__ == "__main__":
@@ -58,6 +59,7 @@ if __name__ == "__main__":
     # Put together list of tests
     test = Test("Basic Test", lambda board: basic_test(board, None))
     test_list.append(test)
+    test_list.append(GdbServerJsonTest())
     test_list.append(SpeedTest())
     test_list.append(CortexTest())
     test_list.append(FlashTest())

--- a/test/gdb_server_json_test.py
+++ b/test/gdb_server_json_test.py
@@ -1,0 +1,191 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2006-2015 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import argparse, os, sys
+from time import sleep, time
+from random import randrange
+import math
+import argparse
+import subprocess
+import json
+
+parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parentdir)
+
+import pyOCD
+from pyOCD import __version__
+from pyOCD.board import MbedBoard
+from pyOCD.utility.conversion import float32beToU32be
+from pyOCD.pyDAPAccess import DAPAccess
+from test_util import Test, TestResult
+import logging
+from random import randrange
+
+class GdbServerJsonTestResult(TestResult):
+    def __init__(self):
+        super(GdbServerJsonTestResult, self).__init__(None, None, None)
+
+class GdbServerJsonTest(Test):
+    def __init__(self):
+        super(GdbServerJsonTest, self).__init__("Gdb Server Json Test", gdb_server_json_test)
+
+    def print_perf_info(self, result_list):
+        pass
+
+    def run(self, board):
+        try:
+            result = self.test_function(board.getUniqueID())
+        except Exception as e:
+            result = GdbServerJsonTestResult()
+            result.passed = False
+            print("Exception %s when testing board %s" % (e, board.getUniqueID()))
+        result.board = board
+        result.test = self
+        return result
+
+def gdb_server_json_test(board_id):
+
+    test_count = 0
+    test_pass_count = 0
+
+    def validate_basic_keys(data):
+        did_pass = True
+
+        print 'pyocd_version',
+        p = data.has_key('pyocd_version')
+        if p:
+            p = data['pyocd_version'] == __version__
+        if p:
+            print "PASSED"
+        else:
+            did_pass = False
+            print"FAILED"
+
+        print 'version',
+        p = data.has_key('version')
+        if p:
+            v = data['version']
+            p = v.has_key('major') and v.has_key('minor')
+        if p:
+            p = v['major'] == 1 and v['minor'] == 0
+        if p:
+            print "PASSED"
+        else:
+            did_pass = False
+            print"FAILED"
+
+        print 'status',
+        p = data.has_key('status')
+        if p:
+            p = data['status'] == 0
+        if p:
+            print "PASSED"
+        else:
+            did_pass = False
+            print"FAILED"
+
+        return did_pass
+
+    def validate_boards(data):
+        did_pass = True
+
+        print 'boards',
+        p = data.has_key('boards') and type(data['boards']) is list
+        if p:
+            b = data['boards']
+        if p:
+            print "PASSED"
+        else:
+            did_pass = False
+            print"FAILED"
+
+        try:
+            all_mbeds = MbedBoard.getAllConnectedBoards(close=True, blocking=False)
+            p = len(all_mbeds) == len(b)
+            matching_boards = 0
+            if p:
+                for mbed in all_mbeds:
+                    for brd in b:
+                        if mbed.unique_id == brd['unique_id']:
+                            matching_boards += 1
+                            p = brd.has_key('info') and brd.has_key('target') and brd.has_key('board_name')
+                            if not p:
+                                break
+                    if not p:
+                        break
+                p = matching_boards == len(all_mbeds)
+            if p:
+                print "PASSED"
+            else:
+                did_pass = False
+                print"FAILED"
+        except Exception:
+            print "FAILED"
+            did_pass = False
+
+        return did_pass
+
+    def validate_targets(data):
+        did_pass = True
+
+        print 'targets',
+        p = data.has_key('targets') and type(data['targets']) is list
+        if p:
+            targets = data['targets']
+            for t in targets:
+                p = t.has_key('name') and t.has_key('part_number')
+                if not p:
+                    break
+        if p:
+            print "PASSED"
+        else:
+            did_pass = False
+            print"FAILED"
+
+        return did_pass
+
+
+    result = GdbServerJsonTestResult()
+
+    print "\r\n\r\n----- TESTING BOARDS LIST -----"
+    out = subprocess.check_output(['pyocd-gdbserver', '--list', '--json'])
+    data = json.loads(out)
+    test_count += 2
+    if validate_basic_keys(data):
+        test_pass_count += 1
+    if validate_boards(data):
+        test_pass_count += 1
+
+    print "\r\n\r\n----- TESTING TARGETS LIST -----"
+    out = subprocess.check_output(['pyocd-gdbserver', '--list-targets', '--json'])
+    data = json.loads(out)
+    test_count += 2
+    if validate_basic_keys(data):
+        test_pass_count += 1
+    if validate_targets(data):
+        test_pass_count += 1
+
+    result.passed = test_count == test_pass_count
+    return result
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='pyocd-gdbserver json output test')
+    parser.add_argument('-d', '--debug', action="store_true", help='Enable debug logging')
+    args = parser.parse_args()
+    level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(level=level)
+    gdb_server_json_test(None)


### PR DESCRIPTION
- `CMSIS_DAP_Protocol.dapInfo()` didn't work in pyDAPAccess. It also returned string values with a null terminating char still present.
- Some typo fixes.
- Improved hidapi interface backend. Mostly fixes an issue where no devices could be listed if one device failed to be opened because it was already in use by some other process.
- Fixed JSON `--list` and `--list-targets` output from pyocd-gdbserver. Required for the pyOCD launch config plugin to properly list available boards and targets. Was broken after the switch to pyDAPAccess.
- Created a test or the pyocd-gdbserver JSON output.