### PR TITLE
Debug contexts

### DIFF
--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -200,27 +200,6 @@ class CoreSightTarget(Target):
     def getTargetXML(self):
         return self.selected_core.getTargetXML()
 
-    def getRegisterContext(self):
-        return self.selected_core.getRegisterContext()
-
-    def setRegisterContext(self, data):
-        return self.selected_core.setRegisterContext(data)
-
-    def setRegister(self, reg, data):
-        return self.selected_core.setRegister(reg, data)
-
-    def getTResponse(self, forceSignal=None):
-        return self.selected_core.getTResponse(forceSignal)
-
-    def getSignalValue(self):
-        return self.selected_core.getSignalValue()
-
-    def getThreadsXML(self):
-        root = Element('threads')
-        t = SubElement(root, 'thread', id="1", core="0")
-        t.text = "Thread mode"
-        return '<?xml version="1.0"?><!DOCTYPE feature SYSTEM "threads.dtd">' + tostring(root)
-
     def getTargetContext(self, core=None):
         if core is None:
             core = self._selected_core

--- a/pyOCD/core/target.py
+++ b/pyOCD/core/target.py
@@ -224,3 +224,12 @@ class Target(object):
 
     def getSignalValue(self):
         raise NotImplementedError()
+
+    def getTargetContext(self, core=None):
+        raise NotImplementedError()
+
+    def getRootContext(self, core=None):
+        raise NotImplementedError()
+
+    def setRootContext(self, context, core=None):
+        raise NotImplementedError()

--- a/pyOCD/core/target.py
+++ b/pyOCD/core/target.py
@@ -202,29 +202,6 @@ class Target(object):
     def getTargetXML(self):
         raise NotImplementedError()
 
-    def getMemoryMapXML(self):
-        if self.memory_map:
-            return self.memory_map.getXML()
-        elif hasattr(self, 'memoryMapXML'):
-            return self.memoryMapXML
-        else:
-            return None
-
-    def getRegisterContext(self):
-        raise NotImplementedError()
-
-    def setRegisterContext(self, data):
-        raise NotImplementedError()
-
-    def setRegister(self, reg, data):
-        raise NotImplementedError()
-
-    def getTResponse(self, gdbInterrupt=False):
-        raise NotImplementedError()
-
-    def getSignalValue(self):
-        raise NotImplementedError()
-
     def getTargetContext(self, core=None):
         raise NotImplementedError()
 

--- a/pyOCD/coresight/cortex_m.py
+++ b/pyOCD/coresight/cortex_m.py
@@ -293,6 +293,7 @@ class CortexM(Target):
         self.dp = dp
         self.ap = ap
         self.core_number = core_num
+        self._target_context = None
 
         # Set up breakpoints manager.
         self.fpb = FPB(self.ap)
@@ -915,3 +916,10 @@ class CortexM(Target):
         t = SubElement(root, 'thread', id="1", core="0")
         t.text = "Thread mode"
         return '<?xml version="1.0"?><!DOCTYPE feature SYSTEM "threads.dtd">' + tostring(root)
+
+    def getTargetContext(self, core=None):
+        return self._target_context
+
+    def setTargetContext(self, context):
+        self._target_context = context
+

--- a/pyOCD/coresight/cortex_m.py
+++ b/pyOCD/coresight/cortex_m.py
@@ -18,7 +18,6 @@ from xml.etree.ElementTree import (Element, SubElement, tostring)
 
 from ..core.target import Target
 from pyOCD.pyDAPAccess import DAPAccess
-from ..gdbserver import signals
 from ..utility import conversion
 from .fpb import FPB
 from .dwt import DWT
@@ -43,19 +42,6 @@ CORE_TYPE_NAME = {
                  ARM_CortexM4 : "Cortex-M4",
                  ARM_CortexM0p : "Cortex-M0+"
                }
-
-# Maps the fault code found in the IPSR to a GDB signal value.
-FAULT = [
-            signals.SIGSTOP,
-            signals.SIGSTOP,    # Reset
-            signals.SIGINT,     # NMI
-            signals.SIGSEGV,    # HardFault
-            signals.SIGSEGV,    # MemManage
-            signals.SIGBUS,     # BusFault
-            signals.SIGILL,     # UsageFault
-                                                # The rest are not faults
-         ]
-
 
 # Map from register name to DCRSR register index.
 #
