### PR TITLE
Clear sticky errors if a fault happens due to a flush

### DIFF
--- a/pyOCD/coresight/cortex_m.py
+++ b/pyOCD/coresight/cortex_m.py
@@ -386,6 +386,9 @@ class CortexM(Target):
         """
         return self.dp.read_id_code()
 
+    def flush(self):
+        self.dp.flush()
+
     def writeMemory(self, addr, value, transfer_size=32):
         """
         write a memory location.

--- a/pyOCD/coresight/dap.py
+++ b/pyOCD/coresight/dap.py
@@ -123,6 +123,9 @@ class DebugPort(object):
     def flush(self):
         try:
             self.link.flush()
+        except DAPAccess.Error as error:
+            self._handle_error(error, self.next_access_number)
+            raise
         finally:
             self._csw = {}
             self._dp_select = -1

--- a/pyOCD/target/coresight_target.py
+++ b/pyOCD/target/coresight_target.py
@@ -91,6 +91,9 @@ class CoreSightTarget(Target):
     def readIDCode(self):
         return self.dp.dpidr
 
+    def flush(self):
+        self.dp.flush()
+
     def halt(self):
         return self.selected_core.halt()
 

--- a/pyOCD/target/target.py
+++ b/pyOCD/target/target.py
@@ -15,6 +15,8 @@
  limitations under the License.
 """
 
+from .memory_map import MemoryMap
+
 class Target(object):
 
     TARGET_RUNNING = 1   # Core is executing code.
@@ -39,7 +41,7 @@ class Target(object):
         self.link = link
         self.flash = None
         self.part_number = ""
-        self.memory_map = memoryMap
+        self.memory_map = memoryMap or MemoryMap()
         self.halt_on_connect = True
         self.has_fpu = False
         self._svd_location = None

--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -649,6 +649,7 @@ class PyOCDTool(object):
             self.target.flash.programPhrase(addr, data)
         else:
             self.target.writeBlockMemoryUnaligned8(addr, data)
+            self.target.flush()
 
     def handle_erase(self, args):
         if len(args) < 1:


### PR DESCRIPTION
This fixes a case where a write to an invalid address is put into a packet and not immediately flushed. When it was flushed, the sticky flags weren't cleared, so the next valid read or write would fail.

- `CoreSightTarget` and `CortexM` classes override `flush()` to call the `DebugPort.flush()` method. 
- Handling errors in `DebugPort.flush()` by clearing sticky flags.

Also includes 2 other fixes:
- If the target subclass does not provide a memory map, an empty one will be created. This currently only applies to the generic 'cortex_m' target.
- The write memory commands in pyocd-tool will now always perform a flush after writing.