### PR TITLE
pyocd-tool improvements

### DIFF
--- a/pyOCD/board/board.py
+++ b/pyOCD/board/board.py
@@ -26,8 +26,8 @@ class Board(object):
     """
     def __init__(self, target, link, frequency=1000000):
         self.link = link
-        self.target = TARGET[target](self.link)
-        self.flash = FLASH[target](self.target)
+        self.target = TARGET[target.lower()](self.link)
+        self.flash = FLASH[target.lower()](self.target)
         self.target.setFlash(self.flash)
         self.debug_clock_frequency = frequency
         self.closed = False

--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -103,6 +103,14 @@ class CoreSightTarget(Target):
     def resume(self):
         return self.selected_core.resume()
 
+    def massErase(self):
+        if self.flash is not None:
+            self.flash.init()
+            self.flash.eraseAll()
+            return True
+        else:
+            return False
+
     def writeMemory(self, addr, value, transfer_size=32):
         return self.selected_core.writeMemory(addr, value, transfer_size)
 

--- a/pyOCD/core/target.py
+++ b/pyOCD/core/target.py
@@ -100,6 +100,9 @@ class Target(object):
     def resume(self):
         raise NotImplementedError()
 
+    def massErase(self):
+        raise NotImplementedError()
+
     def writeMemory(self, addr, value, transfer_size=32):
         raise NotImplementedError()
 

--- a/pyOCD/debug/svd.py
+++ b/pyOCD/debug/svd.py
@@ -44,6 +44,7 @@ class SVDFile(object):
 class SVDLoader(threading.Thread):
     def __init__(self, svdFile, completionCallback):
         super(SVDLoader, self).__init__(name='load-svd')
+        self.daemon = True
         self._svd_location = svdFile
         self._svd_device = None
         self._callback = completionCallback

--- a/pyOCD/tools/flash_tool.py
+++ b/pyOCD/tools/flash_tool.py
@@ -99,6 +99,7 @@ parser.add_argument("-hp", "--hide_progress", action="store_true", help="Don't d
 parser.add_argument("-fp", "--fast_program", action="store_true",
                     help="Use only the CRC of each page to determine if it already has the same data.")
 parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
+parser.add_argument("--mass-erase", action="store_true", help="Mass erase the target device. Only for Kinetis devices.")
 
 # Notes
 # -Currently "--unlock" does nothing since kinetis parts will automatically get unlocked
@@ -168,6 +169,16 @@ def main():
                 chip_erase = True
             elif args.sector_erase:
                 chip_erase = False
+
+            if args.mass_erase:
+                if not isinstance(board.target, pyOCD.target.family.target_kinetis.Kinetis):
+                    print("Device is not a Kinetis; cannot mass erase.")
+                    return
+
+                print("Mass erasing device...")
+                board.target.massErase()
+                print("Done.")
+                return
 
             if not has_file:
                 if chip_erase:

--- a/pyOCD/tools/flash_tool.py
+++ b/pyOCD/tools/flash_tool.py
@@ -99,7 +99,7 @@ parser.add_argument("-hp", "--hide_progress", action="store_true", help="Don't d
 parser.add_argument("-fp", "--fast_program", action="store_true",
                     help="Use only the CRC of each page to determine if it already has the same data.")
 parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
-parser.add_argument("--mass-erase", action="store_true", help="Mass erase the target device. Only for Kinetis devices.")
+parser.add_argument("--mass-erase", action="store_true", help="Mass erase the target device.")
 
 # Notes
 # -Currently "--unlock" does nothing since kinetis parts will automatically get unlocked
@@ -171,13 +171,11 @@ def main():
                 chip_erase = False
 
             if args.mass_erase:
-                if not isinstance(board.target, pyOCD.target.family.target_kinetis.Kinetis):
-                    print("Device is not a Kinetis; cannot mass erase.")
-                    return
-
                 print("Mass erasing device...")
-                board.target.massErase()
-                print("Done.")
+                if board.target.massErase():
+                    print("Successfully erased.")
+                else:
+                    print("Failed.")
                 return
 
             if not has_file:

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -29,7 +29,7 @@ from pyOCD import __version__
 from pyOCD.debug.svd import isCmsisSvdAvailable
 from pyOCD.gdbserver import GDBServer
 from pyOCD.board import MbedBoard
-from pyOCD.utility.cmdline import split_command_line
+from pyOCD.utility.cmdline import (split_command_line, VECTOR_CATCH_CHAR_MAP, convert_vector_catch)
 from pyOCD.pyDAPAccess.dap_access_cmsis_dap import DAPAccessCMSISDAP
 import pyOCD.board.mbed_board
 from pyOCD.pyDAPAccess import DAPAccess
@@ -44,6 +44,18 @@ LEVELS = {
 
 supported_targets = pyOCD.target.TARGET.keys()
 debug_levels = LEVELS.keys()
+
+class InvalidArgumentError(RuntimeError):
+    pass
+
+## @brief Argparse type function to validate the supplied target device name.
+#
+# If the target name is valid, it is returned unmodified to become the --target option's
+# attribute value.
+def validate_target(value):
+    if value.lower() not in supported_targets:
+        raise InvalidArgumentError("invalid target option '{}'".format(value))
+    return value
 
 class GDBServerTool(object):
     def __init__(self):
@@ -66,10 +78,10 @@ class GDBServerTool(object):
         parser.add_argument("--list-targets", action="store_true", dest="list_targets", default=False, help="List all available targets.")
         parser.add_argument("--json", action="store_true", dest="output_json", default=False, help="Output lists in JSON format. Only applies to --list and --list-targets.")
         parser.add_argument("-d", "--debug", dest="debug_level", choices=debug_levels, default='info', help="Set the level of system logging output. Supported choices are: " + ", ".join(debug_levels), metavar="LEVEL")
-        parser.add_argument("-t", "--target", dest="target_override", default=None, help="Override target to debug.", metavar="TARGET")
-        parser.add_argument("-n", "--nobreak", dest="break_at_hardfault", default=True, action="store_false", help="Disable halt at hardfault handler. (Deprecated)")
-        parser.add_argument("-r", "--reset-break", dest="break_on_reset", default=False, action="store_true", help="Halt the target when reset. (Deprecated)")
-        parser.add_argument("-C", "--vector-catch", default='', help="Select enabled vector catch options, one letter per enabled source in any order. (h=hard fault, b=bus fault, m=mem fault, i=irq err, s=state err, c=check err, p=nocp, r=reset, a=all, n=none)")
+        parser.add_argument("-t", "--target", dest="target_override", default=None, help="Override target to debug.", metavar="TARGET", type=validate_target)
+        parser.add_argument("-n", "--nobreak", dest="no_break_at_hardfault", action="store_true", help="Disable halt at hardfault handler. (Deprecated)")
+        parser.add_argument("-r", "--reset-break", dest="break_on_reset", action="store_true", help="Halt the target when reset. (Deprecated)")
+        parser.add_argument("-C", "--vector-catch", default='h', help="Enable vector catch sources, one letter per enabled source in any order, or 'all' or 'none'. (h=hard fault, b=bus fault, m=mem fault, i=irq err, s=state err, c=check err, p=nocp, r=reset, a=all, n=none). (Default is hard fault.)")
         parser.add_argument("-s", "--step-int", dest="step_into_interrupt", default=False, action="store_true", help="Allow single stepping to step into interrupts.")
         parser.add_argument("-f", "--frequency", dest="frequency", default=1000000, type=int, help="Set the SWD clock frequency in Hz.")
         parser.add_argument("-o", "--persist", dest="persist", default=False, action="store_true", help="Keep GDB server running even after remote has detached.")
@@ -87,6 +99,7 @@ class GDBServerTool(object):
         parser.add_argument("-G", "--gdb-syscall", dest="semihost_use_syscalls", action="store_true", help="Use GDB syscalls for semihosting file I/O.")
         parser.add_argument("-c", "--command", dest="commands", metavar="CMD", action='append', nargs='+', help="Run command (OpenOCD compatibility).")
         parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
+        self.parser = parser
         return parser
 
     def get_chip_erase(self, args):
@@ -98,13 +111,29 @@ class GDBServerTool(object):
             chip_erase = False
         return chip_erase
 
+    def get_vector_catch(self, args):
+        vector_catch = args.vector_catch.lower()
+
+        # Handle deprecated options.
+        if args.break_on_reset:
+            vector_catch += 'r'
+        if args.no_break_at_hardfault:
+            # Must handle all case specially since we can't just filter 'h'.
+            if vector_catch == 'all' or 'a' in vector_catch:
+                vector_catch = 'bmiscpr' # Does not include 'h'.
+            else:
+                vector_catch = vector_catch.replace('h', '')
+
+        try:
+            return convert_vector_catch(vector_catch)
+        except ValueError as e:
+            # Reraise as an invalid argument error.
+            raise InvalidArgumentError(e.message)
 
     def get_gdb_server_settings(self, args):
         # Set gdb server settings
         return {
-            'break_at_hardfault' : args.break_at_hardfault,
             'step_into_interrupt' : args.step_into_interrupt,
-            'break_on_reset' : args.break_on_reset,
             'persist' : args.persist,
             'soft_bkpt_as_hard' : args.soft_bkpt_as_hard,
             'chip_erase': self.get_chip_erase(args),
@@ -115,7 +144,7 @@ class GDBServerTool(object):
             'telnet_port' : args.telnet_port,
             'semihost_use_syscalls' : args.semihost_use_syscalls,
             'serve_local_only' : args.serve_local_only,
-            'vector_catch' : args.vector_catch,
+            'vector_catch' : self.get_vector_catch(args),
         }
 
 
@@ -248,54 +277,45 @@ class GDBServerTool(object):
             for t in supported_targets:
                 print t
 
-    def validate_target(self):
-        if self.args.target_override is None:
-            return
-
-        if self.args.target_override.lower() not in supported_targets:
-            targetList = "Available targets: " + ", ".join(supported_targets)
-            targetList = "\n".join(textwrap.wrap(targetList))
-            msg = "Error: unsupported target '%s' specified" % self.args.target_override
-            msg += "\n\n" + targetList
-            print msg
-            sys.exit(1)
-
     def run(self, args=None):
-        self.args = self.build_parser().parse_args(args)
-        self.validate_target()
-        self.gdb_server_settings = self.get_gdb_server_settings(self.args)
-        self.setup_logging(self.args)
-        DAPAccess.set_args(self.args.daparg)
+        try:
+            self.args = self.build_parser().parse_args(args)
+            self.gdb_server_settings = self.get_gdb_server_settings(self.args)
+            self.setup_logging(self.args)
+            DAPAccess.set_args(self.args.daparg)
 
-        self.process_commands(self.args.commands)
+            self.process_commands(self.args.commands)
 
-        gdb = None
-        if self.args.list_all == True:
-            self.list_boards()
-        elif self.args.list_targets == True:
-            self.list_targets()
-        else:
-            try:
-                board_selected = MbedBoard.chooseBoard(
-                    board_id=self.args.board_id,
-                    target_override=self.args.target_override,
-                    frequency=self.args.frequency)
-                with board_selected as board:
-                    gdb = GDBServer(board, self.args.port_number, self.gdb_server_settings)
-                    while gdb.isAlive():
-                        gdb.join(timeout=0.5)
-            except KeyboardInterrupt:
-                if gdb != None:
-                    gdb.stop()
-            except Exception as e:
-                print "uncaught exception: %s" % e
-                traceback.print_exc()
-                if gdb != None:
-                    gdb.stop()
-                return 1
+            gdb = None
+            if self.args.list_all == True:
+                self.list_boards()
+            elif self.args.list_targets == True:
+                self.list_targets()
+            else:
+                try:
+                    board_selected = MbedBoard.chooseBoard(
+                        board_id=self.args.board_id,
+                        target_override=self.args.target_override,
+                        frequency=self.args.frequency)
+                    with board_selected as board:
+                        gdb = GDBServer(board, self.args.port_number, self.gdb_server_settings)
+                        while gdb.isAlive():
+                            gdb.join(timeout=0.5)
+                except KeyboardInterrupt:
+                    if gdb != None:
+                        gdb.stop()
+                except Exception as e:
+                    print "uncaught exception: %s" % e
+                    traceback.print_exc()
+                    if gdb != None:
+                        gdb.stop()
+                    return 1
 
-        # Successful exit.
-        return 0
+            # Successful exit.
+            return 0
+        except InvalidArgumentError as e:
+            self.parser.error(e)
+            return 1
 
 def main():
     sys.exit(GDBServerTool().run())

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -62,7 +62,7 @@ class GDBServerTool(object):
         parser.add_argument("--list-targets", action="store_true", dest="list_targets", default=False, help="List all available targets.")
         parser.add_argument("--json", action="store_true", dest="output_json", default=False, help="Output lists in JSON format. Only applies to --list and --list-targets.")
         parser.add_argument("-d", "--debug", dest="debug_level", choices=debug_levels, default='info', help="Set the level of system logging output. Supported choices are: " + ", ".join(debug_levels), metavar="LEVEL")
-        parser.add_argument("-t", "--target", dest="target_override", choices=supported_targets, default=None, help="Override target to debug.  Supported targets are: " + ", ".join(supported_targets), metavar="TARGET")
+        parser.add_argument("-t", "--target", dest="target_override", default=None, help="Override target to debug.  Supported targets are: " + ", ".join(supported_targets), metavar="TARGET")
         parser.add_argument("-n", "--nobreak", dest="break_at_hardfault", default=True, action="store_false", help="Disable halt at hardfault handler.")
         parser.add_argument("-r", "--reset-break", dest="break_on_reset", default=False, action="store_true", help="Halt the target when reset.")
         parser.add_argument("-C", "--vector-catch", default='', help="Select enabled vector catch options, one letter per enabled source in any order. (h=hard fault, b=bus fault, m=mem fault, i=irq err, s=state err, c=check err, p=nocp, r=reset, a=all, n=none)")

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -22,7 +22,6 @@ import traceback
 import argparse
 import json
 import pkg_resources
-import textwrap
 
 import pyOCD.board.mbed_board
 from pyOCD import __version__

--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -106,7 +106,7 @@ COMMAND_INFO = {
             },
         'reg' : {
             'aliases' : [],
-            'args' : "[REG]",
+            'args' : "[-f] [REG]",
             'help' : "Print all or one register"
             },
         'wreg' : {
@@ -128,11 +128,6 @@ COMMAND_INFO = {
             'aliases' : [],
             'args' : "ADDR FILENAME",
             "help" : "Load a binary file to an address in memory"
-            },
-        'setreset' : {
-            'aliases' : [],
-            'args' : "0/1",
-            'help' : "Set nRESET signal state"
             },
         'read8' : {
             'aliases' : ['read', 'r', 'rb'],
@@ -204,16 +199,6 @@ COMMAND_INFO = {
             'args' : "[-c/--center] ADDR [LEN]",
             'help' : "Disassemble instructions at an address",
             'extra_help' : "Only available if the capstone library is installed."
-            },
-        'log' : {
-            'aliases' : [],
-            'args' : "LEVEL",
-            'help' : "Set log level to one of debug, info, warning, error, critical"
-            },
-        'clock' : {
-            'aliases' : [],
-            'args' : "KHZ",
-            'help' : "Set SWD or JTAG clock frequency"
             },
         'exit' : {
             'aliases' : ['quit'],
@@ -294,6 +279,18 @@ OPTION_HELP = {
         'step-into-interrupt' : {
             'aliases' : ['si'],
             'help' : "Set whether to enable or disable interrupts when single stepping. Set to 1 to enable."
+            },
+        'nreset' : {
+            'aliases' : [],
+            'help' : "Set nRESET signal state. Accepts a value of 0 or 1."
+            },
+        'log' : {
+            'aliases' : [],
+            'help' : "Set log level to one of debug, info, warning, error, critical"
+            },
+        'clock' : {
+            'aliases' : [],
+            'help' : "Set SWD or JTAG clock frequency"
             },
         }
 
@@ -436,7 +433,6 @@ class PyOCDTool(object):
                 'reset' :   self.handle_reset,
                 'savemem' : self.handle_savemem,
                 'loadmem' : self.handle_loadmem,
-                'setreset' :  self.handle_setreset,
                 'read' :    self.handle_read8,
                 'read8' :   self.handle_read8,
                 'read16' :  self.handle_read16,
@@ -468,8 +464,6 @@ class PyOCDTool(object):
                 'lsbreak' : self.handle_list_breakpoints,
                 'disasm' :  self.handle_disasm,
                 'd' :       self.handle_disasm,
-                'log' :     self.handle_log,
-                'clock' :   self.handle_clock,
                 'exit' :    self.handle_exit,
                 'quit' :    self.handle_exit,
                 'core' :    self.handle_core,
@@ -499,6 +493,9 @@ class PyOCDTool(object):
                 'vc' :                  self.handle_set_vectorcatch,
                 'step-into-interrupt' : self.handle_set_step_interrupts,
                 'si' :                  self.handle_set_step_interrupts,
+                'nreset' :              self.handle_set_nreset,
+                'log' :                 self.handle_set_log,
+                'clock' :               self.handle_set_clock,
             }
 
     def get_args(self):
@@ -737,7 +734,7 @@ class PyOCDTool(object):
         else:
             self.target.reset()
 
-    def handle_setreset(self, args):
+    def handle_set_nreset(self, args):
         if len(args) != 1:
             print "Missing reset state"
             return
@@ -933,7 +930,7 @@ class PyOCDTool(object):
             for i, addr in enumerate(bps):
                 print "%d: 0x%08x" % (i, addr)
 
-    def handle_log(self, args):
+    def handle_set_log(self, args):
         if len(args) < 1:
             print "Error: no log level provided"
             return 1
@@ -942,7 +939,7 @@ class PyOCDTool(object):
             return 1
         logging.getLogger().setLevel(LEVELS[args[0].lower()])
 
-    def handle_clock(self, args):
+    def handle_set_clock(self, args):
         if len(args) < 1:
             print "Error: no clock frequency provided"
             return 1

--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -254,7 +254,6 @@ COMMAND_INFO = {
             'aliases' : [],
             'args' : "INFO",
             'help' : "Report info about the target",
-            'extra_help' : "Available info names: map, peripherals, uid, cores, target.",
             },
         'set' : {
             'aliases' : [],

--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -75,11 +75,6 @@ COMMAND_INFO = {
             'args' : "",
             'help' : "Unlock security on the target"
             },
-        'info' : {
-            'aliases' : ['i'],
-            'args' : "",
-            'help' : "Display target type and IDs"
-            },
         'status' : {
             'aliases' : ['stat'],
             'args' : "",
@@ -100,33 +95,48 @@ COMMAND_INFO = {
             'args' : "[-h/--halt]",
             'help' : "Reset the target"
             },
+        'savemem' : {
+            'aliases' : [],
+            'args' : "ADDR LEN FILENAME",
+            "help" : "Save a range of memory to a binary file"
+            },
+        'loadmem' : {
+            'aliases' : [],
+            'args' : "ADDR FILENAME",
+            "help" : "Load a binary file to an address in memory"
+            },
+        'setreset' : {
+            'aliases' : [],
+            'args' : "0/1",
+            'help' : "Set nRESET signal state"
+            },
         'read8' : {
-            'aliases' : ['read', 'r'],
+            'aliases' : ['read', 'r', 'rb'],
             'args' : "ADDR [LEN]",
             'help' : "Read 8-bit bytes"
             },
         'read16' : {
-            'aliases' : ['r16'],
+            'aliases' : ['r16', 'rh'],
             'args' : "ADDR [LEN]",
             'help' : "Read 16-bit halfwords"
             },
         'read32' : {
-            'aliases' : ['r32'],
+            'aliases' : ['r32', 'rw'],
             'args' : "ADDR [LEN]",
             'help' : "Read 32-bit words"
             },
         'write8' : {
-            'aliases' : ['write', 'w'],
+            'aliases' : ['write', 'w', 'wb'],
             'args' : "ADDR DATA...",
             'help' : "Write 8-bit bytes"
             },
         'write16' : {
-            'aliases' : ['w16'],
+            'aliases' : ['w16', 'wh'],
             'args' : "ADDR DATA...",
             'help' : "Write 16-bit halfwords"
             },
         'write32' : {
-            'aliases' : ['w32'],
+            'aliases' : ['w32', 'ww'],
             'args' : "ADDR DATA...",
             'help' : "Write 32-bit words"
             },
@@ -145,6 +155,21 @@ COMMAND_INFO = {
             'args' : "",
             'help' : "Halt the target"
             },
+        'break' : {
+            'aliases' : [],
+            'args' : "ADDR",
+            'help' : "Set a breakpoint address"
+            },
+        'rmbreak' : {
+            'aliases' : [],
+            'args' : "ADDR",
+            'help' : "Remove a breakpoint"
+            },
+        'lsbreak' : {
+            'aliases' : [],
+            'args' : "",
+            'help' : "List breakpoints"
+            },
         'help' : {
             'aliases' : ['?'],
             'args' : "[CMD]",
@@ -153,7 +178,8 @@ COMMAND_INFO = {
         'disasm' : {
             'aliases' : ['d'],
             'args' : "[-c/--center] ADDR [LEN]",
-            'help' : "Disassemble instructions at an address"
+            'help' : "Disassemble instructions at an address",
+            'extra_help' : "Only available if the capstone library is installed."
             },
         'log' : {
             'aliases' : [],
@@ -174,6 +200,37 @@ COMMAND_INFO = {
             'aliases' : [],
             'args' : "[NUM]",
             'help' : "Select CPU core by number or print selected core"
+            },
+        'readdp' : {
+            'aliases' : ['rdp'],
+            'args' : "ADDR",
+            'help' : "Read DP register"
+            },
+        'writedp' : {
+            'aliases' : ['wdp'],
+            'args' : "ADDR DATA",
+            'help' : "Read DP register"
+            },
+        'readap' : {
+            'aliases' : ['rap'],
+            'args' : "[APSEL] ADDR",
+            'help' : "Read AP register"
+            },
+        'writeap' : {
+            'aliases' : ['wap'],
+            'args' : "[APSEL] ADDR DATA",
+            'help' : "Read AP register"
+            },
+        'reinit' : {
+            'aliases' : [],
+            'args' : "",
+            'help' : "Reinitialize the target object"
+            },
+        'show' : {
+            'aliases' : [],
+            'args' : "INFO",
+            'help' : "Report info about the target",
+            'extra_help' : "",
             },
         }
 
@@ -260,19 +317,18 @@ class PyOCDConsole(object):
 
     def process_command(self, cmd):
         try:
-            if (cmd.strip())[0] == '$':
+            firstChar = (cmd.strip())[0]
+            if firstChar in '$!':
                 cmd = cmd[1:].strip()
-                self.tool.handle_python(cmd)
+                if firstChar == '$':
+                    self.tool.handle_python(cmd)
+                elif firstChar == '!':
+                    os.system(cmd)
                 return
 
-            args = cmd.split()
+            args = pyOCD.utility.cmdline.split_command_line(cmd)
             cmd = args[0].lower()
             args = args[1:]
-
-            # Handle help.
-            if cmd in ['?', 'help']:
-                self.show_help(args)
-                return
 
             # Handle register name as command.
             if cmd in pyOCD.coresight.cortex_m.CORE_REGISTER:
@@ -290,30 +346,16 @@ class PyOCDConsole(object):
         except ValueError:
             print "Error: invalid argument"
             traceback.print_exc()
-        except DAPAccess.TransferError:
-            print "Error: transfer failed"
+        except DAPAccess.TransferError as e:
+            print "Error:", e
             traceback.print_exc()
         except ToolError as e:
             print "Error:", e
+        except ToolExitException:
+            raise
         except Exception as e:
             print "Unexpected exception:", e
             traceback.print_exc()
-
-    def show_help(self, args):
-        if not args:
-            self.list_commands()
-
-    def list_commands(self):
-        cmds = sorted(COMMAND_INFO.keys())
-        print "Commands:\n---------"
-        for cmd in cmds:
-            info = COMMAND_INFO[cmd]
-            print "{cmd:<25} {args:<20} {help}".format(
-                cmd=', '.join(sorted([cmd] + info['aliases'])),
-                **info)
-        print
-        print "All register names are also available as commands that print the register's value."
-        print "Any ADDR or LEN argument will accept a register name."
 
 class PyOCDTool(object):
     def __init__(self):
@@ -323,41 +365,69 @@ class PyOCDTool(object):
                 'list' :    self.handle_list,
                 'erase' :   self.handle_erase,
                 'unlock' :  self.handle_unlock,
-                'info' :    self.handle_info,
-                'i' :       self.handle_info,
                 'status' :  self.handle_status,
                 'stat' :    self.handle_status,
                 'reg' :     self.handle_reg,
                 'wreg' :    self.handle_write_reg,
                 'reset' :   self.handle_reset,
+                'savemem' : self.handle_savemem,
+                'loadmem' : self.handle_loadmem,
+                'setreset' :  self.handle_setreset,
                 'read' :    self.handle_read8,
                 'read8' :   self.handle_read8,
                 'read16' :  self.handle_read16,
                 'read32' :  self.handle_read32,
                 'r' :       self.handle_read8,
+                'rb' :      self.handle_read8,
                 'r16' :     self.handle_read16,
+                'rh' :      self.handle_read16,
                 'r32' :     self.handle_read32,
+                'rw' :      self.handle_read32,
                 'write' :   self.handle_write8,
                 'write8' :  self.handle_write8,
                 'write16' : self.handle_write16,
                 'write32' : self.handle_write32,
                 'w' :       self.handle_write8,
+                'wb' :      self.handle_write8,
                 'w16' :     self.handle_write16,
+                'wh' :      self.handle_write16,
                 'w32' :     self.handle_write32,
+                'ww' :      self.handle_write32,
                 'go' :      self.handle_go,
                 'g' :       self.handle_go,
                 'step' :    self.handle_step,
                 's' :       self.handle_step,
                 'halt' :    self.handle_halt,
                 'h' :       self.handle_halt,
+                'break' :   self.handle_breakpoint,
+                'rmbreak' : self.handle_remove_breakpoint,
+                'lsbreak' : self.handle_list_breakpoints,
                 'disasm' :  self.handle_disasm,
                 'd' :       self.handle_disasm,
-                'map' :     self.handle_memory_map,
                 'log' :     self.handle_log,
                 'clock' :   self.handle_clock,
                 'exit' :    self.handle_exit,
                 'quit' :    self.handle_exit,
                 'core' :    self.handle_core,
+                'readdp' :  self.handle_readdp,
+                'writedp' : self.handle_writedp,
+                'readap' :  self.handle_readap,
+                'writeap' : self.handle_writeap,
+                'rdp' :     self.handle_readdp,
+                'wdp' :     self.handle_writedp,
+                'rap' :     self.handle_readap,
+                'wap' :     self.handle_writeap,
+                'reinit' :  self.handle_reinit,
+                'show' :    self.handle_show,
+                'help' :    self.handle_help,
+                '?' :       self.handle_help,
+            }
+        self.info_list = {
+                'map' :         self.handle_show_map,
+                'peripherals' : self.handle_show_peripherals,
+                'uid' :         self.handle_show_unique_id,
+                'cores' :       self.handle_show_cores,
+                'target' :      self.handle_show_target,
             }
 
     def get_args(self):
@@ -368,6 +438,7 @@ class PyOCDTool(object):
         parser = argparse.ArgumentParser(description='Target inspection utility', epilog=epi)
         parser.add_argument('--version', action='version', version=__version__)
         parser.add_argument("-H", "--halt", action="store_true", help="Halt core upon connect.")
+        parser.add_argument("-N", "--no-init", action="store_true", help="Do not init debug system.")
         parser.add_argument('-k', "--clock", metavar='KHZ', default=DEFAULT_CLOCK_FREQ_KHZ, type=int, help="Set SWD speed in kHz. (Default 1 MHz.)")
         parser.add_argument('-b', "--board", action='store', metavar='ID', help="Use the specified board. ")
         parser.add_argument('-t', "--target", action='store', metavar='TARGET', help="Override target.")
@@ -411,7 +482,14 @@ class PyOCDTool(object):
             self.board.target.setAutoUnlock(False)
             self.board.target.setHaltOnConnect(False)
             try:
-                self.board.init()
+                if not self.args.no_init:
+                    self.board.init()
+            except DAPAccess.TransferFaultError as e:
+                if not self.board.target.isLocked():
+                    print "Transfer fault while initing board: %s" % e
+                    traceback.print_exc()
+                    self.exitCode = 1
+                    return self.exitCode
             except Exception as e:
                 print "Exception while initing board: %s" % e
                 traceback.print_exc()
@@ -434,20 +512,18 @@ class PyOCDTool(object):
 
             # Handle a device with flash security enabled.
             self.didErase = False
-            if self.target.isLocked() and self.cmd != 'unlock':
-                print "Error: Target is locked, cannot complete operation. Use unlock command to mass erase and unlock."
-                if self.cmd and self.cmd not in ['reset', 'info']:
-                    return 1
+            if not self.args.no_init and self.target.isLocked() and self.cmd != 'unlock':
+                print "Warning: Target is locked, limited operations available. Use unlock command to mass erase and unlock."
 
             # If no command, enter interactive mode.
             if not self.cmd:
-                # Say what we're connected to.
-                print "Connected to %s [%s]: %s" % (self.target.part_number,
-                    CORE_STATUS_DESC[self.target.getState()], self.board.getUniqueID())
-
-                # Remove list command that disrupts the connection.
-                self.command_list.pop('list')
-                COMMAND_INFO.pop('list')
+                if not self.args.no_init:
+                    try:
+                        # Say what we're connected to.
+                        print "Connected to %s [%s]: %s" % (self.target.part_number,
+                            CORE_STATUS_DESC[self.target.getState()], self.board.getUniqueID())
+                    except DAPAccess.TransferFaultError:
+                        pass
 
                 # Run the command line.
                 console = PyOCDConsole(self)
@@ -479,26 +555,17 @@ class PyOCDTool(object):
     def handle_list(self, args):
         MbedBoard.listConnectedBoards()
 
-    def handle_info(self, args):
-        print "Target:       %s" % self.target.part_number
-        print "Unique ID:    %s" % self.board.getUniqueID()
-        print "DAP IDCODE:   0x%08x" % self.target.readIDCode()
-        print "Cores:        %d" % len(self.target.cores)
-        for i, c in enumerate(self.target.cores):
-            core = self.target.cores[c]
-            print "Core %d type:  %s" % (i, pyOCD.coresight.cortex_m.CORE_TYPE_NAME[core.core_type])
-
     def handle_status(self, args):
         if self.target.isLocked():
             print "Security:       Locked"
         else:
             print "Security:       Unlocked"
         if isinstance(self.target, target_kinetis.Kinetis):
-            print "MDM-AP Control: 0x%08x" % self.target.mdm_ap.read_reg(target_kinetis.MDM_CTRL)
             print "MDM-AP Status:  0x%08x" % self.target.mdm_ap.read_reg(target_kinetis.MDM_STATUS)
-        for i, c in enumerate(self.target.cores):
-            core = self.target.cores[c]
-            print "Core %d status:  %s" % (i, CORE_STATUS_DESC[core.getState()])
+        if not self.target.isLocked():
+            for i, c in enumerate(self.target.cores):
+                core = self.target.cores[c]
+                print "Core %d status:  %s" % (i, CORE_STATUS_DESC[core.getState()])
 
     def handle_reg(self, args):
         # If there are no args, print all register values.
@@ -544,11 +611,43 @@ class PyOCDTool(object):
             raise ToolError("No value specified")
 
         reg = args[0].lower()
-        if reg.startswith('s'):
-            value = float(args[1])
+        if reg in pyOCD.coresight.cortex_m.CORE_REGISTER:
+            if reg.startswith('s'):
+                value = float(args[1])
+            else:
+                value = self.convert_value(args[1])
+            self.target.writeCoreRegister(reg, value)
         else:
             value = self.convert_value(args[1])
-        self.target.writeCoreRegister(reg, value)
+            subargs = reg.split('.')
+            if len(subargs) < 2:
+                raise ToolError("no register specified")
+            if self.peripherals.has_key(subargs[0]):
+                p = self.peripherals[subargs[0]]
+                r = [x for x in p.registers if x.name.lower() == subargs[1]]
+                if len(r):
+                    r = r[0]
+                    addr = p.base_address + r.address_offset
+                    if len(subargs) == 2:
+                        print "writing 0x%x to 0x%x:%d (%s)" % (value, addr, r.size, r.name)
+                        self.target.writeMemory(addr, value, r.size)
+                    elif len(subargs) == 3:
+                        f = [x for x in r.fields if x.name.lower() == subargs[2]]
+                        if len(f):
+                            f = f[0]
+                            msb = f.bit_offset + f.bit_width - 1
+                            lsb = f.bit_offset
+                            originalValue = self.target.readMemory(addr, r.size)
+                            value = mask.bfi(originalValue, msb, lsb, value)
+                            print "writing 0x%x to 0x%x[%d:%d]:%d (%s.%s)" % (value, addr, msb, lsb, r.size, r.name, f.name)
+                            self.target.writeMemory(addr, value, r.size)
+                    else:
+                        raise ToolError("too many dots")
+                    self._dump_peripheral_register(p, r, True)
+                else:
+                    raise ToolError("invalid register '%s' for %s" % (subargs[1], p.name))
+            else:
+                raise ToolError("invalid peripheral '%s'" % (subargs[0]))
 
     @cmdoptions([make_option('-h', "--halt", action="store_true")])
     def handle_reset(self, args, other):
@@ -563,6 +662,14 @@ class PyOCDTool(object):
                 print "Successfully halted device on reset"
         else:
             self.target.reset()
+
+    def handle_setreset(self, args):
+        if len(args) != 1:
+            print "Missing reset state"
+            return
+        state = int(args[0], base=0)
+        print "nRESET = %d" % (state)
+        self.target.dp.assert_reset((state == 0))
 
     @cmdoptions([make_option('-c', "--center", action="store_true")])
     def handle_disasm(self, args, other):
@@ -603,13 +710,39 @@ class PyOCDTool(object):
     def handle_write32(self, args):
         return self.do_write(args, 32)
 
+    def handle_savemem(self, args):
+        if len(args) < 3:
+            print "Error: missing argument"
+            return 1
+        addr = self.convert_value(args[0])
+        count = self.convert_value(args[1])
+        filename = args[2]
+
+        data = bytearray(self.target.readBlockMemoryUnaligned8(addr, count))
+
+        with open(filename, 'wb') as f:
+            f.write(data)
+            print "Saved %d bytes to %s" % (count, filename)
+
+    def handle_loadmem(self, args):
+        if len(args) < 2:
+            print "Error: missing argument"
+            return 1
+        addr = self.convert_value(args[0])
+        filename = args[1]
+
+        with open(filename, 'rb') as f:
+            data = bytearray(f.read())
+            self.target.writeBlockMemoryUnaligned8(addr, data)
+            print "Loaded %d bytes to 0x%08x" % (len(data), addr)
+
     def do_read(self, args, width):
         if len(args) == 0:
             print "Error: no address specified"
             return 1
         addr = self.convert_value(args[0])
         if len(args) < 2:
-            count = 4
+            count = width // 8
         else:
             count = self.convert_value(args[1])
 
@@ -654,11 +787,11 @@ class PyOCDTool(object):
     def handle_erase(self, args):
         if len(args) < 1:
             raise ToolError("invalid arguments")
-        addr = int(args[0], base=0)
+        addr = self.convert_value(args[0])
         if len(args) < 2:
             count = 1
         else:
-            count = int(args[1], base=0)
+            count = self.convert_value(args[1])
         self.flash.init()
         while count:
             info = self.flash.getPageInfo(addr)
@@ -694,8 +827,37 @@ class PyOCDTool(object):
         else:
             print "Successfully halted device"
 
-    def handle_memory_map(self, args):
-        self.print_memory_map()
+    def handle_breakpoint(self, args):
+        if len(args) < 1:
+            raise ToolError("no breakpoint address provided")
+        addr = self.convert_value(args[0])
+        if self.target.setBreakpoint(addr):
+            self.target.selected_core.bp_manager.flush()
+            print "Set breakpoint at 0x%08x" % addr
+        else:
+            print "Failed to set breakpoint at 0x%08x" % addr
+
+    def handle_remove_breakpoint(self, args):
+        if len(args) < 1:
+            raise ToolError("no breakpoint address provided")
+        addr = self.convert_value(args[0])
+        try:
+            type = self.target.getBreakpointType(addr)
+            self.target.removeBreakpoint(addr)
+            self.target.selected_core.bp_manager.flush()
+            print "Removed breakpoint at 0x%08x" % addr
+        except:
+            print "Failed to remove breakpoint at 0x%08x" % addr
+
+    def handle_list_breakpoints(self, args):
+        availableBpCount = self.target.selected_core.availableBreakpoint()
+        print "%d hardware breakpoints available" % availableBpCount
+        bps = self.target.selected_core.bp_manager.get_breakpoints()
+        if not len(bps):
+            print "No breakpoints installed"
+        else:
+            for i, addr in enumerate(bps):
+                print "%d: 0x%08x" % (i, addr)
 
     def handle_log(self, args):
         if len(args) < 1:
@@ -711,7 +873,7 @@ class PyOCDTool(object):
             print "Error: no clock frequency provided"
             return 1
         try:
-            freq_Hz = int(args[0]) * 1000
+            freq_Hz = self.convert_value(args[0]) * 1000
         except:
             print "Error: invalid frequency"
             return 1
@@ -758,6 +920,127 @@ class PyOCDTool(object):
         core = int(args[0], base=0)
         self.target.select_core(core)
         print "Selected core %d" % core
+
+    def handle_readdp(self, args):
+        if len(args) < 1:
+            print "Missing DP address"
+            return
+        addr_int = self.convert_value(args[0])
+        regs = { 0:DAPAccess.REG.DP_0x0,
+                 4:DAPAccess.REG.DP_0x4,
+                 8:DAPAccess.REG.DP_0x8,
+                 0xc:DAPAccess.REG.DP_0xC }
+        addr = regs[addr_int]
+        result = self.target.dp.read_reg(addr)
+        print "DP register 0x%x = 0x%08x" % (addr_int, result)
+
+    def handle_writedp(self, args):
+        if len(args) < 1:
+            print "Missing DP address"
+            return
+        if len(args) < 2:
+            print "Missing value"
+            return
+        addr_int = self.convert_value(args[0])
+        regs = { 0:DAPAccess.REG.DP_0x0,
+                 4:DAPAccess.REG.DP_0x4,
+                 8:DAPAccess.REG.DP_0x8,
+                 0xc:DAPAccess.REG.DP_0xC }
+        addr = regs[addr_int]
+        data = self.convert_value(args[1])
+        self.target.dp.write_reg(addr, data)
+
+    def handle_readap(self, args):
+        if len(args) < 1:
+            print "Missing AP address"
+            return
+        if len(args) == 1:
+            addr = self.convert_value(args[0])
+        elif len(args) == 2:
+            addr = (self.convert_value(args[0]) << 24) | self.convert_value(args[1])
+        result = self.target.dp.readAP(addr)
+        print "AP register 0x%x = 0x%08x" % (addr, result)
+
+    def handle_writeap(self, args):
+        if len(args) < 1:
+            print "Missing AP address"
+            return
+        if len(args) < 2:
+            print "Missing value"
+            return
+        if len(args) == 2:
+            addr = self.convert_value(args[0])
+            data_arg = 1
+        elif len(args) == 3:
+            addr = (self.convert_value(args[0]) << 24) | self.convert_value(args[1])
+            data_arg = 2
+        data = self.convert_value(args[data_arg])
+        self.target.dp.writeAP(addr, data)
+
+    def handle_reinit(self, args):
+        self.target.init()
+
+    def handle_show(self, args):
+        if len(args) < 1:
+            raise ToolError("missing info name argument")
+        infoName = args[0]
+        try:
+            self.info_list[infoName](args[1:])
+        except KeyError:
+            raise ToolError("unkown info name '%s'" % infoName)
+
+    def handle_show_unique_id(self, args):
+        print "Unique ID:    %s" % self.board.getUniqueID()
+
+    def handle_show_target(self, args):
+        print "Target:       %s" % self.target.part_number
+        print "DAP IDCODE:   0x%08x" % self.target.readIDCode()
+
+    def handle_show_cores(self, args):
+        if self.target.isLocked():
+            print "Target is locked"
+        else:
+            print "Cores:        %d" % len(self.target.cores)
+            for i, c in enumerate(self.target.cores):
+                core = self.target.cores[c]
+                print "Core %d type:  %s" % (i, pyOCD.coresight.cortex_m.CORE_TYPE_NAME[core.core_type])
+
+    def handle_show_map(self, args):
+        print "Region          Start         End                 Size    Blocksize"
+        for region in self.target.getMemoryMap():
+            print "{:<15} {:#010x}    {:#010x}    {:#10x}    {}".format(region.name, region.start, region.end, region.length, region.blocksize if region.isFlash else '-')
+
+    def handle_show_peripherals(self, args):
+        for periph in sorted(self.peripherals.values(), key=lambda x:x.base_address):
+            print "0x%08x: %s" % (periph.base_address, periph.name)
+
+    def handle_help(self, args):
+        if not args:
+            self.list_commands()
+        else:
+            cmd = args[0]
+            for name, info in COMMAND_INFO.iteritems():
+                if cmd == name or cmd in info['aliases']:
+                    print "Usage: {cmd} {args}".format(cmd=cmd, args=info['args'])
+                    if len(info['aliases']):
+                        print "Aliases:", ", ".join(info['aliases'])
+                    print info['help']
+                    if info.has_key('extra_help'):
+                        print info['extra_help']
+
+    def list_commands(self):
+        cmds = sorted(COMMAND_INFO.keys())
+        print "Commands:\n---------"
+        for cmd in cmds:
+            info = COMMAND_INFO[cmd]
+            print "{cmd:<25} {args:<20} {help}".format(
+                cmd=', '.join(sorted([cmd] + info['aliases'])),
+                **info)
+        print
+        print "All register names are also available as commands that print the register's value."
+        print "Any ADDR or LEN argument will accept a register name."
+        print "Prefix line with $ to execute a Python expression."
+        print "Prefix line with ! to execute a shell command."
 
     def isFlashWrite(self, addr, width, data):
         mem_map = self.board.target.getMemoryMap()
@@ -861,11 +1144,6 @@ class PyOCDTool(object):
                 else:
                     f_value_enum_str = ""
                 print "  %s[%s] = %s (%s)%s" % (f.name, bits_str, f_value_str, f_value_bin_str, f_value_enum_str)
-
-    def print_memory_map(self):
-        print "Region          Start         End           Blocksize"
-        for region in self.target.getMemoryMap():
-            print "{:<15} {:#010x}    {:#010x}    {}".format(region.name, region.start, region.end, region.blocksize if region.isFlash else '-')
 
     def print_disasm(self, code, startAddr):
         if not isCapstoneAvailable:

--- a/pyOCD/utility/cmdline.py
+++ b/pyOCD/utility/cmdline.py
@@ -15,6 +15,8 @@
  limitations under the License.
 """
 