@@ -811,111 +797,9 @@ class CortexM(Target):
     def getTargetXML(self):
         return self.targetXML
 
-    def getRegisterContext(self):
-        """
-        return hexadecimal dump of registers as expected by GDB
-        """
-        logging.debug("GDB getting register context")
-        resp = ''
-        reg_num_list = map(lambda reg:reg.reg_num, self.register_list)
-        vals = self.readCoreRegistersRaw(reg_num_list)
-        #print("Vals: %s" % vals)
-        for reg, regValue in zip(self.register_list, vals):
-            resp += conversion.u32beToHex8le(regValue)
-            logging.debug("GDB reg: %s = 0x%X", reg.name, regValue)
-
-        return resp
-
-    def setRegisterContext(self, data):
-        """
-        Set registers from GDB hexadecimal string.
-        """
-        logging.debug("GDB setting register context")
-        reg_num_list = []
-        reg_data_list = []
-        for reg in self.register_list:
-            regValue = conversion.hex8leToU32be(data)
-            reg_num_list.append(reg.reg_num)
-            reg_data_list.append(regValue)
-            logging.debug("GDB reg: %s = 0x%X", reg.name, regValue)
-            data = data[8:]
-        self.writeCoreRegistersRaw(reg_num_list, reg_data_list)
-
-    def setRegister(self, reg, data):
-        """
-        Set single register from GDB hexadecimal string.
-        reg parameter is the index of register in targetXML sent to GDB.
-        """
-        if reg < 0:
-            return
-        elif reg < len(self.register_list):
-            regName = self.register_list[reg].name
-            value = conversion.hex8leToU32be(data)
-            logging.debug("GDB: write reg %s: 0x%X", regName, value)
-            self.writeCoreRegisterRaw(regName, value)
-
-    def gdbGetRegister(self, reg):
-        resp = ''
-        if reg < len(self.register_list):
-            regName = self.register_list[reg].name
-            regValue = self.readCoreRegisterRaw(regName)
-            resp = conversion.u32beToHex8le(regValue)
-            logging.debug("GDB reg: %s = 0x%X", regName, regValue)
-        return resp
-
-    def getTResponse(self, forceSignal=None):
-        """
-        Returns a GDB T response string.  This includes:
-            The signal encountered.
-            The current value of the important registers (sp, lr, pc).
-        """
-        if forceSignal is not None:
-            response = 'T' + conversion.byteToHex2(forceSignal)
-        else:
-            response = 'T' + conversion.byteToHex2(self.getSignalValue())
-
-        # Append fp(r7), sp(r13), lr(r14), pc(r15)
-        response += self.getRegIndexValuePairs([7, 13, 14, 15])
-
-        # Append thread and core
-        response += "thread:%x;core:%x;" % (self.core_number + 1, self.core_number)
-
-        return response
-
-    def getSignalValue(self):
-        if self.isDebugTrap():
-            return signals.SIGTRAP
-
-        fault = self.readCoreRegister('xpsr') & 0xff
-        try:
-            signal = FAULT[fault]
-        except:
-            # If not a fault then default to SIGSTOP
-            signal = signals.SIGSTOP
-        logging.debug("GDB lastSignal: %d", signal)
-        return signal
-
     def isDebugTrap(self):
         debugEvents = self.readMemory(CortexM.DFSR) & (CortexM.DFSR_DWTTRAP | CortexM.DFSR_BKPT | CortexM.DFSR_HALTED)
         return debugEvents != 0
-
-    def getRegIndexValuePairs(self, regIndexList):
-        """
-        Returns a string like NN:MMMMMMMM;NN:MMMMMMMM;...
-            for the T response string.  NN is the index of the
-            register to follow MMMMMMMM is the value of the register.
-        """
-        str = ''
-        regList = self.readCoreRegistersRaw(regIndexList)
-        for regIndex, reg in zip(regIndexList, regList):
-            str += conversion.byteToHex2(regIndex) + ':' + conversion.u32beToHex8le(reg) + ';'
-        return str
-
-    def getThreadsXML(self):
-        root = Element('threads')
-        t = SubElement(root, 'thread', id="1", core="0")
-        t.text = "Thread mode"
-        return '<?xml version="1.0"?><!DOCTYPE feature SYSTEM "threads.dtd">' + tostring(root)
 
     def getTargetContext(self, core=None):
         return self._target_context

