### PR TITLE
Basic multicore debug

### DIFF
--- a/pyOCD/gdbserver/context_facade.py
+++ b/pyOCD/gdbserver/context_facade.py
@@ -143,3 +143,10 @@ class GDBDebugContextFacade(object):
         else:
             return None
 
+    def getTargetXML(self):
+        return self._context.core.getTargetXML()
+
+    def flush(self):
+        self._context.core.flush()
+
+

--- a/test/gdb_test.py
+++ b/test/gdb_test.py
@@ -27,6 +27,8 @@ import os
 import json
 import sys
 from subprocess import Popen, STDOUT, PIPE
+import argparse
+import logging
 
 from pyOCD.tools.gdb_server import GDBServerTool
 from pyOCD.board import MbedBoard
@@ -155,4 +157,9 @@ def test_gdb(board_id=None):
     return result
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='pyOCD gdb test')
+    parser.add_argument('-d', '--debug', action="store_true", help='Enable debug logging')
+    args = parser.parse_args()
+    level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(level=level)
     test_gdb()


### PR DESCRIPTION
This PR adds basic support for debugging multiple cores simultaneously. pyocd-gdbserver automatically creates one GDBServer instance per core. The first core is given the user-specified port number. Additional cores have port numbers incremented from there. To prevent reset requests from multiple connected gdb instances causing havoc, the reset monitor commands are only honoured for core 0.

To debug a multicore device, run pyocd-gdbserver as usual. This will connect to the device, detect the cores, and create the gdb server instances on separate ports. Next, start up two gdb instances and connect to the two gdb server ports. For instance, on a dual core device if you pass 3333 for the port, connect to port 3333 for the first core and port 3334 for the second core.

On many devices, secondary cores are by default held in reset until released by the primary core. Because gdb does not have a concept of a core held in reset, pyOCD will report a core held in reset by telling gdb that there is a single thread with the name "Reset". This is visible if you run the `show threads` gdb command, and will appear in the Eclipe Debug view's list of threads. All register values will be reported as 0 until the core is released from reset.

Usually you want to have the primary core load code for the secondary core, so configure the second core's gdb to not load any code to the target. This is highly device-specific, though, and may depend on whether the secondary core's code is running out of flash or RAM.