### PR TITLE
RTOS task awareness

### DIFF
--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -103,6 +103,10 @@ class CoreSightTarget(Target):
     def readIDCode(self):
         return self.dp.dpidr
 
+    @property
+    def run_token(self):
+        return self.selected_core.run_token
+
     def flush(self):
         self.dp.flush()
 

--- a/pyOCD/core/target.py
+++ b/pyOCD/core/target.py
@@ -193,6 +193,10 @@ class Target(object):
     def getState(self):
         raise NotImplementedError()
 
+    @property
+    def run_token(self):
+        return 0
+
     def isRunning(self):
         return self.getState() == Target.TARGET_RUNNING
 

--- a/pyOCD/coresight/cortex_m.py
+++ b/pyOCD/coresight/cortex_m.py
@@ -285,6 +285,7 @@ class CortexM(Target):
         self.dp = dp
         self.ap = ap
         self.core_number = core_num
+        self._run_token = 0
         self._target_context = None
 
         # Set up breakpoints manager.
@@ -478,6 +479,8 @@ class CortexM(Target):
 
         self.dp.flush()
 
+        self._run_token += 1
+
     def clearDebugCauseBits(self):
         self.writeMemory(CortexM.DFSR, CortexM.DFSR_DWTTRAP | CortexM.DFSR_BKPT | CortexM.DFSR_HALTED)
 
@@ -489,6 +492,8 @@ class CortexM(Target):
         if software_reset == None:
             # Default to software reset if nothing is specified
             software_reset = True
+
+        self._run_token += 1
 
         if software_reset:
             # Perform the reset.
@@ -564,6 +569,10 @@ class CortexM(Target):
         else:
             return Target.TARGET_RUNNING
 
+    @property
+    def run_token(self):
+        return self._run_token
+
     def isRunning(self):
         return self.getState() == Target.TARGET_RUNNING
 
@@ -577,6 +586,7 @@ class CortexM(Target):
         if self.getState() != Target.TARGET_HALTED:
             logging.debug('cannot resume: target not halted')
             return
+        self._run_token += 1
         self.clearDebugCauseBits()
         self.writeMemory(CortexM.DHCSR, CortexM.DBGKEY | CortexM.C_DEBUGEN)
         self.dp.flush()

--- a/pyOCD/debug/symbols.py
+++ b/pyOCD/debug/symbols.py
@@ -1,0 +1,22 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2016 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+## @brief Abstract class for getting information about symbols in the target program.
+class SymbolProvider(object):
+    def get_symbol_value(self, name):
+        raise NotImplementedError()
+

--- a/pyOCD/gdbserver/symbols.py
+++ b/pyOCD/gdbserver/symbols.py
@@ -1,0 +1,26 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2016 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from ..debug.symbols import SymbolProvider
+
+## @brief Request symbol information from gdb.
+class GDBSymbolProvider(SymbolProvider):
+    def __init__(self, gdbserver):
+        self._gdbserver = gdbserver
+
+    def get_symbol_value(self, name):
+        return self._gdbserver.getSymbol(name)

--- a/pyOCD/rtos/__init__.py
+++ b/pyOCD/rtos/__init__.py
@@ -1,0 +1,24 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2016 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from .argon import ArgonThreadProvider
+from .freertos import FreeRTOSThreadProvider
+
+RTOS = {
+          'Argon' : ArgonThreadProvider,
+          'FreeRTOS' : FreeRTOSThreadProvider,
+         }