--- a/pyOCD/debug/context.py
+++ b/pyOCD/debug/context.py
@@ -1,0 +1,140 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2016 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from ..coresight.cortex_m import CORE_REGISTER
+from ..utility import conversion
+import logging
+
+## @brief Viewport for inspecting the system being debugged.
+#
+# A debug context is used to access registers and other target information. It enables these
+# accesses to be redirected to different locations. For instance, if you want to read registers
+# from a call frame that is not the topmost, then a context would redirect those reads to
+# locations on the stack.
+#
+# A context always has a specific core associated with it, which cannot be changed after the
+# context is created.
+class DebugContext(object):
+    def __init__(self, core):
+        self._core = core
+
+    @property
+    def core(self):
+        return self._core
+
+    def writeMemory(self, addr, value, transfer_size=32):
+        return self._core.writeMemory(addr, value, transfer_size)
+
+    def readMemory(self, addr, transfer_size=32, now=True):
+        return self._core.readMemory(addr, transfer_size, now)
+
+    def writeBlockMemoryUnaligned8(self, addr, value):
+        return self._core.writeBlockMemoryUnaligned8(addr, value)
+
+    def writeBlockMemoryAligned32(self, addr, data):
+        return self._core.writeBlockMemoryAligned32(addr, data)
+
+    def readBlockMemoryUnaligned8(self, addr, size):
+        return self._core.readBlockMemoryUnaligned8(addr, size)
+
+    def readBlockMemoryAligned32(self, addr, size):
+        return self._core.readBlockMemoryAligned32(addr, size)
+
+    # @brief Shorthand to write a 32-bit word.
+    def write32(self, addr, value):
+        self.writeMemory(addr, value, 32)
+
+    # @brief Shorthand to write a 16-bit halfword.
+    def write16(self, addr, value):
+        self.writeMemory(addr, value, 16)
+
+    # @brief Shorthand to write a byte.
+    def write8(self, addr, value):
+        self.writeMemory(addr, value, 8)
+
+    # @brief Shorthand to read a 32-bit word.
+    def read32(self, addr, now=True):
+        return self.readMemory(addr, 32, now)
+
+    # @brief Shorthand to read a 16-bit halfword.
+    def read16(self, addr, now=True):
+        return self.readMemory(addr, 16, now)
+
+    # @brief Shorthand to read a byte.
+    def read8(self, addr, now=True):
+        return self.readMemory(addr, 8, now)
+
+    def registerNameToIndex(self, reg):
+        """
+        return register index based on name.
+        If reg is a string, find the number associated to this register
+        in the lookup table CORE_REGISTER
+        """
+        if isinstance(reg, str):
+            try:
+                reg = CORE_REGISTER[reg.lower()]
+            except KeyError:
+                logging.error('cannot find %s core register', reg)
+                return
+        return reg
+
+    def readCoreRegister(self, reg):
+        """
+        read CPU register
+        Unpack floating point register values
+        """
+        regIndex = self.registerNameToIndex(reg)
+        regValue = self.readCoreRegisterRaw(regIndex)
+        # Convert int to float.
+        if regIndex >= 0x40:
+            regValue = conversion.u32BEToFloat32BE(regValue)
+        return regValue
+
+    def readCoreRegisterRaw(self, reg):
+        """
+        read a core register (r0 .. r16).
+        If reg is a string, find the number associated to this register
+        in the lookup table CORE_REGISTER
+        """
+        vals = self.readCoreRegistersRaw([reg])
+        return vals[0]
+
+    def readCoreRegistersRaw(self, reg_list):
+        return self._core.readCoreRegistersRaw(reg_list)
+
+    def writeCoreRegister(self, reg, data):
+        """
+        write a CPU register.
+        Will need to pack floating point register values before writing.
+        """
+        regIndex = self.registerNameToIndex(reg)
+        # Convert float to int.
+        if regIndex >= 0x40:
+            data = conversion.float32beToU32be(data)
+        self.writeCoreRegisterRaw(regIndex, data)
+
+    def writeCoreRegisterRaw(self, reg, data):
+        """
+        write a core register (r0 .. r16)
+        If reg is a string, find the number associated to this register
+        in the lookup table CORE_REGISTER
+        """
+        self.writeCoreRegistersRaw([reg], [data])
+
+    def writeCoreRegistersRaw(self, reg_list, data_list):
+        self._core.writeCoreRegistersRaw(reg_list, data_list)
+

