### PR TITLE
Improve ROM table reading performance

### DIFF
--- a/pyOCD/board/board.py
+++ b/pyOCD/board/board.py
@@ -47,6 +47,7 @@ class Board(object):
         """
         logging.debug("init board %s", self)
         self.link.set_clock(self.debug_clock_frequency)
+        self.link.set_deferred_transfer(True)
         self.target.init()
 
     def uninit(self, resume=True):

--- a/pyOCD/board/mbed_board.py
+++ b/pyOCD/board/mbed_board.py
@@ -83,7 +83,6 @@ class MbedBoard(Board):
         """
         self.native_target = None
         self.test_binary = None
-        link.set_deferred_transfer(True)
         unique_id = link.get_unique_id()
         board_id = unique_id[0:4]
         self.name = "Unknown Board"

--- a/pyOCD/board/mbed_board.py
+++ b/pyOCD/board/mbed_board.py
@@ -83,6 +83,7 @@ class MbedBoard(Board):
         """
         self.native_target = None
         self.test_binary = None
+        link.set_deferred_transfer(True)
         unique_id = link.get_unique_id()
         board_id = unique_id[0:4]
         self.name = "Unknown Board"

--- a/pyOCD/coresight/ap.py
+++ b/pyOCD/coresight/ap.py
@@ -337,8 +337,10 @@ class MEM_AP(AccessPort):
 
 class AHB_AP(MEM_AP):
     def init(self, bus_accessible=True):
-        super(AHB_AP, self).init(bus_accessible)
+        # Init super first with bus access disabled, so it doesn't read the ROM table.
+        super(AHB_AP, self).init(False)
 
+        # Look up the page size based on AP ID.
         if self.idr in AHB_IDR_TO_WRAP_SIZE:
             self.auto_increment_page_size = AHB_IDR_TO_WRAP_SIZE[self.idr]
         else:
@@ -348,6 +350,11 @@ class AHB_AP(MEM_AP):
             # read/write errors.
             self.auto_increment_page_size = 0x400
             logging.warning("Unknown AHB IDR: 0x%x" % self.idr)
+
+        # Now we can let the ROM table init since the page size is set, which is very
+        # important for performance.
+        if bus_accessible:
+            super(AHB_AP, self).init(bus_accessible)
 
 
 

--- a/pyOCD/tools/flash_tool.py
+++ b/pyOCD/tools/flash_tool.py
@@ -157,9 +157,6 @@ def main():
             flash = board.flash
             link = board.link
 
-            # Boost speed with deferred transfers
-            link.set_deferred_transfer(True)
-
             progress = print_progress
             if args.hide_progress:
                 progress = None

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -261,8 +261,6 @@ class GDBServerTool(object):
                     target_override=self.args.target_override,
                     frequency=self.args.frequency)
                 with board_selected as board:
-                    # Boost speed with deferred transfers
-                    board.link.set_deferred_transfer(True)
                     gdb = GDBServer(board, self.args.port_number, self.gdb_server_settings)
                     while gdb.isAlive():
                         gdb.join(timeout=0.5)


### PR DESCRIPTION
These changes enable deferred transfers by default and optimize the way the ROM table and CoreSight ID registers are read.

On a Kinetis K66F, reading the ROM table was improved from ~540ms to ~29ms.