--- a/pyOCD/rtos/argon.py
+++ b/pyOCD/rtos/argon.py
@@ -1,0 +1,427 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2016 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from .provider import (TargetThread, ThreadProvider)
+from .common import (read_c_string, HandlerModeThread)
+from ..debug.context import DebugContext
+from ..coresight.cortex_m import CORE_REGISTER
+from pyOCD.pyDAPAccess import DAPAccess
+import logging
+
+IS_RUNNING_OFFSET = 0x54
+
+ALL_OBJECTS_THREADS_OFFSET = 0
+
+THREAD_STACK_POINTER_OFFSET = 0
+THREAD_EXTENDED_FRAME_OFFSET = 4
+THREAD_NAME_OFFSET = 8
+THREAD_STACK_BOTTOM_OFFSET = 12
+THREAD_PRIORITY_OFFSET = 16
+THREAD_STATE_OFFSET = 17
+THREAD_CREATED_NODE_OFFSET = 36
+
+LIST_NODE_NEXT_OFFSET = 0
+LIST_NODE_OBJ_OFFSET= 8
+
+# Create a logger for this module.
+log = logging.getLogger("argon")
+
+class TargetList(object):
+    def __init__(self, context, ptr):
+        self._context = context
+        self._list = ptr
+
+    def __iter__(self):
+        next = 0
+        head = self._context.read32(self._list)
+        node = head
+        is_valid = head != 0
+
+        while is_valid and next != head:
+            try:
+                # Read the object from the node.
+                obj = self._context.read32(node + LIST_NODE_OBJ_OFFSET)
+                yield obj
+
+                next = self._context.read32(node + LIST_NODE_NEXT_OFFSET)
+                node = next
+            except DAPAccess.TransferError:
+                log.warning("TransferError while reading list elements (list=0x%08x, node=0x%08x), terminating list", self._list, node)
+                is_valid = False
+
+## @brief
+class ArgonThreadContext(DebugContext):
+    # SP is handled specially, so it is not in these dicts.
+
+    CORE_REGISTER_OFFSETS = {
+                # Software stacked
+                 4: 0, # r4
+                 5: 4, # r5
+                 6: 8, # r6
+                 7: 12, # r7
+                 8: 16, # r8
+                 9: 20, # r9
+                 10: 24, # r10
+                 11: 28, # r11
+                # Hardware stacked
+                 0: 32, # r0
+                 1: 36, # r1
+                 2: 40, # r2
+                 3: 44, # r3
+                 12: 48, # r12
+                 14: 52, # lr
+                 15: 56, # pc
+                 16: 60, # xpsr
+            }
+
+    FPU_EXTENDED_REGISTER_OFFSETS = {
+                # Software stacked
+                 4: 0, # r4
+                 5: 4, # r5
+                 6: 8, # r6
+                 7: 12, # r7
+                 8: 16, # r8
+                 9: 20, # r9
+                 10: 24, # r10
+                 11: 28, # r11
+                 0x50: 32, # s16
+                 0x51: 36, # s17
+                 0x52: 40, # s18
+                 0x53: 44, # s19
+                 0x54: 48, # s20
+                 0x55: 52, # s21
+                 0x56: 56, # s22
+                 0x57: 60, # s23
+                 0x58: 64, # s24
+                 0x59: 68, # s25
+                 0x5a: 72, # s26
+                 0x5b: 76, # s27
+                 0x5c: 80, # s28
+                 0x5d: 84, # s29
+                 0x5e: 88, # s30
+                 0x5f: 92, # s31
+                # Hardware stacked
+                 0: 96, # r0
+                 1: 100, # r1
+                 2: 104, # r2
+                 3: 108, # r3
+                 12: 112, # r12
+                 14: 116, # lr
+                 15: 120, # pc
+                 16: 124, # xpsr
+                 0x40: 128, # s0
+                 0x41: 132, # s1
+                 0x42: 136, # s2
+                 0x43: 140, # s3
+                 0x44: 144, # s4
+                 0x45: 148, # s5
+                 0x46: 152, # s6
+                 0x47: 156, # s7
+                 0x48: 160, # s8
+                 0x49: 164, # s9
+                 0x4a: 168, # s10
+                 0x4b: 172, # s11
+                 0x4c: 176, # s12
+                 0x4d: 180, # s13
+                 0x4e: 184, # s14
+                 0x4f: 188, # s15
+                 33: 192, # fpscr
+                 # (reserved word: 196)
+            }
+
+    # Registers that are not available on the stack for exceptions.
+    EXCEPTION_UNAVAILABLE_REGS = (4, 5, 6, 7, 8, 9, 10, 11)
+
+    def __init__(self, parentContext, thread):
+        super(ArgonThreadContext, self).__init__(parentContext.core)
+        self._parent = parentContext
+        self._thread = thread
+
+    def readCoreRegistersRaw(self, reg_list):
+        reg_list = [self.registerNameToIndex(reg) for reg in reg_list]
+        reg_vals = []
+
+        inException = self._get_ipsr() > 0
+        isCurrent = self._thread.is_current
+
+        # If this is the current thread and we're not in an exception, just read the live registers.
+        if isCurrent and not inException:
+            return self._parent.readCoreRegistersRaw(reg_list)
+
+        sp = self._thread.get_stack_pointer()
+
+        # Determine which register offset table to use and the offsets past the saved state.
+        realSpOffset = 0x40
+        realSpExceptionOffset = 0x20
+        table = self.CORE_REGISTER_OFFSETS
+        if self._thread.has_extended_frame:
+            table = self.FPU_EXTENDED_REGISTER_OFFSETS
+            realSpOffset = 0xc8
+            realSpExceptionOffset = 0x68
+
+        for reg in reg_list:
+            # Check for regs we can't access.
+            if isCurrent and inException:
+                if reg in self.EXCEPTION_UNAVAILABLE_REGS:
+                    reg_vals.append(0)
+                    continue
+                if reg == 18 or reg == 13: # PSP
+                    log.debug("psp = 0x%08x", sp + realSpExceptionOffset)
+                    reg_vals.append(sp + realSpExceptionOffset)
+                    continue
+
+            # Must handle stack pointer specially.
+            if reg == 13:
+                reg_vals.append(sp + realSpOffset)
+                continue
+
+            # Look up offset for this register on the stack.
+            spOffset = table.get(reg, None)
+            if spOffset is None:
+                reg_vals.append(self._parent.readCoreRegisterRaw(reg))
+                continue
+            if isCurrent and inException:
+                spOffset -= realSpExceptionOffset #0x20
+
+            try:
+                reg_vals.append(self._parent.read32(sp + spOffset))
+            except DAPAccess.TransferError:
+                reg_vals.append(0)
+
+        return reg_vals
+
+    def _get_ipsr(self):
+        return self._parent.readCoreRegister('xpsr') & 0xff
+
+    def writeCoreRegistersRaw(self, reg_list, data_list):
+        self._parent.writeCoreRegistersRaw(reg_list, data_list)
+
+## @brief Base class representing a thread on the target.
+class ArgonThread(TargetThread):
+    UNKNOWN = 0
+    SUSPENDED = 1
+    READY = 2
+    RUNNING = 3
+    BLOCKED = 4
+    SLEEPING = 5
+    DONE = 6
+
+    STATE_NAMES = {
+            UNKNOWN : "Unknown",
+            SUSPENDED : "Suspended",
+            READY : "Ready",
+            RUNNING : "Running",
+            BLOCKED : "Blocked",
+            SLEEPING : "Sleeping",
+            DONE : "Done",
+        }
+
+    def __init__(self, targetContext, provider, base):
+        super(ArgonThread, self).__init__()
+        self._target_context = targetContext
+        self._provider = provider
+        self._base = base
+        self._thread_context = ArgonThreadContext(self._target_context, self)
+        self._has_fpu = self._thread_context.core.has_fpu
+        self._priority = 0
+        self._state = self.UNKNOWN
+        self._name = "?"
+
+        try:
+            self.update_info()
+
+            ptr = self._target_context.read32(self._base + THREAD_NAME_OFFSET)
+            self._name = read_c_string(self._target_context, ptr)
+        except DAPAccess.TransferError:
+            log.debug("Transfer error while reading thread info")
+
+    def get_stack_pointer(self):
+        sp = 0
+        if self.is_current:
+            # Read live process stack.
+            sp = self._target_context.readCoreRegister('psp')
+        else:
+            # Get stack pointer saved in thread struct.
+            try:
+                sp = self._target_context.read32(self._base + THREAD_STACK_POINTER_OFFSET)
+            except DAPAccess.TransferError:
+                log.debug("Transfer error while reading thread's stack pointer @ 0x%08x", self._base + THREAD_STACK_POINTER_OFFSET)
+        return sp
+
+    def update_info(self):
+        try:
+            self._priority = self._target_context.read8(self._base + THREAD_PRIORITY_OFFSET)
+
+            self._state = self._target_context.read8(self._base + THREAD_STATE_OFFSET)
+            if self._state > self.DONE:
+                self._state = self.UNKNOWN
+        except DAPAccess.TransferError:
+            log.debug("Transfer error while reading thread info")
+
+    @property
+    def state(self):
+        return self._state
+
+    @property
+    def priority(self):
+        return self._priority
+
+    @property
+    def unique_id(self):
+        return self._base
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def description(self):
+        return "%s; Priority %d" % (self.STATE_NAMES[self.state], self.priority)
+
+    @property
+    def is_current(self):
+        return self._provider.get_actual_current_thread_id() == self.unique_id
+
+    @property
+    def context(self):
+        return self._thread_context
+
+    @property
+    def has_extended_frame(self):
+        if not self._has_fpu:
+            return False
+        try:
+            flag = self._target_context.read8(self._base + THREAD_EXTENDED_FRAME_OFFSET)
+            return flag != 0
+        except DAPAccess.TransferError:
+            log.debug("Transfer error while reading thread's extended frame flag @ 0x%08x", self._base + THREAD_EXTENDED_FRAME_OFFSET)
+            return False
+
+    def __str__(self):
+        return "<ArgonThread@0x%08x id=%x name=%s>" % (id(self), self.unique_id, self.name)
+
+    def __repr__(self):
+        return str(self)
+
+## @brief Base class for RTOS support plugins.
+class ArgonThreadProvider(ThreadProvider):
+    def __init__(self, target):
+        super(ArgonThreadProvider, self).__init__(target)
+        self._target_context = self._target.getTargetContext()
+        self.g_ar = None
+        self.g_ar_objects = None
+        self._all_threads = None
+        self._threads = {}
+
+    def init(self, symbolProvider):
+        self.g_ar = symbolProvider.get_symbol_value("g_ar")
+        if self.g_ar is None:
+            return False
+        log.debug("Argon: g_ar = 0x%08x", self.g_ar)
+
+        self.g_ar_objects = symbolProvider.get_symbol_value("g_ar_objects")
+        if self.g_ar_objects is None:
+            return False
+        log.debug("Argon: g_ar_objects = 0x%08x", self.g_ar_objects)
+
+        self._all_threads = self.g_ar_objects + ALL_OBJECTS_THREADS_OFFSET
+
+        return True
+
+    def _build_thread_list(self):
+        allThreads = TargetList(self._target_context, self._all_threads)
+        newThreads = {}
+        for threadBase in allThreads:
+            try:
+                # Reuse existing thread objects if possible.
+                if threadBase in self._threads:
+                    t = self._threads[threadBase]
+
+                    # Ask the thread object to update its state and priority.
+                    t.update_info()
+                else:
+                    t = ArgonThread(self._target_context, self, threadBase)
+                log.debug("Thread 0x%08x (%s)", threadBase, t.name)
+                newThreads[t.unique_id] = t
+            except DAPAccess.TransferError:
+                log.debug("TransferError while examining thread 0x%08x", threadBase)
+
+        # Create fake handler mode thread.
+        if self.get_ipsr() > 0:
+            log.debug("creating handler mode thread")
+            t = HandlerModeThread(self._target_context, self)
+            newThreads[t.unique_id] = t
+
+        self._threads = newThreads
+
+    def get_threads(self):
+        if not self.is_enabled:
+            return []
+        self.update_threads()
+        return self._threads.values()
+
+    def get_thread(self, threadId):
+        if not self.is_enabled:
+            return None
+        self.update_threads()
+        return self._threads.get(threadId, None)
+
+    @property
+    def is_enabled(self):
+        return self.g_ar is not None and self.get_is_running()
+
+    @property
+    def current_thread(self):
+        if not self.is_enabled:
+            return None
+        self.update_threads()
+        id = self.get_current_thread_id()
+        try:
+            return self._threads[id]
+        except KeyError:
+            log.debug("key error getting current thread id=%x", id)
+            log.debug("self._threads = %s", repr(self._threads))
+            return None
+
+    def is_valid_thread_id(self, threadId):
+        if not self.is_enabled:
+            return False
+        self.update_threads()
+        return threadId in self._threads
+
+    def get_current_thread_id(self):
+        if not self.is_enabled:
+            return None
+        if self.get_ipsr() > 0:
+            return 2
+        return self.get_actual_current_thread_id()
+
+    def get_actual_current_thread_id(self):
+        if not self.is_enabled:
+            return None
+        return self._target_context.read32(self.g_ar)
+
+    def get_ipsr(self):
+        return self._target_context.readCoreRegister('xpsr') & 0xff
+
+    def get_is_running(self):
+        if self.g_ar is None:
+            return False
+        flag = self._target_context.read8(self.g_ar + IS_RUNNING_OFFSET)
+        return flag != 0
+
+

