### PR TITLE
Remove rom table initialization

### DIFF
--- a/pyOCD/coresight/ap.py
+++ b/pyOCD/coresight/ap.py
@@ -84,7 +84,8 @@ class AccessPort(object):
 
             self.inited_primary = True
         if not self.inited_secondary and self.has_rom_table and bus_accessible:
-            self.init_rom_table()
+            #Initializing and reading rom table decrease the performance. Connecting to board takes 4 times longer.
+            #self.init_rom_table()
             self.inited_secondary = True
 
     def init_rom_table(self):


### PR DESCRIPTION
Currently ROM table is not being used. I commented it because it increase the time of the connection by 4 times.

@c1728p9 @flit @matthewelse