### PR TITLE
Display a warning for unsupported boards

### DIFF
--- a/pyOCD/board/mbed_board.py
+++ b/pyOCD/board/mbed_board.py
@@ -97,7 +97,7 @@ class MbedBoard(Board):
             target = self.native_target
 
         if target is None:
-            logging.error("Unsupported board found %s", board_id)
+            logging.warning("Unsupported board found %s", board_id)
             target = "cortex_m"
 
         super(MbedBoard, self).__init__(target, target, link, frequency)


### PR DESCRIPTION
Display a warning rather than an error when the target board is
unsupported. This is not a fatal error, since pyOCD can still connect
and be used to debug. It just cannot flash the target.