--- a/pyOCD/rtos/argon.py
+++ b/pyOCD/rtos/argon.py
@@ -321,7 +321,6 @@ class ArgonThread(TargetThread):
 class ArgonThreadProvider(ThreadProvider):
     def __init__(self, target):
         super(ArgonThreadProvider, self).__init__(target)
-        self._target_context = self._target.getTargetContext()
         self.g_ar = None
         self.g_ar_objects = None
         self._all_threads = None
@@ -414,9 +413,6 @@ class ArgonThreadProvider(ThreadProvider):
         if not self.is_enabled:
             return None
         return self._target_context.read32(self.g_ar)
-
-    def get_ipsr(self):
-        return self._target_context.readCoreRegister('xpsr') & 0xff
 
     def get_is_running(self):
         if self.g_ar is None:

--- a/pyOCD/rtos/common.py
+++ b/pyOCD/rtos/common.py
@@ -1,0 +1,204 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2016 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from .provider import (TargetThread, ThreadProvider)
+from ..debug.context import DebugContext
+from ..coresight.cortex_m import CORE_REGISTER
+from pyOCD.pyDAPAccess import DAPAccess
+import logging
+
+LIST_NODE_NEXT_OFFSET = 0
+LIST_NODE_OBJ_OFFSET= 8
+
+## @brief Reads a null-terminated C string from the target.
+def read_c_string(context, ptr):
+    if ptr == 0:
+        return ""
+
+    s = ""
+    done = False
+    count = 0
+    badCount = 0
+    try:
+        while not done and count < 256:
+            data = context.readBlockMemoryUnaligned8(ptr, 16)
+            ptr += 16
+            count += 16
+
+            for c in data:
+                if c == 0:
+                    done = True
+                    break
+                elif c > 127:
+                    # Replace non-ASCII characters. If there is a run of invalid characters longer
+                    # than 4, then terminate the string early.
+                    badCount += 1
+                    if badCount > 4:
+                        done = True
+                        break
+                    s += '?'
+                else:
+                    s += chr(c)
+                    badCount = 0
+    except DAPAccess.TransferError:
+        logging.debug("TransferError while trying to read 16 bytes at 0x%08x", ptr)
+
+    return s
+
+## @brief Standard Cortex-M register stacking context.
+class CommonThreadContext(DebugContext):
+    # SP is handled specially, so it is not in this dict.
+    CORE_REGISTER_OFFSETS = {
+                 0: 32, # r0
+                 1: 36, # r1
+                 2: 40, # r2
+                 3: 44, # r3
+                 4: 0, # r4
+                 5: 4, # r5
+                 6: 8, # r6
+                 7: 12, # r7
+                 8: 16, # r8
+                 9: 20, # r9
+                 10: 24, # r10
+                 11: 28, # r11
+                 12: 48, # r12
+                 14: 52, # lr
+                 15: 56, # pc
+                 16: 60, # xpsr
+            }
+
+    def __init__(self, parentContext, thread):
+        super(CommonThreadContext, self).__init__(parentContext.core)
+        self._parent = parentContext
+        self._thread = thread
+
+    def readCoreRegistersRaw(self, reg_list):
+        reg_list = [self.registerNameToIndex(reg) for reg in reg_list]
+        reg_vals = []
+
+        inException = self._get_ipsr() > 0
+        isCurrent = self._is_current()
+
+        sp = self._get_stack_pointer()
+        saveSp = sp
+        if not isCurrent:
+            sp -= 0x40
+        elif inException:
+            sp -= 0x20
+
+        for reg in reg_list:
+            if isCurrent:
+                if not inException:
+                    # Not in an exception, so just read the live register.
+                    reg_vals.append(self._core.readCoreRegisterRaw(reg))
+                    continue
+                else:
+                    # Check for regs we can't access.
+                    if reg in (4, 5, 6, 7, 8, 9, 10, 11):
+                        reg_vals.append(0)
+                        continue
+
+            # Must handle stack pointer specially.
+            if reg == 13:
+                reg_vals.append(saveSp)
+                continue
+
+            spOffset = self.CORE_REGISTER_OFFSETS.get(reg, None)
+            if spOffset is None:
+                reg_vals.append(self._core.readCoreRegisterRaw(reg))
+                continue
+            if isCurrent and inException:
+                spOffset -= 0x20
+
+            try:
+                reg_vals.append(self._core.read32(sp + spOffset))
+            except DAPAccess.TransferError:
+                reg_vals.append(0)
+
+        return reg_vals
+
+    def _get_stack_pointer(self):
+        sp = 0
+        if self._is_current():
+            # Read live process stack.
+            sp = self._core.readCoreRegister('sp')
+
+            # In IRQ context, we have to adjust for hw saved state.
+            if self._get_ipsr() > 0:
+                sp += 0x20
+        else:
+            # Get stack pointer saved in thread struct.
+            sp = self._core.read32(self._thread._base + THREAD_STACK_POINTER_OFFSET)
+
+            # Skip saved thread state.
+            sp += 0x40
+        return sp
+
+    def _get_ipsr(self):
+        return self._core.readCoreRegister('xpsr') & 0xff
+
+    def _has_extended_frame(self):
+        return False
+
+    def _is_current(self):
+        return self._thread.is_current
+
+    def writeCoreRegistersRaw(self, reg_list, data_list):
+        self._core.writeCoreRegistersRaw(reg_list, data_list)
+
+## @brief Class representing the handler mode.
+class HandlerModeThread(TargetThread):
+    def __init__(self, targetContext, provider):
+        super(HandlerModeThread, self).__init__()
+        self._target_context = targetContext
+        self._provider = provider
+
+    def get_stack_pointer(self):
+        return self._target_context.readCoreRegister('msp')
+
+    @property
+    def priority(self):
+        return 0
+
+    @property
+    def unique_id(self):
+        return 2
+
+    @property
+    def name(self):
+        return "Handler mode"
+
+    @property
+    def description(self):
+        return ""
+
+    @property
+    def is_current(self):
+        return self._provider.get_ipsr() > 0
+
+    @property
+    def context(self):
+        return self._target_context
+
+    def __str__(self):
+        return "<HandlerModeThread@0x%08x>" % (id(self))
+
+    def __repr__(self):
+        return str(self)
+
+
+

