### PR TITLE
add nrf51's UICR to its memory map

### DIFF
--- a/pyOCD/target/target_nrf51.py
+++ b/pyOCD/target/target_nrf51.py
@@ -27,6 +27,8 @@ class NRF51(CortexM):
 
     memoryMap = MemoryMap(
         FlashRegion(    start=0,           length=0x40000,      blocksize=0x400, isBootMemory=True),
+        # User Information Configation Registers (UICR) as a flash region
+        FlashRegion(    start=0x10001000,  length=0x100,        blocksize=0x100),
         RamRegion(      start=0x20000000,  length=0x4000)
         )
 


### PR DESCRIPTION
A nRF51 bootloader contains data in the User Information Configuration Registers (UICR). To support to flash a nRF51 bootloader,  the UICR should be added to the memory map. 