### PR TITLE
Support reverse stepping in gdbserver.

### DIFF
--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -116,6 +116,9 @@ class CoreSightTarget(Target):
     def step(self, disable_interrupts=True, start=0, end=0):
         return self.selected_core.step(disable_interrupts, start, end)
 
+    def reverse_step(self):
+        return self.selected_core.reverse_step()
+
     def resume(self):
         return self.selected_core.resume()
 

--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -113,8 +113,8 @@ class CoreSightTarget(Target):
     def halt(self):
         return self.selected_core.halt()
 
-    def step(self, disable_interrupts=True):
-        return self.selected_core.step(disable_interrupts)
+    def step(self, disable_interrupts=True, start=0, end=0):
+        return self.selected_core.step(disable_interrupts, start, end)
 
     def resume(self):
         return self.selected_core.resume()

--- a/pyOCD/core/instruction.py
+++ b/pyOCD/core/instruction.py
@@ -1,0 +1,251 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2015-2017 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+thumb16_decoder_registry = {}
+def thumb16_decoder(cls):
+    thumb16_decoder_registry[cls.group] = cls
+    return cls
+
+@thumb16_decoder
+class thumb16_decode_0(object):
+    group = 0
+    def decode(self, instr):
+        rd = instr.instruction & 0x7
+        instr.append_reg(rd)
+
+@thumb16_decoder
+class thumb16_decode_1(object):
+    group = 1
+    def decode(self, instr):
+        opcode = (instr.instruction >> 11) & 0x3
+        if opcode == 1:  # CMP(1)
+            pass
+        else:  # MOV(1), ADD(2), SUB(2)
+            rd = (instr.instruction >> 8) & 0x7
+            instr.append_reg(rd)
+
+@thumb16_decoder
+class thumb16_decode_2(object):
+    group = 2
+    def decode(self, instr):
+        instruction = instr.instruction
+        opcode = (instruction >> 11) & 0x3
+        if opcode == 0:
+            branch_op = (instruction >> 7) & 0xF
+            if branch_op == 0xF:     # BLX
+                instr.append_reg('lr')
+            else:
+                rd = instruction & 0x7
+                instr.append_reg(rd)
+        elif opcode == 1:
+            rt = (instruction >> 8) & 0x7
+            instr.append_reg(rt)
+        elif opcode == 2:
+            subopcode = (instruction >> 9) & 0x3
+            if subopcode == 3:
+                rt = instruction & 0x7
+                instr.append_reg(rt)
+            else:
+                rm = (instruction >> 6) & 0x7
+                rn = (instruction >> 3) & 0x7
+                rm_value = instr.core.readCoreRegisterRaw(rm)
+                rn_value = instr.core.readCoreRegisterRaw(rn)
+                address = rn_value + rm_value
+                if subopcode == 0:  # STR(reg)
+                    instr.append_mem(address, 32)
+                elif subopcode == 1:  # STRH(reg)
+                    instr.append_mem(address, 16)
+                elif subopcode == 2:  # STRB(reg)
+                    instr.append_mem(address, 8)
+        elif opcode == 3:
+            rt = instruction & 0x7
+            instr.append_reg(rt)
+
+@thumb16_decoder
+class thumb16_decode_3(object):
+    group = 3
+    def decode(self, instr):
+        instruction = instr.instruction
+        opcode = (instruction >> 11) & 0x3
+        if opcode == 0:  # STR
+            imm = ((instruction >> 6) & 0x1F) << 2
+            rn = (instruction >> 3) & 0x7
+            rn_value = instr.core.readCoreRegisterRaw(rn)
+            address = rn_value + imm
+            instr.append_mem(address, 32)
+        elif opcode == 2:  # STRB
+            imm = (instruction >> 6) & 0x1F
+            rn = (instruction >> 3) & 0x7
+            rn_value = instr.core.readCoreRegisterRaw(rn)
+            address = rn_value + imm
+            instr.append_mem(address, 8)
+        else:  # LDR or LDRB
+            rt = instruction & 0x7
+            instr.append_reg(rt)
+
+@thumb16_decoder
+class thumb16_decode_4(object):
+    group = 4
+    def decode(self, instr):
+        instruction = instr.instruction
+        opcode = (instruction >> 11) & 0x3
+        if opcode == 0:    # STRH
+            imm = ((instruction >> 6) & 0x1F) << 1
+            rn = (instruction >> 3) & 0x7
+            rn_value = instr.core.readCoreRegisterRaw(rn)
+            address = rn_value + imm
+            instr.append_mem(address, 16)
+        elif opcode == 1:  # LDRH
+            rt = instruction & 0x7
+            instr.append_reg(rt)
+        elif opcode == 2:  # STR
+            imm = (instruction & 0xFF) << 2
+            rn_value = instr.core.readCoreRegister('sp')
+            address = rn_value + imm
+            instr.append_mem(address, 32)
+        else:              # LDR
+            rt = (instruction >> 8) & 0x7
+            instr.append_reg(rt)
+
+@thumb16_decoder
+class thumb16_decode_5(object):
+    group = 5
+    def decode(self, instr):
+        instruction = instr.instruction
+        opcode = (instruction >> 11) & 0x3
+        if opcode == 0 or opcode == 1:
+            rd = (instruction >> 8) & 0x7
+            instr.append_reg(rd)
+        else:
+            subopcode = (instruction >> 8) & 0x1F
+            if subopcode == 0b10110:  # CPS
+                instr.append_reg('primask')
+                instr.append_reg('faultmask')
+            elif subopcode == 0b10000:  # ADD(sp+imm) SUB(sp-imm)
+                instr.append_reg('sp')
+            elif subopcode == 0b10010 or subopcode == 0b11010:
+                rd = instruction & 0x7
+                instr.append_reg(rd)
+            else:
+                subopcode = (instruction >> 9) & 0xF
+                if subopcode == 0b1010:  # PUSH
+                    sp_value = instr.core.readCoreRegisterRaw('sp')
+                    register_list = instruction & 0x1FF
+                    bit_count = 0
+                    while register_list != 0:
+                        if register_list & 0x1:
+                            bit_count = bit_count + 1
+                            instr.append_mem(sp_value - 4 * bit_count, 32)
+                        register_list = register_list >> 1
+                elif subopcode == 0b1110: # POP
+                    register_list = instruction & 0xFF
+                    reg_no = 0
+                    while register_list != 0:
+                        if register_list & 0x1:
+                            instr.append_reg(reg_no)
+                        reg_no = reg_no + 1
+                        register_list = register_list >> 1
+
+@thumb16_decoder
+class thumb16_decode_6(object):
+    group = 6
+    def decode(self, instr):
+        instruction = instr.instruction
+        opcode = (instruction >> 11) & 0x3
+        if opcode == 0: # STM, STMIA, STMEA
+            rn = (instruction >> 8) & 0x7
+            register_list = instruction & 0xFF
+            address = instr.core.readCoreRegisterRaw(rn)
+            bit_count = 0
+            while register_list != 0:
+                if register_list & 0x1:
+                    instr.append_mem(address + 4 * bit_count, 32)
+                    bit_count = bit_count + 1
+                register_list = register_list >> 1
+
+            instr.append(rn)
+        elif opcode == 1: # LDM, LDMIA, LDMFD
+            rn = (instruction >> 8) & 0x7
+            register_list = instruction & 0xFF
+            reg_no = 0
+            wback = 1
+            while register_list != 0:
+                if register_list & 0x1:
+                    instr.append_reg(reg_no)
+                    if reg_no == rn:
+                        wback = 0
+                reg_no = reg_no + 1
+                register_list = register_list >> 1
+
+            if wback:
+                instr.append_reg(rn)
+        else:
+            cond = (instruction >> 8) & 0xF
+            if cond == 0b1110 or cond == 0b1111:  # UDF or SVC
+                pass
+            else:  # B
+                pass
+
+@thumb16_decoder
+class thumb16_decode_7(object):
+    group = 7
+    def decode(self, instr):
+        pass
+
+class Instruction(object):
+    class RegisterAccess(object):
+        def __init__(self, reg_no, value):
+            self.reg_no = reg_no
+            self.value = value
+
+    class MemoryAccess(object):
+        def __init__(self, address, size, value):
+            self.address = address
+            self.size = size
+            self.value = value
+
+    def __init__(self, instruction, core):
+        self.core = core 
+        self.instruction = instruction
+        group_id = (self.instruction >> 13) & 0x7
+        self.decoder = thumb16_decoder_registry[group_id]()
+        self.registers = []
+        self.memory_access = []
+
+        # Always push pc and xpsr into registers[].
+        for reg in ['pc', 'xpsr']:
+            self.append_reg(reg)
+
+    def restore(self):
+        # Restore register values.
+        for reg in self.registers:
+            self.core.writeCoreRegister(reg.reg_no, reg.value)
+        # Restore memory values.
+        for mem_access in self.memory_access:
+            self.core.writeMemory(mem_access.address, mem_access.value, mem_access.size)
+
+    def decode(self):
+        self.decoder.decode(self)
+
+    def append_reg(self, reg):
+        reg_no = self.core.registerNameToIndex(reg)
+        value = self.core.readCoreRegisterRaw(reg_no)
+        self.registers.append(self.RegisterAccess(reg_no, value))
+
+    def append_mem(self, address, size):
+        value = self.core.readMemory(address, size)
+        self.memory_access.append(self.MemoryAccess(address, size, value))

