### PR TITLE
GDB server log, command processing, and XML encoding improvements

### DIFF
--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -828,6 +828,14 @@ class GDBServer(threading.Thread):
 
         return data
 
+    def escape(self, data):
+        result = ''
+        for c in data:
+            if c in '#$}*':
+                result += '}' + chr(ord(c) ^ 0x20)
+            else:
+                result += c
+        return result
 
     def getMemory(self, data):
         split = data.split(',')
@@ -1157,7 +1165,7 @@ class GDBServer(threading.Thread):
             prefix = 'l'
             size = nbBytesAvailable
 
-        resp = prefix + xml[offset:offset + size]
+        resp = prefix + self.escape(xml[offset:offset + size])
 
         return resp
 

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -1117,7 +1117,7 @@ class GDBServer(threading.Thread):
 
             # Run cmds in proper order
             if resultMask & 0x1:
-                self.target.init()
+                pass
             if (resultMask & 0x6) == 0x6:
                 self.target.resetStopOnReset()
             elif resultMask & 0x2:

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -272,28 +272,40 @@ class GDBServer(threading.Thread):
         self.semihost = semihost.SemihostAgent(self.target_context, io_handler=semihost_io_handler, console=self.telnet_console)
 
         # Command handler table.
+        #
+        # The dict keys are the first character of the incoming command from gdb. Values are a
+        # bi-tuple. The first element is the handler method, and the second element is the start
+        # offset of the command string passed to the handler.
+        #
+        # Start offset values:
+        #  0 - Special case: handler method does not take any parameters.
+        #  1 - Strip off leading "$" from command.
+        #  2 - Strip leading "$" plus character matched through this table.
+        #  3+ - Supported, but not very useful.
+        #
         self.COMMANDS = {
-                '?' : (self.stopReasonQuery, 0),        # Stop reason query.
-                'C' : (self.resume, 1),                 # Continue (at addr)
-                'c' : (self.resume, 1),                 # Continue with signal.
-                'D' : (self.detach, 1),                 # Detach.
-                'g' : (self.getRegisters, 0),           # Read general registers.
-                'G' : (self.setRegisters, 2),           # Write general registers.
-                'H' : (self.setThread, 2),              # Set thread for subsequent operations.
-                'k' : (self.kill, 0),                   # Kill.
-                'm' : (self.getMemory, 2),              # Read memory.
-                'M' : (self.writeMemoryHex, 2),         # Write memory (hex).
-                'p' : (self.readRegister, 2),           # Read register.
-                'P' : (self.writeRegister, 2),          # Write register.
-                'q' : (self.handleQuery, 2),            # General query.
-                'Q' : (self.handleGeneralSet, 2),       # General set.
-                's' : (self.step, 1),                   # Single step.
-                'S' : (self.step, 1),                   # Step with signal.
-                'T' : (self.isThreadAlive, 1),          # Thread liveness query.
-                'v' : (self.vCommand, 2),               # v command.
-                'X' : (self.writeMemory, 2),            # Write memory (binary).
-                'z' : (self.breakpoint, 1),             # Insert breakpoint/watchpoint.
-                'Z' : (self.breakpoint, 1),             # Remove breakpoint/watchpoint.
+        #       CMD    HANDLER                  START    DESCRIPTION
+                '?' : (self.stopReasonQuery,    0   ), # Stop reason query.
+                'C' : (self.resume,             1   ), # Continue (at addr)
+                'c' : (self.resume,             1   ), # Continue with signal.
+                'D' : (self.detach,             1   ), # Detach.
+                'g' : (self.getRegisters,       0   ), # Read general registers.
+                'G' : (self.setRegisters,       2   ), # Write general registers.
+                'H' : (self.setThread,          2   ), # Set thread for subsequent operations.
+                'k' : (self.kill,               0   ), # Kill.
+                'm' : (self.getMemory,          2   ), # Read memory.
+                'M' : (self.writeMemoryHex,     2   ), # Write memory (hex).
+                'p' : (self.readRegister,       2   ), # Read register.
+                'P' : (self.writeRegister,      2   ), # Write register.
+                'q' : (self.handleQuery,        2   ), # General query.
+                'Q' : (self.handleGeneralSet,   2   ), # General set.
+                's' : (self.step,               1   ), # Single step.
+                'S' : (self.step,               1   ), # Step with signal.
+                'T' : (self.isThreadAlive,      1   ), # Thread liveness query.
+                'v' : (self.vCommand,           2   ), # v command.
+                'X' : (self.writeMemory,        2   ), # Write memory (binary).
+                'z' : (self.breakpoint,         1   ), # Insert breakpoint/watchpoint.
+                'Z' : (self.breakpoint,         1   ), # Remove breakpoint/watchpoint.
             }
 
         # Commands that kill the connection to gdb.

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -148,8 +148,9 @@ class GDBServerTool(object):
 
 
     def setup_logging(self, args):
+        format = "%(relativeCreated)07d:%(levelname)s:%(module)s:%(message)s"
         level = LEVELS.get(args.debug_level, logging.NOTSET)
-        logging.basicConfig(level=level)
+        logging.basicConfig(level=level, format=format)
 
     ## @brief Handle OpenOCD commands for compatibility.
     def process_commands(self, commands):


### PR DESCRIPTION
- `GDBServerPacketIOThread` and `GDBServer` classes create their own logger instances.
- Using a custom logger format for pyocd-gdbserver that shows the module name and timestamp. The module name is used instead of the logger name since most pyOCD code still uses the root logger.
- Moved to a table-driven gdb command processor in `GDBServer.handleMsg()`. See the `COMMANDS` dictionary that is built in `GDBServer.__init__()`.
- Properly encoding XML data sent back to gdb. Added `GDBServer.escape()`, which is used in `GDBServer.handleQueryXML()`.