--- a/pyOCD/debug/context.py
+++ b/pyOCD/debug/context.py
@@ -138,3 +138,6 @@ class DebugContext(object):
     def writeCoreRegistersRaw(self, reg_list, data_list):
         self._core.writeCoreRegistersRaw(reg_list, data_list)
 
+    def flush(self):
+        self._core.flush()
+

--- a/pyOCD/gdbserver/context_facade.py
+++ b/pyOCD/gdbserver/context_facade.py
@@ -1,0 +1,145 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2016 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from ..utility import conversion
+from . import signals
+import logging
+
+# Maps the fault code found in the IPSR to a GDB signal value.
+FAULT = [
+            signals.SIGSTOP,
+            signals.SIGSTOP,    # Reset
+            signals.SIGINT,     # NMI
+            signals.SIGSEGV,    # HardFault
+            signals.SIGSEGV,    # MemManage
+            signals.SIGBUS,     # BusFault
+            signals.SIGILL,     # UsageFault
+                                                # The rest are not faults
+         ]
+
+## @brief Provides GDB specific transformations to a DebugContext.
+class GDBDebugContextFacade(object):
+    def __init__(self, context):
+        self._context = context
+        self._register_list = self._context.core.register_list
+
+    @property
+    def context(self):
+        return self._context
+
+    def set_context(self, newContext):
+        self._context = newContext
+
+    def getRegisterContext(self):
+        """
+        return hexadecimal dump of registers as expected by GDB
+        """
+        logging.debug("GDB getting register context")
+        resp = ''
+        reg_num_list = map(lambda reg:reg.reg_num, self._register_list)
+        vals = self._context.readCoreRegistersRaw(reg_num_list)
+        #print("Vals: %s" % vals)
+        for reg, regValue in zip(self._register_list, vals):
+            resp += conversion.u32beToHex8le(regValue)
+            logging.debug("GDB reg: %s = 0x%X", reg.name, regValue)
+
+        return resp
+
+    def setRegisterContext(self, data):
+        """
+        Set registers from GDB hexadecimal string.
+        """
+        logging.debug("GDB setting register context")
+        reg_num_list = []
+        reg_data_list = []
+        for reg in self._register_list:
+            regValue = conversion.hex8leToU32be(data)
+            reg_num_list.append(reg.reg_num)
+            reg_data_list.append(regValue)
+            logging.debug("GDB reg: %s = 0x%X", reg.name, regValue)
+            data = data[8:]
+        self._context.writeCoreRegistersRaw(reg_num_list, reg_data_list)
+
+    def setRegister(self, reg, data):
+        """
+        Set single register from GDB hexadecimal string.
+        reg parameter is the index of register in targetXML sent to GDB.
+        """
+        if reg < 0:
+            return
+        elif reg < len(self._register_list):
+            regName = self._register_list[reg].name
+            value = conversion.hex8leToU32be(data)
+            logging.debug("GDB: write reg %s: 0x%X", regName, value)
+            self._context.writeCoreRegisterRaw(regName, value)
+
+    def gdbGetRegister(self, reg):
+        resp = ''
+        if reg < len(self._register_list):
+            regName = self._register_list[reg].name
+            regValue = self._context.readCoreRegisterRaw(regName)
+            resp = conversion.u32beToHex8le(regValue)
+            logging.debug("GDB reg: %s = 0x%X", regName, regValue)
+        return resp
+
+    def getTResponse(self, forceSignal=None):
+        """
+        Returns a GDB T response string.  This includes:
+            The signal encountered.
+            The current value of the important registers (sp, lr, pc).
+        """
+        if forceSignal is not None:
+            response = 'T' + conversion.byteToHex2(forceSignal)
+        else:
+            response = 'T' + conversion.byteToHex2(self.getSignalValue())
+
+        # Append fp(r7), sp(r13), lr(r14), pc(r15)
+        response += self.getRegIndexValuePairs([7, 13, 14, 15])
+
+        return response
+
+    def getSignalValue(self):
+        if self._context.core.isDebugTrap():
+            return signals.SIGTRAP
+
+        fault = self._context.readCoreRegister('xpsr') & 0xff
+        try:
+            signal = FAULT[fault]
+        except:
+            # If not a fault then default to SIGSTOP
+            signal = signals.SIGSTOP
+        logging.debug("GDB lastSignal: %d", signal)
+        return signal
+
+    def getRegIndexValuePairs(self, regIndexList):
+        """
+        Returns a string like NN:MMMMMMMM;NN:MMMMMMMM;...
+            for the T response string.  NN is the index of the
+            register to follow MMMMMMMM is the value of the register.
+        """
+        str = ''
+        regList = self._context.readCoreRegistersRaw(regIndexList)
+        for regIndex, reg in zip(regIndexList, regList):
+            str += conversion.byteToHex2(regIndex) + ':' + conversion.u32beToHex8le(reg) + ';'
+        return str
+
+    def getMemoryMapXML(self):
+        if self._context.core.memory_map:
+            return self._context.core.memory_map.getXML()
+        else:
+            return None
+

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -22,6 +22,7 @@ from gdb_socket import GDBSocket
 from gdb_websocket import GDBWebSocket
 from syscall import GDBSyscallIOHandler
 from ..debug import semihost