--- a/pyOCD/rtos/freertos.py
+++ b/pyOCD/rtos/freertos.py
@@ -1,0 +1,503 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2016 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from .provider import (TargetThread, ThreadProvider)
+from .common import (read_c_string, HandlerModeThread)
+from ..debug.context import DebugContext
+from ..coresight.cortex_m import CORE_REGISTER
+from pyOCD.pyDAPAccess import DAPAccess
+import logging
+
+FREERTOS_MAX_PRIORITIES	= 63
+
+LIST_SIZE = 20
+LIST_INDEX_OFFSET = 16
+LIST_NODE_NEXT_OFFSET = 8 # 4?
+LIST_NODE_OBJECT_OFFSET = 12
+
+THREAD_STACK_POINTER_OFFSET = 0
+THREAD_PRIORITY_OFFSET = 44
+THREAD_NAME_OFFSET = 52
+
+# Create a logger for this module.
+log = logging.getLogger("freertos")
+
+class TargetList(object):
+    def __init__(self, context, ptr):
+        self._context = context
+        self._list = ptr
+
+    def __iter__(self):
+        prev = -1
+        found = 0
+        count = self._context.read32(self._list)
+        if count == 0:
+            return
+
+        node = self._context.read32(self._list + LIST_INDEX_OFFSET)
+
+        while (node != 0) and (node != prev) and (found < count):
+            try:
+                # Read the object from the node.
+                obj = self._context.read32(node + LIST_NODE_OBJECT_OFFSET)
+                yield obj
+                found += 1
+
+                # Read next list node pointer.
+                prev = node
+                node = self._context.read32(node + LIST_NODE_NEXT_OFFSET)
+            except DAPAccess.TransferError:
+                log.warning("TransferError while reading list elements (list=0x%08x, node=0x%08x), terminating list", self._list, node)
+                node = 0
+
+## @brief
+class FreeRTOSThreadContext(DebugContext):
+    # SP/PSP are handled specially, so it is not in these dicts.
+
+    COMMON_REGISTER_OFFSETS = {
+                 4: 0, # r4
+                 5: 4, # r5
+                 6: 8, # r6
+                 7: 12, # r7
+                 8: 16, # r8
+                 9: 20, # r9
+                 10: 24, # r10
+                 11: 28, # r11
+            }
+
+    NOFPU_REGISTER_OFFSETS = {
+                 0: 32, # r0
+                 1: 36, # r1
+                 2: 40, # r2
+                 3: 44, # r3
+                 12: 48, # r12
+                 14: 52, # lr
+                 15: 56, # pc
+                 16: 60, # xpsr
+            }
+    NOFPU_REGISTER_OFFSETS.update(COMMON_REGISTER_OFFSETS)
+
+    FPU_BASIC_REGISTER_OFFSETS = {
+                -1: 32, # exception LR
+                 0: 36, # r0
+                 1: 40, # r1
+                 2: 44, # r2
+                 3: 48, # r3
+                 12: 42, # r12
+                 14: 56, # lr
+                 15: 60, # pc
+                 16: 64, # xpsr
+            }
+    FPU_BASIC_REGISTER_OFFSETS.update(COMMON_REGISTER_OFFSETS)
+
+    FPU_EXTENDED_REGISTER_OFFSETS = {
+                -1: 32, # exception LR
+                 0x50: 36, # s16
+                 0x51: 40, # s17
+                 0x52: 44, # s18
+                 0x53: 48, # s19
+                 0x54: 52, # s20
+                 0x55: 56, # s21
+                 0x56: 60, # s22
+                 0x57: 64, # s23
+                 0x58: 68, # s24
+                 0x59: 72, # s25
+                 0x5a: 76, # s26
+                 0x5b: 80, # s27
+                 0x5c: 84, # s28
+                 0x5d: 88, # s29
+                 0x5e: 92, # s30
+                 0x5f: 96, # s31
+                 0: 100, # r0
+                 1: 104, # r1
+                 2: 108, # r2
+                 3: 112, # r3
+                 12: 116, # r12
+                 14: 120, # lr
+                 15: 124, # pc
+                 16: 128, # xpsr
+                 0x40: 132, # s0
+                 0x41: 136, # s1
+                 0x42: 140, # s2
+                 0x43: 144, # s3
+                 0x44: 148, # s4
+                 0x45: 152, # s5
+                 0x46: 156, # s6
+                 0x47: 160, # s7
+                 0x48: 164, # s8
+                 0x49: 168, # s9
+                 0x4a: 172, # s10
+                 0x4b: 176, # s11
+                 0x4c: 180, # s12
+                 0x4d: 184, # s13
+                 0x4e: 188, # s14
+                 0x4f: 192, # s15
+                 33: 196, # fpscr
+                 # (reserved word: 200)
+            }
+    FPU_EXTENDED_REGISTER_OFFSETS.update(COMMON_REGISTER_OFFSETS)
+
+    # Registers that are not available on the stack for exceptions.
+    EXCEPTION_UNAVAILABLE_REGS = (4, 5, 6, 7, 8, 9, 10, 11)
+
+    def __init__(self, parentContext, thread):
+        super(FreeRTOSThreadContext, self).__init__(parentContext.core)
+        self._parent = parentContext
+        self._thread = thread
+        self._has_fpu = parentContext.core.has_fpu
+
+    def readCoreRegistersRaw(self, reg_list):
+        reg_list = [self.registerNameToIndex(reg) for reg in reg_list]
+        reg_vals = []
+
+        inException = self._get_ipsr() > 0
+        isCurrent = self._thread.is_current
+
+        # If this is the current thread and we're not in an exception, just read the live registers.
+        if isCurrent and not inException:
+            return self._parent.readCoreRegistersRaw(reg_list)
+
+        sp = self._thread.get_stack_pointer()
+
+        # Determine which register offset table to use and the offsets past the saved state.
+        realSpOffset = 0x40
+        realSpExceptionOffset = 0x20
+        table = self.NOFPU_REGISTER_OFFSETS
+        if self._has_fpu:
+            try:
+                # Read stacked exception return LR.
+                offset = self.FPU_BASIC_REGISTER_OFFSETS[-1]
+                exceptionLR = self._parent.read32(sp + offset)
+
+                # Check bit 4 of the saved exception LR to determine if FPU registers were stacked.
+                if (exceptionLR & (1 << 4)) != 0:
+                    table = self.FPU_BASIC_REGISTER_OFFSETS
+                    realSpOffset = 0x44
+                else:
+                    table = self.FPU_EXTENDED_REGISTER_OFFSETS
+                    realSpOffset = 0xcc
+                    realSpExceptionOffset = 0x6c
+            except DAPAccess.TransferError:
+                log.debug("Transfer error while reading thread's saved LR")
+
+        for reg in reg_list:
+            # Check for regs we can't access.
+            if isCurrent and inException:
+                if reg in self.EXCEPTION_UNAVAILABLE_REGS:
+                    reg_vals.append(0)
+                    continue
+                if reg == 18 or reg == 13: # PSP
+                    reg_vals.append(sp + realSpExceptionOffset)
+                    continue
+
+            # Must handle stack pointer specially.
+            if reg == 13:
+                reg_vals.append(sp + realSpOffset)
+                continue
+
+            # Look up offset for this register on the stack.
+            spOffset = table.get(reg, None)
+            if spOffset is None:
+                reg_vals.append(self._parent.readCoreRegisterRaw(reg))
+                continue
+            if isCurrent and inException:
+                spOffset -= realSpExceptionOffset #0x20
+
+            try:
+                reg_vals.append(self._parent.read32(sp + spOffset))
+            except DAPAccess.TransferError:
+                reg_vals.append(0)
+
+        return reg_vals
+
+    def _get_ipsr(self):
+        return self._parent.readCoreRegister('xpsr') & 0xff
+
+    def writeCoreRegistersRaw(self, reg_list, data_list):
+        self._parent.writeCoreRegistersRaw(reg_list, data_list)
+
+## @brief A FreeRTOS task.
+class FreeRTOSThread(TargetThread):
+    RUNNING = 1
+    READY = 2
+    BLOCKED = 3
+    SUSPENDED = 4
+    DELETED = 5
+
+    STATE_NAMES = {
+            RUNNING : "Running",
+            READY : "Ready",
+            BLOCKED : "Blocked",
+            SUSPENDED : "Suspended",
+            DELETED : "Deleted",
+        }
+
+    def __init__(self, targetContext, provider, base):
+        super(FreeRTOSThread, self).__init__()
+        self._target_context = targetContext
+        self._provider = provider
+        self._base = base
+        self._state = FreeRTOSThread.READY
+        self._thread_context = FreeRTOSThreadContext(self._target_context, self)
+
+        self._priority = self._target_context.read32(self._base + THREAD_PRIORITY_OFFSET)
+
+        self._name = read_c_string(self._target_context, self._base + THREAD_NAME_OFFSET)
+        if len(self._name) == 0:
+            self._name = "Unnamed"
+
+    def get_stack_pointer(self):
+        if self.is_current:
+            # Read live process stack.
+            sp = self._target_context.readCoreRegister('psp')
+        else:
+            # Get stack pointer saved in thread struct.
+            try:
+                sp = self._target_context.read32(self._base + THREAD_STACK_POINTER_OFFSET)
+            except DAPAccess.TransferError:
+                log.debug("Transfer error while reading thread's stack pointer @ 0x%08x", self._base + THREAD_STACK_POINTER_OFFSET)
+        return sp
+
+    @property
+    def state(self):
+        return self._state
+
+    @state.setter
+    def state(self, value):
+        self._state = value
+
+    @property
+    def priority(self):
+        return self._priority
+
+    @property
+    def unique_id(self):
+        return self._base
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def description(self):
+        return "%s; Priority %d" % (self.STATE_NAMES[self.state], self.priority)
+
+    @property
+    def is_current(self):
+        return self._provider.get_actual_current_thread_id() == self.unique_id
+
+    @property
+    def context(self):
+        return self._thread_context
+
+    def __str__(self):
+        return "<FreeRTOSThread@0x%08x id=%x name=%s>" % (id(self), self.unique_id, self.name)
+
+    def __repr__(self):
+        return str(self)
+
+## @brief Thread provider for FreeRTOS.
+class FreeRTOSThreadProvider(ThreadProvider):
+
+    ## Required FreeRTOS symbols.
+    FREERTOS_SYMBOLS = [
+        "uxCurrentNumberOfTasks",
+        "pxCurrentTCB",
+        "pxReadyTasksLists",
+        "xDelayedTaskList1",
+        "xDelayedTaskList2",
+        "xPendingReadyList",
+        "uxTopReadyPriority",
+        "xSchedulerRunning",
+        ]
+
+    def __init__(self, target):
+        super(FreeRTOSThreadProvider, self).__init__(target)
+        self._target_context = self._target.getTargetContext()
+        self._symbols = None
+        self._total_priorities = 0
+        self._threads = {}
+
+    def init(self, symbolProvider):
+        # Lookup required symbols.
+        self._symbols = self._lookup_symbols(self.FREERTOS_SYMBOLS, symbolProvider)
+        if self._symbols is None:
+            return False
+
+        # Look up optional xSuspendedTaskList, controlled by INCLUDE_vTaskSuspend
+        suspendedTaskListSym = self._lookup_symbols(["xSuspendedTaskList"], symbolProvider)
+        if suspendedTaskListSym is not None:
+            self._symbols['xSuspendedTaskList'] = suspendedTaskListSym['xSuspendedTaskList']
+
+        # Look up optional xTasksWaitingTermination, controlled by INCLUDE_vTaskDelete
+        tasksWaitingTerminationSym = self._lookup_symbols(["xTasksWaitingTermination"], symbolProvider)
+        if tasksWaitingTerminationSym is not None:
+            self._symbols['xTasksWaitingTermination'] = tasksWaitingTerminationSym['xTasksWaitingTermination']
+
+        # Look up vPortEnableVFP() to determine if the FreeRTOS port supports the FPU.
+        vPortEnableVFP = self._lookup_symbols(["vPortEnableVFP"], symbolProvider)
+        self._fpu_port = vPortEnableVFP is not None
+
+        # Check for the expected list size. These two symbols are each a single list and xDelayedTaskList2
+        # immediately follows xDelayedTaskList1, so we can just subtract their addresses to get the
+        # size of a single list.
+        delta = self._symbols['xDelayedTaskList2'] - self._symbols['xDelayedTaskList1']
+        if delta != LIST_SIZE:
+            log.warning("FreeRTOS: list size is unexpected, maybe an unsupported configuration of FreeRTOS")
+            return False
+
+        # xDelayedTaskList1 immediately follows pxReadyTasksLists, so subtracting their addresses gives
+        # us the total size of the pxReadyTaskLists array.
+        delta = self._symbols['xDelayedTaskList1'] - self._symbols['pxReadyTasksLists']
+        if delta % LIST_SIZE:
+            log.warning("FreeRTOS: pxReadyTasksLists size is unexpected, maybe an unsupported version of FreeRTOS")
+            return False
+        self._total_priorities = delta // LIST_SIZE
+        if self._total_priorities > FREERTOS_MAX_PRIORITIES:
+            log.warning("FreeRTOS: number of priorities is too large (%d)", self._total_priorities)
+            return False
+        log.debug("FreeRTOS: number of priorities is %d", self._total_priorities)
+
+        return True
+
+    def _build_thread_list(self):
+        newThreads = {}
+
+        # Read the number of threads.
+        threadCount = self._target_context.read32(self._symbols['uxCurrentNumberOfTasks'])
+
+        # Read the current thread.
+        currentThread = self._target_context.read32(self._symbols['pxCurrentTCB'])
+
+        # We should only be building the thread list if the scheduler is running, so a zero thread
+        # count or a null current thread means something is bizarrely wrong.
+        if threadCount == 0 or currentThread == 0:
+            log.warning("FreeRTOS: no threads even though the scheduler is running")
+            return
+
+        # Read the top ready priority.
+        topPriority = self._target_context.read32(self._symbols['uxTopReadyPriority'])
+
+        # Handle an uxTopReadyPriority value larger than the number of lists. This is most likely
+        # caused by the configUSE_PORT_OPTIMISED_TASK_SELECTION option being enabled, which treats
+        # uxTopReadyPriority as a bitmap instead of integer. This is ok because uxTopReadyPriority
+        # in optimised mode will always be >= the actual top priority.
+        if topPriority > self._total_priorities:
+            topPriority = self._total_priorities
+
+        # Build up list of all the thread lists we need to scan.
+        listsToRead = []
+        for i in range(topPriority + 1):
+            listsToRead.append((self._symbols['pxReadyTasksLists'] + i * LIST_SIZE, FreeRTOSThread.READY))
+
+        listsToRead.append((self._symbols['xDelayedTaskList1'], FreeRTOSThread.BLOCKED))
+        listsToRead.append((self._symbols['xDelayedTaskList2'], FreeRTOSThread.BLOCKED))
+        listsToRead.append((self._symbols['xPendingReadyList'], FreeRTOSThread.READY))
+        if self._symbols.has_key('xSuspendedTaskList'):
+            listsToRead.append((self._symbols['xSuspendedTaskList'], FreeRTOSThread.SUSPENDED))
+        if self._symbols.has_key('xTasksWaitingTermination'):
+            listsToRead.append((self._symbols['xTasksWaitingTermination'], FreeRTOSThread.DELETED))
+
+        for listPtr, state in listsToRead:
+            for threadBase in TargetList(self._target_context, listPtr):
+                try:
+                    # Don't try adding more threads than the number of threads that FreeRTOS says there are.
+                    if len(newThreads) >= threadCount:
+                        break
+
+                    # Reuse existing thread objects.
+                    if threadBase in self._threads:
+                        t = self._threads[threadBase]
+                    else:
+                        t = FreeRTOSThread(self._target_context, self, threadBase)
+
+                    # Set thread state.
+                    if threadBase == currentThread:
+                        t.state = FreeRTOSThread.RUNNING
+                    else:
+                        t.state = state
+
+                    log.debug("Thread 0x%08x (%s)", threadBase, t.name)
+                    newThreads[t.unique_id] = t
+                except DAPAccess.TransferError:
+                    log.debug("TransferError while examining thread 0x%08x", threadBase)
+
+        if len(newThreads) != threadCount:
+            log.warning("FreeRTOS: thread count mismatch")
+
+        # Create fake handler mode thread.
+        if self.get_ipsr() > 0:
+            log.debug("FreeRTOS: creating handler mode thread")
+            t = HandlerModeThread(self._target_context, self)
+            newThreads[t.unique_id] = t
+
+        self._threads = newThreads
+
+    def get_threads(self):
+        if not self.is_enabled:
+            return []
+        self.update_threads()
+        return self._threads.values()
+
+    def get_thread(self, threadId):
+        if not self.is_enabled:
+            return None
+        self.update_threads()
+        return self._threads.get(threadId, None)
+
+    @property
+    def is_enabled(self):
+        return self._symbols is not None and self.get_is_running()
+
+    @property
+    def current_thread(self):
+        if not self.is_enabled:
+            return None
+        self.update_threads()
+        id = self.get_current_thread_id()
+        try:
+            return self._threads[id]
+        except KeyError:
+            return None
+
+    def is_valid_thread_id(self, threadId):
+        if not self.is_enabled:
+            return False
+        self.update_threads()
+        return threadId in self._threads
+
+    def get_current_thread_id(self):
+        if not self.is_enabled:
+            return None
+        if self.get_ipsr() > 0:
+            return 2
+        return self.get_actual_current_thread_id()
+
+    def get_actual_current_thread_id(self):
+        if not self.is_enabled:
+            return None
+        return self._target_context.read32(self._symbols['pxCurrentTCB'])
+
+    def get_ipsr(self):
+        return self._target_context.readCoreRegister('xpsr') & 0xff
+
+    def get_is_running(self):
+        if self._symbols is None:
+            return False
+        return self._target_context.read32(self._symbols['xSchedulerRunning']) != 0
+
+

