### PR TITLE
Support GDB range step

### DIFF
--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -113,8 +113,8 @@ class CoreSightTarget(Target):
     def halt(self):
         return self.selected_core.halt()
 
-    def step(self, disable_interrupts=True):
-        return self.selected_core.step(disable_interrupts)
+    def step(self, disable_interrupts=True, start=0, end=0):
+        return self.selected_core.step(disable_interrupts, start, end)
 
     def resume(self):
         return self.selected_core.resume()

--- a/pyOCD/core/target.py
+++ b/pyOCD/core/target.py
@@ -94,7 +94,7 @@ class Target(object):
     def halt(self):
         raise NotImplementedError()
 
-    def step(self, disable_interrupts=True):
+    def step(self, disable_interrupts=True, start=0, end=0):
         raise NotImplementedError()
 
     def resume(self):


### PR DESCRIPTION
If target supports range step, GDB will ask for range step by default.
Under range step, GDB will issue 'r start,end' instead of multiple 's'
packets to target stub. It could reduce greatly the traffic between GDB
and target stub, especially step out one line loop.