+from .context_facade import GDBDebugContextFacade
 import signals
 import logging, threading, socket
 from struct import unpack
@@ -29,6 +30,7 @@ from time import sleep, time
 import sys
 import traceback
 import Queue
+from xml.etree.ElementTree import (Element, SubElement, tostring)
 
 CTRL_C = '\x03'
 
@@ -245,6 +247,8 @@ class GDBServer(threading.Thread):
         self.lock = threading.Lock()
         self.shutdown_event = threading.Event()
         self.detach_event = threading.Event()
+        self.target_context = self.target.getTargetContext()
+        self.target_facade = GDBDebugContextFacade(self.target_context)
         if self.wss_server == None:
             self.abstract_socket = GDBSocket(self.port, self.packet_size)
             if self.serve_local_only:
@@ -537,7 +541,7 @@ class GDBServer(threading.Thread):
         if self.non_stop and self.is_target_running:
             return self.createRSPPacket("OK")
 
-        return self.createRSPPacket(self.target.getTResponse())
+        return self.createRSPPacket(self.getTResponse())
 
     def _get_resume_step_addr(self, data):
         if data is None:
@@ -570,7 +574,7 @@ class GDBServer(threading.Thread):
                 logging.debug("receive CTRL-C")
                 self.packet_io.interrupt_event.clear()
                 self.target.halt()
-                val = self.target.getTResponse(forceSignal=signals.SIGINT)
+                val = self.getTResponse(forceSignal=signals.SIGINT)
                 break
 
             try:
@@ -583,8 +587,9 @@ class GDBServer(threading.Thread):
                             self.target.resume()
                             continue
 
-                    logging.debug("state halted")
-                    val = self.target.getTResponse()
+                    pc = self.target.readCoreRegister('pc')
+                    logging.debug("state halted; pc=0x%08x", pc)
+                    val = self.getTResponse()
                     break
             except Exception as e:
                 try:
@@ -593,7 +598,7 @@ class GDBServer(threading.Thread):
                     pass
                 traceback.print_exc()
                 logging.debug('Target is unavailable temporarily.')
-                val = 'S%02x' % self.target.getSignalValue()
+                val = 'S%02x' % self.target_facade.getSignalValue()
                 break
 
         return self.createRSPPacket(val)
@@ -602,14 +607,14 @@ class GDBServer(threading.Thread):
         addr = self._get_resume_step_addr(data)
         logging.debug("GDB step: %s", data)
         self.target.step(not self.step_into_interrupt)
-        return self.createRSPPacket(self.target.getTResponse())
+        return self.createRSPPacket(self.getTResponse())
 
     def halt(self):
         self.target.halt()
-        return self.createRSPPacket(self.target.getTResponse())
+        return self.createRSPPacket(self.getTResponse())
 
     def sendStopNotification(self, forceSignal=None):
-        data = self.target.getTResponse(forceSignal=forceSignal)
+        data = self.getTResponse(forceSignal=forceSignal)
         packet = '%Stop:' + data + '#' + checksum(data)
         self.packet_io.send(packet)
 
