### PR TITLE
Support all vector catch options

### DIFF
--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -172,17 +172,11 @@ class CoreSightTarget(Target):
     def getMemoryMap(self):
         return self.memory_map
 
-    def setVectorCatchFault(self, enable):
-        return self.selected_core.setVectorCatchFault(enable)
+    def setVectorCatch(self, enableMask):
+        return self.selected_core.setVectorCatch(enableMask)
 
-    def getVectorCatchFault(self):
-        return self.selected_core.getVectorCatchFault()
-
-    def setVectorCatchReset(self, enable):
-        return self.selected_core.setVectorCatchReset(enable)
-
-    def getVectorCatchReset(self):
-        return self.selected_core.getVectorCatchReset()
+    def getVectorCatch(self):
+        return self.selected_core.getVectorCatch()
 
     # GDB functions
     def getTargetXML(self):

--- a/pyOCD/core/target.py
+++ b/pyOCD/core/target.py
@@ -37,6 +37,19 @@ class Target(object):
     WATCHPOINT_WRITE = 2
     WATCHPOINT_READ_WRITE = 3
 
+    # Vector catch option masks.
+    CATCH_NONE = 0
+    CATCH_HARD_FAULT = (1 << 0)
+    CATCH_BUS_FAULT = (1 << 1)
+    CATCH_MEM_FAULT = (1 << 2)
+    CATCH_INTERRUPT_ERR = (1 << 3)
+    CATCH_STATE_ERR = (1 << 4)
+    CATCH_CHECK_ERR = (1 << 5)
+    CATCH_COPROCESSOR_ERR = (1 << 6)
+    CATCH_CORE_RESET = (1 << 7)
+    CATCH_ALL = (CATCH_HARD_FAULT | CATCH_BUS_FAULT | CATCH_MEM_FAULT | CATCH_INTERRUPT_ERR \
+                | CATCH_STATE_ERR | CATCH_CHECK_ERR | CATCH_COPROCESSOR_ERR | CATCH_CORE_RESET)
+
     def __init__(self, link, memoryMap=None):
         self.link = link
         self.flash = None
@@ -186,16 +199,10 @@ class Target(object):
     def getMemoryMap(self):
         return self.memory_map
 
-    def setVectorCatchFault(self, enable):
+    def setVectorCatch(self, enableMask):
         raise NotImplementedError()
 
-    def getVectorCatchFault(self):
-        raise NotImplementedError()
-
-    def setVectorCatchReset(self, enable):
-        raise NotImplementedError()
-
-    def getVectorCatchReset(self):
+    def getVectorCatch(self):
         raise NotImplementedError()
 
     # GDB functions

--- a/pyOCD/coresight/cortex_m.py
+++ b/pyOCD/coresight/cortex_m.py
@@ -151,7 +151,12 @@ class CortexM(Target):
     # DWTENA in armv6 architecture reference manual
     DEMCR_TRCENA = (1 << 24)
     DEMCR_VC_HARDERR = (1 << 10)
+    DEMCR_VC_INTERR = (1 << 9)
     DEMCR_VC_BUSERR = (1 << 8)
+    DEMCR_VC_STATERR = (1 << 7)
+    DEMCR_VC_CHKERR = (1 << 6)
+    DEMCR_VC_NOCPERR = (1 << 5)
+    DEMCR_VC_MMERR = (1 << 4)
     DEMCR_VC_CORERESET = (1 << 0)
 
     # CPUID Register
