### PR TITLE
Add support for the VBLUno51 board

### DIFF
--- a/pyOCD/board/mbed_board.py
+++ b/pyOCD/board/mbed_board.py
@@ -94,6 +94,7 @@ BOARD_ID_TO_INFO = {
                 "9012": BoardInfo(  "Seeed Tiny BLE",       "nrf51",            "l1_nrf51.bin",         ),
                 "9900": BoardInfo(  "Microbit",             "nrf51",            "l1_microbit.bin",      ),
                 "C004": BoardInfo(  "tinyK20",              "k20d50m",          "l1_k20d50m.bin",       ),
+                "C006": BoardInfo(  "VBLUno51",             "nrf51",            "l1_nrf51.bin",         ),
               }
 
 mbed_vid = 0x0d28


### PR DESCRIPTION
Add support for the VBLUno51 board

`Sarah Marsh (mbed)` said that the VBLUno51 board could use board ID is `C006`
The slug: VBLUNO51

The VBLUno51 board was added to mbed-os 5.5.2 released
https://github.com/ARMmbed/mbed-os/pull/4629
https://github.com/ARMmbed/mbed-os/pull/4719

Signed-off-by: iotvietmember <robotden@gmail.com>