### PR TITLE
Separate SWJ sequence from connect

### DIFF
--- a/pyOCD/coresight/dap.py
+++ b/pyOCD/coresight/dap.py
@@ -109,6 +109,7 @@ class DebugPort(object):
     def init(self):
         # Connect to the target.
         self.link.connect()
+        self.link.swj_sequence()
         self.read_id_code()
         self.clear_sticky_err()
 

--- a/pyOCD/pyDAPAccess/dap_access_api.py
+++ b/pyOCD/pyDAPAccess/dap_access_api.py
@@ -118,11 +118,15 @@ class DAPAccessIntf(object):
     #          Target control functions
     # ------------------------------------------- #
     def connect(self, port=None):
-        """Connect to target with JTAG or SWD"""
+        """Initailize DAP IO pins for JTAG or SWD"""
+        raise NotImplementedError()
+
+    def swj_sequence(self):
+        """Send seqeunce to activate JTAG or SWD on the target"""
         raise NotImplementedError()
 
     def disconnect(self):
-        """Disconnect from target"""
+        """Deinitialize the DAP I/O pins"""
         raise NotImplementedError()
 
     def set_clock(self, frequency):

--- a/pyOCD/pyDAPAccess/dap_access_cmsis_dap.py
+++ b/pyOCD/pyDAPAccess/dap_access_cmsis_dap.py
@@ -516,6 +516,8 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         self._protocol.setSWJClock(self._frequency)
         # configure transfer
         self._protocol.transferConfigure()
+
+    def swj_sequence(self):
         if self._dap_port == DAPAccessIntf.PORT.SWD:
             # configure swd protocol
             self._protocol.swdConfigure()


### PR DESCRIPTION
Move the sending of the SWJ sequence out of connect. This allows the SWJ sequence to be sent multiple times without re-initializing the SWD/JTAG pins. It also allows the SWJ sequence to be sent while reset is held low.

With this patch the function connect just configures debugger IO pins for the desired protocol. The function swj_sequence() must then be used to prepare the target for communication.