### PR TITLE
Add .cache to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,6 @@ output.txt
 gdb_test_raw.txt
 test_results.txt
 
-
+.cache
 .eggs/
 pyOCD/_version.py


### PR DESCRIPTION
The `.cache` folder is created by py.test.