### PR TITLE
Fix hanging GDB when continuing after a hardfault

### DIFF
--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -345,7 +345,7 @@ class GDBServer(threading.Thread):
                         self.is_target_running = False
                         self.sendStopNotification()
                     else:
-                        logging.debug("Got unexpected ctrl-c, ignoring")
+                        logging.error("Got unexpected ctrl-c, ignoring")
                     self.packet_io.interrupt_event.clear()
 
                 if self.non_stop and self.is_target_running:
@@ -664,14 +664,14 @@ class GDBServer(threading.Thread):
                 return self.createRSPPacket('E01')
             thread_actions[1] = default_action
 
-        if thread_actions[1] in ('c', 'C'):
+        if thread_actions[1][0] in ('c', 'C'):
             if self.non_stop:
                 self.target.resume()
                 self.is_target_running = True
                 return self.createRSPPacket("OK")
             else:
                 return self.resume(None)
-        elif thread_actions[1] in ('s', 'S'):
+        elif thread_actions[1][0] in ('s', 'S'):
             if self.non_stop:
                 self.target.step(not self.step_into_interrupt)
                 self.packet_io.send(self.createRSPPacket("OK"))
@@ -687,6 +687,8 @@ class GDBServer(threading.Thread):
             self.target.halt()
             self.is_target_running = False
             self.sendStopNotification(forceSignal=0)
+        else:
+            logging.error("Unsupported vCont action '%s'" % thread_actions[1])
 
     def flashOp(self, data):
         ops = data.split(':')[0]


### PR DESCRIPTION
If a hard fault occurs while debugging the signal SIGSEGV is returned
on halt.  When trying to continue after this hard fault the GDB client
sends the vCommand "Cont;C0b:1;c".  This is ignored in the vCont
processing since nothing matches the action "C0b".  This causes the
target to remain halted and the gdb client and server to go out of
sync.

This patch fixes this problem by comparing against only the first
character in the command.  That way if a continue or step packet
comes in with a signal specified then the correct action will still be
taken.  This patch also adds an error log statement to print if there
is an unsupported command.