@@ -784,27 +789,57 @@ class CortexM(Target):
         """
         return self.dwt.remove_watchpoint(addr, size, type)
 
-    def setVectorCatchFault(self, enable):
+    @staticmethod
+    def _map_to_vector_catch_mask(mask):
+        result = 0
+        if mask & Target.CATCH_HARD_FAULT:
+            result |= CortexM.DEMCR_VC_HARDERR
+        if mask & Target.CATCH_BUS_FAULT:
+            result |= CortexM.DEMCR_VC_BUSERR
+        if mask & Target.CATCH_MEM_FAULT:
+            result |= CortexM.DEMCR_VC_MMERR
+        if mask & Target.CATCH_INTERRUPT_ERR:
+            result |= CortexM.DEMCR_VC_INTERR
+        if mask & Target.CATCH_STATE_ERR:
+            result |= CortexM.DEMCR_VC_STATERR
+        if mask & Target.CATCH_CHECK_ERR:
+            result |= CortexM.DEMCR_VC_CHKERR
+        if mask & Target.CATCH_COPROCESSOR_ERR:
+            result |= CortexM.DEMCR_VC_NOCPERR
+        if mask & Target.CATCH_CORE_RESET:
+            result |= CortexM.DEMCR_VC_CORERESET
+        return result
+
+    @staticmethod
+    def _map_from_vector_catch_mask(mask):
+        result = 0
+        if mask & CortexM.DEMCR_VC_HARDERR:
+            result |= Target.CATCH_HARD_FAULT
+        if mask & CortexM.DEMCR_VC_BUSERR:
+            result |= Target.CATCH_BUS_FAULT
+        if mask & CortexM.DEMCR_VC_MMERR:
+            result |= Target.CATCH_MEM_FAULT
+        if mask & CortexM.DEMCR_VC_INTERR:
+            result |= Target.CATCH_INTERRUPT_ERR
+        if mask & CortexM.DEMCR_VC_STATERR:
+            result |= Target.CATCH_STATE_ERR
+        if mask & CortexM.DEMCR_VC_CHKERR:
+            result |= Target.CATCH_CHECK_ERR
+        if mask & CortexM.DEMCR_VC_NOCPERR:
+            result |= Target.CATCH_COPROCESSOR_ERR
+        if mask & CortexM.DEMCR_VC_CORERESET:
+            result |= Target.CATCH_CORE_RESET
+        return result
+
+    def setVectorCatch(self, enableMask):
         demcr = self.readMemory(CortexM.DEMCR)
-        if enable:
-            demcr = demcr | CortexM.DEMCR_VC_HARDERR
-        else:
-            demcr = demcr & ~CortexM.DEMCR_VC_HARDERR
+        demcr |= CortexM._map_to_vector_catch_mask(enableMask)
+        demcr &= ~CortexM._map_to_vector_catch_mask(~enableMask)
         self.writeMemory(CortexM.DEMCR, demcr)
 
-    def getVectorCatchFault(self):
-        return bool(self.readMemory(CortexM.DEMCR) & CortexM.DEMCR_VC_HARDERR)
-
-    def setVectorCatchReset(self, enable):
+    def getVectorCatch(self):
         demcr = self.readMemory(CortexM.DEMCR)
-        if enable:
-            demcr = demcr | CortexM.DEMCR_VC_CORERESET
-        else:
-            demcr = demcr & ~CortexM.DEMCR_VC_CORERESET
-        self.writeMemory(CortexM.DEMCR, demcr)
-
-    def getVectorCatchReset(self):
-        return bool(self.readMemory(CortexM.DEMCR) & CortexM.DEMCR_VC_CORERESET)
+        return CortexM._map_from_vector_catch_mask(demcr)
 
     # GDB functions
     def getTargetXML(self):

--- a/pyOCD/flash/flash.py
+++ b/pyOCD/flash/flash.py
@@ -309,10 +309,8 @@ class Flash(object):
 
         if self.flash_algo_debug:
             # Save vector catch state for use in waitForCompletion()
-            self._vector_catch_enabled = self.target.getVectorCatchFault()
-            self._reset_catch_enabled = self.target.getVectorCatchReset()
-            self.target.setVectorCatchFault(True)
-            self.target.setVectorCatchReset(True)
+            self._saved_vector_catch = self.target.getVectorCatch()
+            self.target.setVectorCatch(Target.CATCH_ALL)
 
         if init:
             # download flash algo in RAM
@@ -390,8 +388,7 @@ class Flash(object):
             #    logging.error("Analyzer overwritten!")
             #    error = True
             assert error == False
-            self.target.setVectorCatchFault(self._vector_catch_enabled)
-            self.target.setVectorCatchReset(self._reset_catch_enabled)
+            self.target.setVectorCatch(self._saved_vector_catch)
 
         return self.target.readCoreRegister('r0')
 

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -65,7 +65,7 @@ class GDBServerTool(object):
         parser.add_argument("-t", "--target", dest="target_override", choices=supported_targets, default=None, help="Override target to debug.  Supported targets are: " + ", ".join(supported_targets), metavar="TARGET")
         parser.add_argument("-n", "--nobreak", dest="break_at_hardfault", default=True, action="store_false", help="Disable halt at hardfault handler.")
         parser.add_argument("-r", "--reset-break", dest="break_on_reset", default=False, action="store_true", help="Halt the target when reset.")
-        parser.add_argument("-C", "--vector-catch", default=None, help="Select enabled vector catch options, one letter per enabled source in any order. (h=hard fault, b=bus fault, m=mem fault, i=irq err, s=state err, c=check err, p=nocp, r=reset, a=all)")
+        parser.add_argument("-C", "--vector-catch", default='', help="Select enabled vector catch options, one letter per enabled source in any order. (h=hard fault, b=bus fault, m=mem fault, i=irq err, s=state err, c=check err, p=nocp, r=reset, a=all, n=none)")
         parser.add_argument("-s", "--step-int", dest="step_into_interrupt", default=False, action="store_true", help="Allow single stepping to step into interrupts.")
         parser.add_argument("-f", "--frequency", dest="frequency", default=1000000, type=int, help="Set the SWD clock frequency in Hz.")
         parser.add_argument("-o", "--persist", dest="persist", default=False, action="store_true", help="Keep GDB server running even after remote has detached.")

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -65,6 +65,7 @@ class GDBServerTool(object):
         parser.add_argument("-t", "--target", dest="target_override", choices=supported_targets, default=None, help="Override target to debug.  Supported targets are: " + ", ".join(supported_targets), metavar="TARGET")
         parser.add_argument("-n", "--nobreak", dest="break_at_hardfault", default=True, action="store_false", help="Disable halt at hardfault handler.")
         parser.add_argument("-r", "--reset-break", dest="break_on_reset", default=False, action="store_true", help="Halt the target when reset.")
+        parser.add_argument("-C", "--vector-catch", default=None, help="Select enabled vector catch options, one letter per enabled source in any order. (h=hard fault, b=bus fault, m=mem fault, i=irq err, s=state err, c=check err, p=nocp, r=reset, a=all)")
         parser.add_argument("-s", "--step-int", dest="step_into_interrupt", default=False, action="store_true", help="Allow single stepping to step into interrupts.")
         parser.add_argument("-f", "--frequency", dest="frequency", default=1000000, type=int, help="Set the SWD clock frequency in Hz.")
         parser.add_argument("-o", "--persist", dest="persist", default=False, action="store_true", help="Keep GDB server running even after remote has detached.")
@@ -110,6 +111,7 @@ class GDBServerTool(object):
             'telnet_port' : args.telnet_port,
             'semihost_use_syscalls' : args.semihost_use_syscalls,
             'serve_local_only' : args.serve_local_only,
+            'vector_catch' : args.vector_catch,
         }
 
 


### PR DESCRIPTION
Reworked vector catch APIs in `Target`. There is now a single `setVectorCatch()` that takes a mask and `getVectorCatch()` that returns a mask.

There are new mask constants defined in `Target`.
```py
    CATCH_NONE = 0
    CATCH_HARD_FAULT = (1 << 0)
    CATCH_BUS_FAULT = (1 << 1)
    CATCH_MEM_FAULT = (1 << 2)
    CATCH_INTERRUPT_ERR = (1 << 3)
    CATCH_STATE_ERR = (1 << 4)
    CATCH_CHECK_ERR = (1 << 5)
    CATCH_COPROCESSOR_ERR = (1 << 6)
    CATCH_CORE_RESET = (1 << 7)
    CATCH_ALL = (CATCH_HARD_FAULT | CATCH_BUS_FAULT | CATCH_MEM_FAULT | CATCH_INTERRUPT_ERR \
                | CATCH_STATE_ERR | CATCH_CHECK_ERR | CATCH_COPROCESSOR_ERR | CATCH_CORE_RESET)
```

Added `--vector-catch` option to pyocd-gdbserver. It accepts a list of vector catch options to enable as a string composed of these characters: h=hard fault, b=bus fault, m=mem fault, i=irq err, s=state err, c=check err, p=nocp, r=reset, a=all.
