### PR TITLE
Fix two error log related exceptions

### DIFF
--- a/pyOCD/coresight/dap.py
+++ b/pyOCD/coresight/dap.py
@@ -178,7 +178,7 @@ class DebugPort(object):
                     break
                 logging.info("AP#%d IDR = 0x%08x", ap_num, idr)
             except Exception, e:
-                logging.error("Exception reading AP#%d IDR", ap_num, e)
+                logging.error("Exception reading AP#%d IDR: %s", ap_num, repr(e))
                 break
             ap_num += 1
 

--- a/pyOCD/target/family/target_kinetis.py
+++ b/pyOCD/target/family/target_kinetis.py
@@ -63,7 +63,7 @@ class Kinetis(CoreSightTarget):
 
         # check MDM-AP ID
         if self.mdm_ap.idr != self.mdm_idr:
-            logging.error("%s: bad MDM-AP IDR (is 0x%08x, expected 0x%08x)", self.part_number, val, self.mdm_idr)
+            logging.error("%s: bad MDM-AP IDR (is 0x%08x, expected 0x%08x)", self.part_number, self.mdm_ap.idr, self.mdm_idr)
 
         # check for flash security
         isLocked = self.isLocked()


### PR DESCRIPTION
Fixed exceptions raised when logging errors from two places:
1. DebugPort when scanning APs.
2. Kinetis target class when MDM-AP IDR match fails.