### PR TITLE
Fix travis failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@
 from setuptools import setup, find_packages
 import sys
 
-install_requires = ['intelhex', 'six', 'enum34', 'cmsis-svd', 'future', 'websocket-client']
+install_requires = ['intelhex', 'six', 'enum34', 'cmsis-svd>=0.4', 'future', 'websocket-client']
 if sys.platform.startswith('linux'):
     install_requires.extend([
         'pyusb>=1.0.0b2',


### PR DESCRIPTION
Pin the cmsis-svd version to 0.1 since version 0.2 and 0.3 cause
installation problems in some configurations.