--- a/pyOCD/rtos/freertos.py
+++ b/pyOCD/rtos/freertos.py
@@ -327,7 +327,6 @@ class FreeRTOSThreadProvider(ThreadProvider):
 
     def __init__(self, target):
         super(FreeRTOSThreadProvider, self).__init__(target)
-        self._target_context = self._target.getTargetContext()
         self._symbols = None
         self._total_priorities = 0
         self._threads = {}
@@ -491,9 +490,6 @@ class FreeRTOSThreadProvider(ThreadProvider):
         if not self.is_enabled:
             return None
         return self._target_context.read32(self._symbols['pxCurrentTCB'])
-
-    def get_ipsr(self):
-        return self._target_context.readCoreRegister('xpsr') & 0xff
 
     def get_is_running(self):
         if self._symbols is None:

--- a/pyOCD/rtos/provider.py
+++ b/pyOCD/rtos/provider.py
@@ -1,0 +1,98 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2016 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import logging
+
+## @brief Base class representing a thread on the target.
+class TargetThread(object):
+    def __init__(self):
+        pass
+
+    @property
+    def unique_id(self):
+        raise NotImplementedError()
+
+    @property
+    def name(self):
+        raise NotImplementedError()
+
+    @property
+    def description(self):
+        raise NotImplementedError()
+
+    @property
+    def is_current(self):
+        raise NotImplementedError()
+
+    @property
+    def context(self):
+        raise NotImplementedError()
+
+## @brief Base class for RTOS support plugins.
+class ThreadProvider(object):
+    def __init__(self, target):
+        self._target = target
+        self._last_run_token = -1
+
+    def _lookup_symbols(self, symbolList, symbolProvider):
+        syms = {}
+        for name in symbolList:
+            addr = symbolProvider.get_symbol_value(name)
+            logging.debug("Value for symbol %s = %s", name, hex(addr) if addr is not None else "<none>")
+            if addr is None:
+                return None
+            syms[name] = addr
+        return syms
+
+    ##
+    # @retval True The provider was successfully initialzed.
+    # @retval False The provider could not be initialized successfully.
+    def init(self, symbolProvider):
+        raise NotImplementedError()
+
+    def _build_thread_list(self):
+        raise NotImplementedError()
+
+    def _is_thread_list_dirty(self):
+        token = self._target.run_token
+        if token == self._last_run_token:
+            # Target hasn't run since we last updated threads, so there is nothing to do.
+            return False
+        self._last_run_token = token
+        return True
+
+    def update_threads(self):
+        if self._is_thread_list_dirty():
+            self._build_thread_list()
+
+    def get_threads(self):
+        raise NotImplementedError()
+
+    def get_thread(self, threadId):
+        raise NotImplementedError()
+
+    @property
+    def is_enabled(self):
+        raise NotImplementedError()
+
+    @property
+    def current_thread(self):
+        raise NotImplementedError()
+
+    def is_valid_thread_id(self, threadId):
+        raise NotImplementedError()
+