+from ..core.target import Target
+
 ## @brief Split command line by whitespace, supporting quoted strings.
 #
 # Accepts
@@ -49,4 +51,38 @@ def split_command_line(cmd_line):
         if word:
             result.append(word)
     return result
+
+## Map of vector char characters to masks.
+VECTOR_CATCH_CHAR_MAP = {
+        'h': Target.CATCH_HARD_FAULT,
+        'b': Target.CATCH_BUS_FAULT,
+        'm': Target.CATCH_MEM_FAULT,
+        'i': Target.CATCH_INTERRUPT_ERR,
+        's': Target.CATCH_STATE_ERR,
+        'c': Target.CATCH_CHECK_ERR,
+        'p': Target.CATCH_COPROCESSOR_ERR,
+        'r': Target.CATCH_CORE_RESET,
+        'a': Target.CATCH_ALL,
+        'n': Target.CATCH_NONE,
+    }
+
+## @brief Convert a vector catch string to a mask.
+#
+# @exception ValueError Raised if an invalid vector catch character is encountered.
+def convert_vector_catch(value):
+    # Make case insensitive.
+    value = value.lower()
+
+    # Handle special vector catch options.
+    if value == 'all':
+        return Target.CATCH_ALL
+    elif value == 'none':
+        return Target.CATCH_NONE
+
+    # Convert options string to mask.
+    try:
+        return sum([VECTOR_CATCH_CHAR_MAP[c] for c in value])
+    except KeyError as e:
+        # Reraise an error with a more helpful message.
+        raise ValueError("invalid vector catch option '{}'".format(e.args[0]))
 

