### PR TITLE
Provide option to select semihosting console

### DIFF
--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -238,6 +238,7 @@ class GDBServer(threading.Thread):
         self.hide_programming_progress = options.get('hide_programming_progress', False)
         self.fast_program = options.get('fast_program', False)
         self.enable_semihosting = options.get('enable_semihosting', False)
+        self.semihost_console_type = options.get('semihost_console_type', 'telnet')
         self.telnet_port = options.get('telnet_port', 4444)
         self.semihost_use_syscalls = options.get('semihost_use_syscalls', False)
         self.server_listening_callback = options.get('server_listening_callback', None)
@@ -269,8 +270,15 @@ class GDBServer(threading.Thread):
         else:
             # Use internal IO handler.
             semihost_io_handler = semihost.InternalSemihostIOHandler()
-        self.telnet_console = semihost.TelnetSemihostIOHandler(self.telnet_port, self.serve_local_only)
-        self.semihost = semihost.SemihostAgent(self.target_context, io_handler=semihost_io_handler, console=self.telnet_console)
+
+        self.log.error("semihosting console = %s" % self.semihost_console_type)
+        if self.semihost_console_type == 'telnet':
+            self.telnet_console = semihost.TelnetSemihostIOHandler(self.telnet_port, self.serve_local_only)
+            semihost_console = self.telnet_console
+        else:
+            self.telnet_console = None
+            semihost_console = semihost_io_handler
+        self.semihost = semihost.SemihostAgent(self.target_context, io_handler=semihost_io_handler, console=semihost_console)
 
         # Command handler table.
         #

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -70,6 +70,7 @@ class GDBServerTool(object):
         parser = argparse.ArgumentParser(description='PyOCD GDB Server', epilog=epilog)
         parser.add_argument('--version', action='version', version=__version__)
         parser.add_argument("-p", "--port", dest="port_number", type=int, default=3333, help="Write the port number that GDB server will open.")
+        parser.add_argument("-sc", "--semihost-console", dest="semihost_console_type", default="telnet", choices=('telnet', 'stdx'), help="Console for semihosting.")
         parser.add_argument("-T", "--telnet-port", dest="telnet_port", type=int, default=4444, help="Specify the telnet port for semihosting.")
         parser.add_argument("--allow-remote", dest="serve_local_only", default=True, action="store_false", help="Allow remote TCP/IP connections (default is no).")
         parser.add_argument("-b", "--board", dest="board_id", default=None, help="Connect to board by board id.  Use -l to list all connected boards.")
@@ -140,6 +141,7 @@ class GDBServerTool(object):
             'fast_program' : args.fast_program,
             'server_listening_callback' : self.server_listening,
             'enable_semihosting' : args.enable_semihosting,
+            'semihost_console_type' : args.semihost_console_type,
             'telnet_port' : args.telnet_port,
             'semihost_use_syscalls' : args.semihost_use_syscalls,
             'serve_local_only' : args.serve_local_only,


### PR DESCRIPTION
pyOCD code has code for both telnet or IO handler to be used as console. This PR provides option to select telnet or IO handler (i.e. stdin/out). It is useful on machines without telnet. Fixes https://github.com/mbedmicro/pyOCD/issues/342 