### PR TITLE
pyusb backend: add exception for Hexiwear

### DIFF
--- a/pyOCD/pyDAPAccess/interface/pyusb_backend.py
+++ b/pyOCD/pyDAPAccess/interface/pyusb_backend.py
@@ -86,6 +86,9 @@ class PyUSB(Interface):
                 # This can cause an exception to be thrown if the device
                 # is malfunctioning.
                 product = board.product
+            except ValueError:
+                if board.idVendor is 0xd28 and board.idProduct is 0x204:
+                    continue
             except usb.core.USBError as error:
                 logging.warning("Exception getting product string: %s", error)
                 continue


### PR DESCRIPTION
Enable pyOCD to run as normal user, a hack for Hexiwear.
Without this hack, only root user can debug/flash.
Kinetis Design Studio launches pyOCD as normal user.

Signed-off-by: Aurabindo J <mail@aurabindo.in>