--- a/pyOCD/core/instruction_record.py
+++ b/pyOCD/core/instruction_record.py
@@ -1,0 +1,57 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2015-2017 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from .instruction import Instruction
+
+## @brief A list of executed instructions.
+class InstructionRecord(object):
+    def __init__(self):
+        self.instructions = []
+        self.position = -1
+
+    def append(self, instruction):
+        instruction.decode()
+        self.instructions.append(instruction)
+        self.position = self.position + 1
+
+    @property
+    def size(self):
+        return len(self.instructions)
+
+    def flush(self):
+        self.instructions[:] = []
+        self.position = -1
+
+    def next(self):
+        if self.position == (self.size - 1):
+            return False
+
+        # Step to next instruction.
+        self.position = self.position + 1
+        return True
+
+    def prev(self):
+        if self.position == -1:
+            return False
+
+        # Restore the state before execution.
+        self.instructions[self.position].restore()
+
+        # Update position.
+        self.position = self.position - 1
+
+        return True

--- a/pyOCD/core/target.py
+++ b/pyOCD/core/target.py
@@ -94,7 +94,7 @@ class Target(object):
     def halt(self):
         raise NotImplementedError()
 
-    def step(self, disable_interrupts=True):
+    def step(self, disable_interrupts=True, start=0, end=0):
         raise NotImplementedError()
 
     def resume(self):

