### PR TITLE
Add command-line option to limit USB packet count

### DIFF
--- a/pyOCD/pyDAPAccess/dap_access_cmsis_dap.py
+++ b/pyOCD/pyDAPAccess/dap_access_cmsis_dap.py
@@ -512,7 +512,13 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
         self._interface.open()
         self._protocol = CMSIS_DAP_Protocol(self._interface)
-        self._packet_count = self._protocol.dapInfo("PACKET_COUNT")
+
+        if DAPSettings.limit_packets:
+            self._packet_count = 1
+            self._logger.debug("Limiting packet count to %d", self._packet_count)
+        else:
+            self._packet_count = self._protocol.dapInfo("PACKET_COUNT")
+
         self._interface.setPacketCount(self._packet_count)
         self._packet_size = self._protocol.dapInfo("PACKET_SIZE")
         self._interface.setPacketSize(self._packet_size)

--- a/pyOCD/pyDAPAccess/dap_settings.py
+++ b/pyOCD/pyDAPAccess/dap_settings.py
@@ -20,3 +20,5 @@ class DAPSettings():
 	use_ws = False
 	ws_host = "localhost"
 	ws_port = 8081
+
+	limit_packets = False

--- a/test/flash_test.py
+++ b/test/flash_test.py
@@ -29,6 +29,7 @@ sys.path.insert(0, parentdir)
 
 import pyOCD
 from pyOCD.board import MbedBoard
+from pyOCD.pyDAPAccess import DAPAccess
 from pyOCD.utility.conversion import float32beToU32be
 from pyOCD.flash.flash import Flash
 from pyOCD.flash.flash_builder import FlashBuilder
@@ -413,9 +414,11 @@ def flash_test(board_id):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='pyOCD flash test')
     parser.add_argument('-d', '--debug', action="store_true", help='Enable debug logging')
+    parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
     args = parser.parse_args()
     level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(level=level)
+    DAPAccess.set_args(args.daparg)
     # Set to debug to print some of the decisions made while flashing
     board = pyOCD.board.mbed_board.MbedBoard.getAllConnectedBoards(close=True)[0]
     test = FlashTest()

--- a/test/speed_test.py
+++ b/test/speed_test.py
@@ -27,6 +27,7 @@ sys.path.insert(0, parentdir)
 
 import pyOCD
 from pyOCD.board import MbedBoard
+from pyOCD.pyDAPAccess import DAPAccess
 from test_util import Test, TestResult
 import logging
 
@@ -158,9 +159,11 @@ def speed_test(board_id):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='pyOCD speed test')
     parser.add_argument('-d', '--debug', action="store_true", help='Enable debug logging')
+    parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
     args = parser.parse_args()
     level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(level=level)
+    DAPAccess.set_args(args.daparg)
     board = pyOCD.board.mbed_board.MbedBoard.getAllConnectedBoards(close=True)[0]
     test = SpeedTest()
     result = [test.run(board)]


### PR DESCRIPTION
Addresses USB issues found when running pyOCD in a VirtualBox VM.

Similar to #154, but implemented as a command-line option rather than always limiting the packet count.