### PR TITLE
Add UICR region to Nordic NRF52

### DIFF
--- a/pyOCD/target/target_nRF52832_xxAA.py
+++ b/pyOCD/target/target_nRF52832_xxAA.py
@@ -52,6 +52,8 @@ class NRF52(CoreSightTarget):
 
     memoryMap = MemoryMap(
         FlashRegion(    start=0x0,         length=0x80000,      blocksize=0x1000, isBootMemory=True),
+        # User Information Configation Registers (UICR) as a flash region
+        FlashRegion(    start=0x10001000,  length=0x100,        blocksize=0x100),
         RamRegion(      start=0x20000000,  length=0x10000)
         )
 


### PR DESCRIPTION
UICR is user configuration area. It is used by the MBR to select
the boot address.