--- a/pyOCD/rtos/provider.py
+++ b/pyOCD/rtos/provider.py
@@ -46,6 +46,7 @@ class TargetThread(object):
 class ThreadProvider(object):
     def __init__(self, target):
         self._target = target
+        self._target_context = self._target.getTargetContext()
         self._last_run_token = -1
 
     def _lookup_symbols(self, symbolList, symbolProvider):
@@ -94,5 +95,11 @@ class ThreadProvider(object):
         raise NotImplementedError()
 
     def is_valid_thread_id(self, threadId):
+        raise NotImplementedError()
+
+    def get_ipsr(self):
+        return self._target_context.readCoreRegister('xpsr') & 0xff
+
+    def get_current_thread_id(self):
         raise NotImplementedError()
 

--- a/pyOCD/utility/conversion.py
+++ b/pyOCD/utility/conversion.py
@@ -84,6 +84,11 @@ def hex8leToU32be(data):
     return int(data[6:8] + data[4:6] + data[2:4] + data[0:2], 16)
 
 
+def hex8leToU32le(data):
+    """Build 32-bit register value from little-endian 8-digit hexadecimal string"""
+    return int(data[0:2] + data[2:4] + data[4:6] + data[6:8], 16)
+
+
 def byteToHex2(val):
     """Create 2-digit hexadecimal string from 8-bit value"""
     return "%02x" % int(val)


### PR DESCRIPTION
This PR adds support for RTOS modules that provide thread information to GDB. Two RTOSes are currently supported: FreeRTOS, and my own Argon. As part of this change set, some refactoring was done.

There is a new `DebugContext` class that has methods for reading/writing memory and registers. `DebugContext` objects can be stacked, allowing filtering of these accesses. The RTOS module creates `DebugContext` instances for each thread. This is then used to redirect register accesses to the thread's saved state (or live registers if the thread is the current one).

`GdbServer` now uses a façade class named  `GDBDebugContextFacade` that wraps `DebugContext` to provide its gdb-specific data. With this change, the gdb-specific methods were removed from `CortexM` and `Target`.

RTOS modules implement a subclass of `ThreadProvider`. There is a table of RTOS modules similar to the targets list in `./targets/__init__.py`. RTOSes are automatically discovered.
