### PR TITLE
Remove flash parameter for Board class

### DIFF
--- a/pyOCD/board/board.py
+++ b/pyOCD/board/board.py
@@ -24,10 +24,10 @@ class Board(object):
     """
     This class associates a target, a flash and a link to create a board
     """
-    def __init__(self, target, flash, link, frequency=1000000):
+    def __init__(self, target, link, frequency=1000000):
         self.link = link
         self.target = TARGET[target](self.link)
-        self.flash = FLASH[flash](self.target)
+        self.flash = FLASH[target](self.target)
         self.target.setFlash(self.flash)
         self.debug_clock_frequency = frequency
         self.closed = False

--- a/pyOCD/board/mbed_board.py
+++ b/pyOCD/board/mbed_board.py
@@ -121,7 +121,7 @@ class MbedBoard(Board):
             logging.warning("Unsupported board found %s", board_id)
             target = "cortex_m"
 
-        super(MbedBoard, self).__init__(target, target, link, frequency)
+        super(MbedBoard, self).__init__(target, link, frequency)
         self.unique_id = unique_id
         self.target_type = target
 


### PR DESCRIPTION
Flash is always the same as the target, so specifying it is redundant. Remove this parameter and use the target name for this purpose instead.