--- a/pyOCD/core/target.py
+++ b/pyOCD/core/target.py
@@ -100,6 +100,9 @@ class Target(object):
     def step(self, disable_interrupts=True, start=0, end=0):
         raise NotImplementedError()
 
+    def reverse_step(self):
+        raise NotImplementedError()
+
     def resume(self):
         raise NotImplementedError()
 

--- a/pyOCD/core/target.py
+++ b/pyOCD/core/target.py
@@ -16,6 +16,7 @@
 """
 
 from .memory_map import MemoryMap
+from .instruction_record import InstructionRecord
 
 class Target(object):
 
@@ -59,6 +60,8 @@ class Target(object):
         self.has_fpu = False
         self._svd_location = None
         self._svd_device = None
+        self.instruction_record = InstructionRecord()
+
 
     @property
     def svd_device(self):

--- a/pyOCD/coresight/cortex_m.py
+++ b/pyOCD/coresight/cortex_m.py
@@ -469,9 +469,13 @@ class CortexM(Target):
                 # If there is no next instruction in instruction record, append it.
                 pc = self.readCoreRegister(CORE_REGISTER['pc'])
                 instr = self.read16(pc)
-                # TODO: process thumb2 instructions
+                size = 16
+                if not Instruction.is_thumb16(instr):
+                    instr_high = self.read16(pc+2)
+                    instr = (instr_high << 16) | instr
+                    size = 32
 
-                instruction = Instruction(instr, self)
+                instruction = Instruction(instr, size, self)
                 self.instruction_record.append(instruction)
 
             # Single step using current C_MASKINTS setting

--- a/pyOCD/coresight/cortex_m.py
+++ b/pyOCD/coresight/cortex_m.py
@@ -514,6 +514,8 @@ class CortexM(Target):
         reset a core. After a call to this function, the core
         is running
         """
+        self.instruction_record.flush()
+
         if software_reset == None:
             # Default to software reset if nothing is specified
             software_reset = True