--- a/test/test_pyocd_tool.sh
+++ b/test/test_pyocd_tool.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Run through all pyocd-tool commands.
-pyocd-tool <<EOF
+pyocd-tool -tcortex_m -dinfo <<EOF
 help
 clock 1000
 disasm 0x410 16
@@ -9,13 +9,16 @@ reset -h
 disasm -c pc 16
 go
 halt
-info
+show target
+show cores
+show map
+show uid
+show peripherals
 log debug
 read 0 16
 read16 0 16
 read32 0 16
 reg
-stat
 reset
 reset -h
 pc
@@ -32,7 +35,7 @@ read32 0x20000000 4
 wreg r0 0xabcd1234
 r0
 reset -h
-stat
+show cores
 reg
 EOF
 


### PR DESCRIPTION
Multiple changes to pyocd-tool.
- New commands:
  - savemem, loadmem
  - setreset
  - break, rmbreak, lsbreak
  - readdp, writedp, readap, writeap
  - reinit
  - show
- New aliases for read/write memory commands with {b,h,w} suffixes.
- Prefixing the command with "!" lets you execute a shell command.
- Replaced info command with show command, with these options: map, peripherals, uid, cores, target
- Support for writing peripheral registers and bitfields, as defined in the target's SVD file.
- --no-init command line option, to allow for debugging of the initial connect sequence.

Includes a couple other small changes.
- New --mass-erase command line option to pyocd-flashtool, currently only implemented for Kinetis.
- Case-insensitive target name matching.