@@ -853,19 +858,19 @@ class GDBServer(threading.Thread):
         return self.createRSPPacket(resp)
 
     def readRegister(self, which):
-        return self.createRSPPacket(self.target.gdbGetRegister(which))
+        return self.createRSPPacket(self.target_facade.gdbGetRegister(which))
 
     def writeRegister(self, data):
         reg = int(data.split('=')[0], 16)
         val = data.split('=')[1].split('#')[0]
-        self.target.setRegister(reg, val)
+        self.target_facade.setRegister(reg, val)
         return self.createRSPPacket("OK")
 
     def getRegisters(self):
-        return self.createRSPPacket(self.target.getRegisterContext())
+        return self.createRSPPacket(self.target_facade.getRegisterContext())
 
     def setRegisters(self, data):
-        self.target.setRegisterContext(data)
+        self.target_facade.setRegisterContext(data)
         return self.createRSPPacket("OK")
 
     def handleQuery(self, msg):
@@ -883,7 +888,7 @@ class GDBServer(threading.Thread):
             # Build our list of features.
             features = ['qXfer:features:read+', 'QStartNoAckMode+', 'qXfer:threads:read+', 'QNonStop+']
             features.append('PacketSize=' + hex(self.packet_size)[2:])
-            if self.target.getMemoryMapXML() is not None:
+            if self.target_facade.getMemoryMapXML() is not None:
                 features.append('qXfer:memory-map:read+')
             resp = ';'.join(features)
             return self.createRSPPacket(resp)
@@ -1015,11 +1020,11 @@ class GDBServer(threading.Thread):
         logging.debug('GDB query %s: offset: %s, size: %s', query, offset, size)
         xml = ''
         if query == 'memory_map':
-            xml = self.target.getMemoryMapXML()
+            xml = self.target_facade.getMemoryMapXML()
         elif query == 'read_feature':
             xml = self.target.getTargetXML()
         elif query == 'threads':
-            xml = self.target.getThreadsXML()
+            xml = self.getThreadsXML()
         else:
             raise RuntimeError("Invalid XML query (%s)" % query)
 
@@ -1086,4 +1091,16 @@ class GDBServer(threading.Thread):
                 break
 
         return -1, 0
+
+    def getThreadsXML(self):
+        root = Element('threads')
+        t = SubElement(root, 'thread', id="1", core="0")
+        t.text = "Thread mode"
+        return '<?xml version="1.0"?><!DOCTYPE feature SYSTEM "threads.dtd">' + tostring(root)
+
+    def getTResponse(self, forceSignal=None):
+        response = self.target_facade.getTResponse(forceSignal)
+
+        logging.debug("Tresponse=%s", response)
+        return response
 

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -263,7 +263,7 @@ class GDBServer(threading.Thread):
             # Use internal IO handler.
             semihost_io_handler = semihost.InternalSemihostIOHandler()
         self.telnet_console = semihost.TelnetSemihostIOHandler(self.telnet_port, self.serve_local_only)
-        self.semihost = semihost.SemihostAgent(self.target, io_handler=semihost_io_handler, console=self.telnet_console)
+        self.semihost = semihost.SemihostAgent(self.target_context, io_handler=semihost_io_handler, console=self.telnet_console)
 
         self.setDaemon(True)
         self.start()
@@ -587,7 +587,7 @@ class GDBServer(threading.Thread):
                             self.target.resume()
                             continue
 
-                    pc = self.target.readCoreRegister('pc')
+                    pc = self.target_context.readCoreRegister('pc')
                     logging.debug("state halted; pc=0x%08x", pc)
                     val = self.getTResponse()
                     break
@@ -789,9 +789,9 @@ class GDBServer(threading.Thread):
 
         try:
             val = ''
-            mem = self.target.readBlockMemoryUnaligned8(addr, length)
+            mem = self.target_context.readBlockMemoryUnaligned8(addr, length)
             # Flush so an exception is thrown now if invalid memory was accesses
-            self.target.flush()
+            self.target_context.flush()
             for x in mem:
                 if x >= 0x10:
                     val += hex(x)[2:4]
@@ -817,9 +817,9 @@ class GDBServer(threading.Thread):
 
         try:
             if length > 0:
-                self.target.writeBlockMemoryUnaligned8(addr, data)
+                self.target_context.writeBlockMemoryUnaligned8(addr, data)
                 # Flush so an exception is thrown now if invalid memory was accessed
