### PR TITLE
pyusb: catch ValueError when fetching the product id

### DIFF
--- a/pyOCD/pyDAPAccess/interface/pyusb_backend.py
+++ b/pyOCD/pyDAPAccess/interface/pyusb_backend.py
@@ -86,6 +86,10 @@ class PyUSB(Interface):
                 # This can cause an exception to be thrown if the device
                 # is malfunctioning.
                 product = board.product
+            except ValueError as error:
+                # Permission denied error gets reported as ValueError (langid)
+                logging.debug("Exception getting product string: %s", error)
+                continue
             except usb.core.USBError as error:
                 logging.warning("Exception getting product string: %s", error)
                 continue


### PR DESCRIPTION
Lack of permission gets reported as ValueError (no langid), so catch
that and report, but avoid stopping the execution.

Issue #259.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>