@@ -549,6 +551,8 @@ class CortexM(Target):
         perform a reset and stop the core on the reset handler
         """
         logging.debug("reset stop on Reset")
+
+        self.instruction_record.flush()
 
         # halt the target
         self.halt()
@@ -608,6 +612,8 @@ class CortexM(Target):
         """
         resume the execution
         """
+        self.instruction_record.flush()
+
         if self.getState() != Target.TARGET_HALTED:
             logging.debug('cannot resume: target not halted')
             return

--- a/pyOCD/coresight/cortex_m.py
+++ b/pyOCD/coresight/cortex_m.py
@@ -506,6 +506,9 @@ class CortexM(Target):
 
         self._run_token += 1
 
+    def reverse_step(self):
+        self.instruction_record.prev()
+
     def clearDebugCauseBits(self):
         self.writeMemory(CortexM.DFSR, CortexM.DFSR_DWTTRAP | CortexM.DFSR_BKPT | CortexM.DFSR_HALTED)
 

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -286,7 +286,7 @@ class GDBServer(threading.Thread):
         self.COMMANDS = {
         #       CMD    HANDLER                  START    DESCRIPTION
                 '?' : (self.stopReasonQuery,    0   ), # Stop reason query.
-                'b' : (self.reverse_step,       1   ), # Reverse step.
+                'b' : (self.reverse_exec,       1   ), # Reverse execution.
                 'C' : (self.resume,             1   ), # Continue (at addr)
                 'c' : (self.resume,             1   ), # Continue with signal.
                 'D' : (self.detach,             1   ), # Detach.
@@ -666,8 +666,14 @@ class GDBServer(threading.Thread):
         self.target.step(not self.step_into_interrupt, start, end)
         return self.createRSPPacket(self.getTResponse())
 
-    def reverse_step(self, data):
-        self.target.reverse_step()
+    def reverse_exec(self, data):
+        data = data.split('#')[0]
+
+        # Only support 'bs' now.
+        if data[1] == 's':
+            self.target.reverse_step()
+        elif data[1] == 'c':
+            self.createRSPPacket('E01')
         return self.createRSPPacket(self.getTResponse())
 
     def halt(self):

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -286,6 +286,7 @@ class GDBServer(threading.Thread):
         self.COMMANDS = {
         #       CMD    HANDLER                  START    DESCRIPTION
                 '?' : (self.stopReasonQuery,    0   ), # Stop reason query.
+                'b' : (self.reverse_step,       1   ), # Reverse step.
                 'C' : (self.resume,             1   ), # Continue (at addr)
                 'c' : (self.resume,             1   ), # Continue with signal.
                 'D' : (self.detach,             1   ), # Detach.
@@ -665,6 +666,10 @@ class GDBServer(threading.Thread):
         self.target.step(not self.step_into_interrupt, start, end)
         return self.createRSPPacket(self.getTResponse())
 
+    def reverse_step(self, data):
+        self.target.reverse_step()
+        return self.createRSPPacket(self.getTResponse())
+
     def halt(self):
         self.target.halt()
         return self.createRSPPacket(self.getTResponse())
@@ -962,7 +967,7 @@ class GDBServer(threading.Thread):
             self.gdb_features = query[1].split(';')
 
             # Build our list of features.
-            features = ['qXfer:features:read+', 'QStartNoAckMode+', 'qXfer:threads:read+', 'QNonStop+']
+            features = ['qXfer:features:read+', 'QStartNoAckMode+', 'qXfer:threads:read+', 'QNonStop+', 'ReverseStep+']
             features.append('PacketSize=' + hex(self.packet_size)[2:])
             if self.target_facade.getMemoryMapXML() is not None:
                 features.append('qXfer:memory-map:read+')

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -241,6 +241,7 @@ class GDBServer(threading.Thread):
         self.semihost_use_syscalls = options.get('semihost_use_syscalls', False)
         self.server_listening_callback = options.get('server_listening_callback', None)
         self.serve_local_only = options.get('serve_local_only', True)
+        self.reverse_debugging = options.get('reverse_debugging', False)
         self.packet_size = 2048
         self.packet_io = None
         self.gdb_features = []
@@ -973,7 +974,9 @@ class GDBServer(threading.Thread):
             self.gdb_features = query[1].split(';')
 
             # Build our list of features.
-            features = ['qXfer:features:read+', 'QStartNoAckMode+', 'qXfer:threads:read+', 'QNonStop+', 'ReverseStep+']
+            features = ['qXfer:features:read+', 'QStartNoAckMode+', 'qXfer:threads:read+', 'QNonStop+']
+            if self.reverse_debugging:
+                features.append('ReverseStep+')
             features.append('PacketSize=' + hex(self.packet_size)[2:])
             if self.target_facade.getMemoryMapXML() is not None:
                 features.append('qXfer:memory-map:read+')

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -98,6 +98,7 @@ class GDBServerTool(object):
         parser.add_argument("-G", "--gdb-syscall", dest="semihost_use_syscalls", action="store_true", help="Use GDB syscalls for semihosting file I/O.")
         parser.add_argument("-c", "--command", dest="commands", metavar="CMD", action='append', nargs='+', help="Run command (OpenOCD compatibility).")
         parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
+        parser.add_argument("-R", "--reverse_debugging", dest="reverse_debugging", action="store_true", help="Enable reverse debugging.")
         self.parser = parser
         return parser
 
@@ -144,6 +145,7 @@ class GDBServerTool(object):
             'semihost_use_syscalls' : args.semihost_use_syscalls,
             'serve_local_only' : args.serve_local_only,
             'vector_catch' : self.get_vector_catch(args),
+            'reverse_debugging' : args.reverse_debugging,
         }
 
 

--- a/test/gdb_script.py
+++ b/test/gdb_script.py
@@ -58,6 +58,7 @@ STACK_OFFSET = 0x800
 TEST_RAM_OFFSET = 0x800
 MAX_TEST_SIZE = 0x1000
 MAX_BKPT = 10
+TEST_STEP_COUNT = 20
 
 assert STACK_OFFSET < MAX_TEST_SIZE
 assert TEST_RAM_OFFSET < MAX_TEST_SIZE
@@ -433,6 +434,21 @@ def run_test():
             # -test hard fault handling
             # -test reset catch
         # TODO,c1728p9 - test signals/hard fault
+
+        # Test reverse stepping
+        recorded_pc = []
+        for i in range(TEST_STEP_COUNT):
+            pc = gdb.selected_frame().pc()
+            recorded_pc.append(pc)
+            gdb.execute("si")
+
+        for i in range(TEST_STEP_COUNT):
+            gdb.execute("rsi")
+            pc = gdb.selected_frame().pc()
+            if pc != recorded_pc.pop():
+                fail_count += 1
+                print("Error - reverse step to wrong $pc")
+                break
 
         if fail_count:
             print("Test completed with %i errors" % fail_count)

--- a/test/gdb_script.py
+++ b/test/gdb_script.py
@@ -435,20 +435,22 @@ def run_test():
             # -test reset catch
         # TODO,c1728p9 - test signals/hard fault
 
+## Stepping removed as a workaround for a GDB bug. Launchpad issue tracking this is here:
+## https://bugs.launchpad.net/gcc-arm-embedded/+bug/1700595
         # Test reverse stepping
-        recorded_pc = []
-        for i in range(TEST_STEP_COUNT):
-            pc = gdb.selected_frame().pc()
-            recorded_pc.append(pc)
-            gdb.execute("si")
+        # recorded_pc = []
+        # for i in range(TEST_STEP_COUNT):
+        #     pc = gdb.selected_frame().pc()
+        #     recorded_pc.append(pc)
+        #     gdb.execute("si")
 
-        for i in range(TEST_STEP_COUNT):
-            gdb.execute("rsi")
-            pc = gdb.selected_frame().pc()
-            if pc != recorded_pc.pop():
-                fail_count += 1
-                print("Error - reverse step to wrong $pc")
-                break
+        # for i in range(TEST_STEP_COUNT):
+        #     gdb.execute("rsi")
+        #     pc = gdb.selected_frame().pc()
+        #     if pc != recorded_pc.pop():
+        #         fail_count += 1
+        #         print("Error - reverse step to wrong $pc")
+        #         break
 
         if fail_count:
             print("Test completed with %i errors" % fail_count)


### PR DESCRIPTION
GDB supports reverse debugging for users. However, the GDB stub should have the capability to record processor states of every instruction to make the program reversible. This pull request adds the capability to decode Thumb instructions in ARMv7M to record the processor states of every instruction during stepping. It provides limited capability to reverse debugging, i.e., only support reverse stepping after stepping forward.

The feature is optional now. Users could use -R to enable the feature.

Users should use GDB 7.11 or later to enable the feature due to GDB bug 19840 (https://sourceware.org/bugzilla/show_bug.cgi?id=19840).

Reference:
https://www.gnu.org/software/gdb/news/reversible.html