### PR TITLE
chooseBoard(): pass board_id to avoid accessing other devices

### DIFF
--- a/pyOCD/board/mbed_board.py
+++ b/pyOCD/board/mbed_board.py
@@ -150,7 +150,8 @@ class MbedBoard(Board):
 
     @staticmethod
     def getAllConnectedBoards(dap_class=DAPAccess, close=False, blocking=True,
-                              target_override=None, frequency=1000000):
+                              target_override=None, frequency=1000000,
+                              board_id = None):
         """
         Return an array of all mbed boards connected
         """
@@ -158,7 +159,7 @@ class MbedBoard(Board):
         mbed_list = []
         while True:
 
-            connected_daps = dap_class.get_connected_devices()
+            connected_daps = dap_class.get_connected_devices(board_id)
             for dap_access in connected_daps:
                 new_mbed = MbedBoard(dap_access, target_override, frequency)
                 mbed_list.append(new_mbed)
@@ -186,7 +187,8 @@ class MbedBoard(Board):
         Allow you to select a board among all boards connected
         """
         all_mbeds = MbedBoard.getAllConnectedBoards(dap_class, False, blocking,
-                                                    target_override, frequency)
+                                                    target_override, frequency,
+                                                    board_id)
 
         # If a board ID is specified close all other boards
         if board_id != None:

--- a/pyOCD/pyDAPAccess/dap_access_api.py
+++ b/pyOCD/pyDAPAccess/dap_access_api.py
@@ -76,7 +76,7 @@ class DAPAccessIntf(object):
         pass
 
     @staticmethod
-    def get_connected_devices():
+    def get_connected_devices(board_id = None):
         """Return a list of DAPAccess devices"""
         raise NotImplementedError()
 

--- a/pyOCD/pyDAPAccess/dap_access_usb.py
+++ b/pyOCD/pyDAPAccess/dap_access_usb.py
@@ -35,9 +35,9 @@ VALUE_MATCH = 1 << 4
 MATCH_MASK = 1 << 5
 
 
-def _get_interfaces():
+def _get_interfaces(board_id = None):
     """Get the connected USB devices"""
-    return INTERFACE[usb_backend].getAllConnectedInterface()
+    return INTERFACE[usb_backend].getAllConnectedInterface(board_id)
 
 
 def _get_unique_id(interface):
@@ -339,12 +339,15 @@ class DAPAccessUSB(DAPAccessIntf):
     #          Static Functions
     # ------------------------------------------- #
     @staticmethod
-    def get_connected_devices():
+    def get_connected_devices(board_id = None):
         """
         Return an array of all mbed boards connected
+
+        :param str board_id: if specifed, serial number of the board(s)
+            we want
         """
         all_daplinks = []
-        all_interfaces = _get_interfaces()
+        all_interfaces = _get_interfaces(board_id)
         for interface in all_interfaces:
             try:
                 unique_id = _get_unique_id(interface)

--- a/pyOCD/pyDAPAccess/interface/hidapi_backend.py
+++ b/pyOCD/pyDAPAccess/interface/hidapi_backend.py
@@ -47,7 +47,7 @@ class HidApiUSB(Interface):
         pass
 
     @staticmethod
-    def getAllConnectedInterface():
+    def getAllConnectedInterface(board_id = None):
         """
         returns all the connected devices which matches HidApiUSB.vid/HidApiUSB.pid.
         returns an array of HidApiUSB (Interface) objects
@@ -66,7 +66,8 @@ class HidApiUSB(Interface):
             if (product_name.find("CMSIS-DAP") < 0):
                 # Skip non cmsis-dap devices
                 continue
-
+            if board_id and board_id != deviceInfo['serial_number']:
+                continue
             try:
                 dev = hid.device(vendor_id=deviceInfo['vendor_id'], product_id=deviceInfo['product_id'],
                     path=deviceInfo['path'])

--- a/pyOCD/pyDAPAccess/interface/pyusb_backend.py
+++ b/pyOCD/pyDAPAccess/interface/pyusb_backend.py
@@ -64,9 +64,10 @@ class PyUSB(Interface):
                 self.rcv_data.append(self.ep_in.read(self.ep_in.wMaxPacketSize, -1))
 
     @staticmethod
-    def getAllConnectedInterface():
+    def getAllConnectedInterface(board_id = None):
         """
-        returns all the connected devices which matches PyUSB.vid/PyUSB.pid.
+        returns all the connected devices which matches
+        PyUSB.vid/PyUSB.pid and (optionally) board_id.
         returns an array of PyUSB (Interface) objects
         """
         # find all devices matching the vid/pid specified
@@ -85,7 +86,9 @@ class PyUSB(Interface):
                 # The product string is read over USB when accessed.
                 # This can cause an exception to be thrown if the device
                 # is malfunctioning.
+                # Also lack of permissions
                 product = board.product
+                serial = board.serial_number
             except usb.core.USBError as error:
                 logging.warning("Exception getting product string: %s", error)
                 continue
@@ -93,7 +96,9 @@ class PyUSB(Interface):
                 # Not a cmsis-dap device so close it
                 usb.util.dispose_resources(board)
                 continue
-
+            if board_id and serial != board_id:
+                continue
+            
             # get active config
             config = board.get_active_configuration()
 

--- a/pyOCD/pyDAPAccess/interface/pywinusb_backend.py
+++ b/pyOCD/pyDAPAccess/interface/pywinusb_backend.py
@@ -60,7 +60,7 @@ class PyWinUSB(Interface):
         self.device.open(shared=False)
 
     @staticmethod
-    def getAllConnectedInterface():
+    def getAllConnectedInterface(board_id = None):
         """
         returns all the connected CMSIS-DAP devices
         """


### PR DESCRIPTION
If a board_id is specified, pass it all the way to the low level layer
to avoid accessing other boards or devices we might:

(a) not have access to (no permissions)
(b) be already accessing (and thus it'll be busy)

The call chain of functions for which the `board_id` is added
(defaulting to None) is:

board/mbed_board.py--MbedBoard.chooseBoard()
                               getAllConnectedBoards()
pyDAPAccess/dap_access_usb.py -- DAPAccessIntf.get_connected_devices()
pyDAPAccess/dap_access_usb.py -- _get_interfaces()
pyDAPAccess/interface/pyusb_backend.py -- PyUSB.getAllConnectedInterface()

Only pyusb_backend.py could be tested.

Signed-off-by: Inaky Perez-Gonzalez inaky.perez-gonzalez@intel.com
