### PR TITLE
Fix issues programming DAP under python3

### DIFF
--- a/pyOCD/coresight/ap.py
+++ b/pyOCD/coresight/ap.py
@@ -356,9 +356,9 @@ class MEM_AP(AccessPort):
             n = self.auto_increment_page_size - (addr & (self.auto_increment_page_size - 1))
             if size*4 < n:
                 n = (size*4) & 0xfffffffc
-            self._writeBlock32(addr, data[:n/4])
-            data = data[n/4:]
-            size -= n/4
+            self._writeBlock32(addr, data[:n//4])
+            data = data[n//4:]
+            size -= n//4
             addr += n
         return
 
@@ -371,8 +371,8 @@ class MEM_AP(AccessPort):
             n = self.auto_increment_page_size - (addr & (self.auto_increment_page_size - 1))
             if size*4 < n:
                 n = (size*4) & 0xfffffffc
-            resp += self._readBlock32(addr, n/4)
-            size -= n/4
+            resp += self._readBlock32(addr, n//4)
+            size -= n//4
             addr += n
         return resp
 

--- a/pyOCD/coresight/cortex_m.py
+++ b/pyOCD/coresight/cortex_m.py
@@ -337,7 +337,7 @@ class CortexM(Target):
             for reg in self.regs_float:
                 self.register_list.append(reg)
                 SubElement(xml_regs_general, 'reg', **reg.gdb_xml_attrib)
-        self.targetXML = '<?xml version="1.0"?><!DOCTYPE feature SYSTEM "gdb-target.dtd">' + tostring(xml_root)
+        self.targetXML = b'<?xml version="1.0"?><!DOCTYPE feature SYSTEM "gdb-target.dtd">' + tostring(xml_root)
 
     ## @brief Read the CPUID register and determine core type.
     def readCoreType(self):
@@ -842,4 +842,3 @@ class CortexM(Target):
 
     def setTargetContext(self, context):
         self._target_context = context
-

--- a/pyOCD/utility/conversion.py
+++ b/pyOCD/utility/conversion.py
@@ -22,7 +22,7 @@ import binascii
 def byteListToU32leList(data):
     """Convert a list of bytes to a list of 32-bit integers (little endian)"""
     res = []
-    for i in range(len(data) / 4):
+    for i in range(len(data) // 4):
         res.append(data[i * 4 + 0] |
                    data[i * 4 + 1] << 8 |
                    data[i * 4 + 2] << 16 |


### PR DESCRIPTION
Trying to program the FRDM-K64F DAP under python3 currently fails because
of the changed semantics for division which returns `float` on py3 and
unicode string literals which cause an abort on XML processing.

NOTE: This was tested under Python 3.6.1 and 2.7.12.