-                self.target.flush()
+                self.target_context.flush()
             resp = "OK"
         except DAPAccess.TransferError:
             logging.debug("writeMemory failed at 0x%x" % addr)
@@ -847,9 +847,9 @@ class GDBServer(threading.Thread):
 
         try:
             if length > 0:
-                self.target.writeBlockMemoryUnaligned8(addr, data)
+                self.target_context.writeBlockMemoryUnaligned8(addr, data)
                 # Flush so an exception is thrown now if invalid memory was accessed
-                self.target.flush()
+                self.target_context.flush()
             resp = "OK"
         except DAPAccess.TransferError:
             logging.debug("writeMemory failed at 0x%x" % addr)

--- a/pyOCD/target/target_MKL28Z512xxx7.py
+++ b/pyOCD/target/target_MKL28Z512xxx7.py
@@ -186,14 +186,14 @@ class KL28x(Kinetis):
             logging.info("KL28 is dual core")
 
             # Add second core's AHB-AP.
-            self.core1_ap = ap.AHB_AP(self.dp, 2)
-            self.aps[2] = self.core1_ap
-            self.core1_ap.init(True)
+            core1_ap = ap.AHB_AP(self.dp, 2)
+            core1_ap.init(True)
+            self.add_ap(core1_ap)
 
             # Add second core. It is held in reset until released by software.
-            self.core1 = CortexM(self.link, self.dp, self.core1_ap, self.memory_map, core_num=1)
-            self.cores[1] = self.core1
-            self.core1.init()
+            core1 = CortexM(self.link, self.dp, core1_ap, self.memory_map, core_num=1)
+            core1.init()
+            self.add_core(core1)
 
         # Disable ROM vector table remapping.
         self.write32(RCM_MR, RCM_MR_BOOTROM_MASK)

--- a/test/cortex_test.py
+++ b/test/cortex_test.py
@@ -108,6 +108,9 @@ def cortex_test(board_id):
         test_count = 0
         result = CortexTestResult()
 
+        debugContext = target.getTargetContext()
+        gdbFacade = pyOCD.gdbserver.context_facade.GDBDebugContextFacade(debugContext)
+
         print "\r\n\r\n----- FLASH NEW BINARY BEFORE TEST -----"
         flash.flashBinary(binary_file, addr_bin)
         # Let the target run for a bit so it
@@ -120,7 +123,7 @@ def cortex_test(board_id):
 
 
         print "\r\n\r\n----- TESTING CORTEX-M PERFORMANCE -----"
-        test_time = test_function(board, target.getTResponse)
+        test_time = test_function(board, gdbFacade.getTResponse)
         print("Function getTResponse time: %f" % test_time)
 
         # Step
@@ -135,13 +138,13 @@ def cortex_test(board_id):
         print("Add and remove breakpoint: %f" % test_time)
 
         # getRegisterContext
-        test_time = test_function(board, target.getRegisterContext)
+        test_time = test_function(board, gdbFacade.getRegisterContext)
         print("Function getRegisterContext: %f" % test_time)
 
         # setRegisterContext
-        context = target.getRegisterContext()
+        context = gdbFacade.getRegisterContext()
         def set_register_context():
-            target.setRegisterContext(context)
+            gdbFacade.setRegisterContext(context)
         test_time = test_function(board, set_register_context)
         print("Function setRegisterContext: %f" % test_time)
 
@@ -155,11 +158,11 @@ def cortex_test(board_id):
         # GDB stepping
         def simulate_step():
             target.step()
-            target.getTResponse()
+            gdbFacade.getTResponse()
             target.setBreakpoint(0)
             target.resume()
             target.halt()
-            target.getTResponse()
+            gdbFacade.getTResponse()
             target.removeBreakpoint(0)
         test_time = test_function(board, simulate_step)
         print("Simulated GDB step: %f" % test_time)


### PR DESCRIPTION
Defined the `DebugContext` class. It provides a view to registers and memory on the target. It forms the basic building block of RTOS support, as well as caching and memory filters.

Related to this is a change to refactor the GDB related methods from the `Target` class hierarchy into a new `GDBDebugContextFacade` class. It wraps a debug context and provides methods to transform data to or from GDB-specific forms.