### PR TITLE
Fix typo in initialization sequence

### DIFF
--- a/pyOCD/pyDAPAccess/cmsis_dap_core.py
+++ b/pyOCD/pyDAPAccess/cmsis_dap_core.py
@@ -129,10 +129,10 @@ class CMSIS_DAP_Protocol(object):
             raise DAPAccessIntf.CommandError()
 
         if resp[1] == 1:
-            logging.info('DAP SWD MODE initialised')
+            logging.info('DAP SWD MODE initialized')
 
         if resp[1] == 2:
-            logging.info('DAP JTAG MODE initialised')
+            logging.info('DAP JTAG MODE initialized')
 
         return resp[1]
 


### PR DESCRIPTION
Change 'initialised' to 'initialized' so it uses the US spelling of the word rather than the UK spelling.