### PR TITLE
Fix stale rtos

### DIFF
--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -20,6 +20,7 @@ from ..coresight import (dap, ap, cortex_m)
 from ..debug.svd import (SVDFile, SVDLoader)
 from ..debug.context import DebugContext
 from ..debug.cache import CachingDebugContext
+from ..utility.notification import Notification
 import threading
 import logging
 from xml.etree.ElementTree import (Element, SubElement, tostring)
@@ -96,7 +97,10 @@ class CoreSightTarget(Target):
             core0.init()
         self.add_core(core0)
 
+        self.notify(Notification(event=Target.EVENT_POST_CONNECT, source=self))
+
     def disconnect(self):
+        self.notify(Notification(event=Target.EVENT_PRE_DISCONNECT, source=self))
         for core in self.cores.values():
             core.disconnect()
         self.dp.power_down_debug()

--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -31,6 +31,7 @@ class CoreSightTarget(Target):
 
     def __init__(self, link, memoryMap=None):
         super(CoreSightTarget, self).__init__(link, memoryMap)
+        self.root_target = self
         self.part_number = self.__class__.__name__
         self.cores = {}
         self.aps = {}
@@ -92,7 +93,7 @@ class CoreSightTarget(Target):
         self.add_ap(ap0)
 
         # Create CortexM core.
-        core0 = cortex_m.CortexM(self.link, self.dp, self.aps[0], self.memory_map)
+        core0 = cortex_m.CortexM(self, self.dp, self.aps[0], self.memory_map)
         if bus_accessible:
             core0.init()
         self.add_core(core0)

--- a/pyOCD/core/target.py
+++ b/pyOCD/core/target.py
@@ -15,9 +15,10 @@
  limitations under the License.
 """
 
+from ..utility.notification import Notifier
 from .memory_map import MemoryMap
 
-class Target(object):
+class Target(Notifier):
 
     TARGET_RUNNING = 1   # Core is executing code.
     TARGET_HALTED = 2    # Core is halted in debug mode.
@@ -50,7 +51,26 @@ class Target(object):
     CATCH_ALL = (CATCH_HARD_FAULT | CATCH_BUS_FAULT | CATCH_MEM_FAULT | CATCH_INTERRUPT_ERR \
                 | CATCH_STATE_ERR | CATCH_CHECK_ERR | CATCH_COPROCESSOR_ERR | CATCH_CORE_RESET)
 
+    # Events
+    EVENT_POST_CONNECT = 1
+    EVENT_PRE_DISCONNECT = 2
+    EVENT_PRE_RUN = 3 # data is run type
+    EVENT_POST_RUN = 4 # data is run type
+    EVENT_PRE_HALT = 5 # data is halt reason
+    EVENT_POST_HALT = 6 # data is halt reason
+    EVENT_PRE_RESET = 7
+    EVENT_POST_RESET = 8
+
+    # Run types
+    RUN_TYPE_RESUME = 1
+    RUN_TYPE_STEP = 2
+
+    # Halt reasons
+    HALT_REASON_USER = 1
+    HALT_REASON_DEBUG = 2
+
     def __init__(self, link, memoryMap=None):
+        super(Target, self).__init__()
         self.link = link
         self.flash = None
         self.part_number = ""

--- a/pyOCD/core/target.py
+++ b/pyOCD/core/target.py
@@ -60,6 +60,8 @@ class Target(Notifier):
     EVENT_POST_HALT = 6 # data is halt reason
     EVENT_PRE_RESET = 7
     EVENT_POST_RESET = 8
+    EVENT_PRE_FLASH_PROGRAM = 9
+    EVENT_POST_FLASH_PROGRAM = 10
 
     # Run types
     RUN_TYPE_RESUME = 1
@@ -73,6 +75,7 @@ class Target(Notifier):
         super(Target, self).__init__()
         self.link = link
         self.flash = None
+        self.root_target = None
         self.part_number = ""
         self.memory_map = memoryMap or MemoryMap()
         self.halt_on_connect = True

--- a/pyOCD/coresight/cortex_m.py
+++ b/pyOCD/coresight/cortex_m.py
@@ -285,9 +285,10 @@ class CortexM(Target):
         RegisterInfo('s31',     32,         'float',        'float'),
         ]
 
-    def __init__(self, link, dp, ap, memoryMap=None, core_num=0):
-        super(CortexM, self).__init__(link, memoryMap)
+    def __init__(self, rootTarget, dp, ap, memoryMap=None, core_num=0):
+        super(CortexM, self).__init__(rootTarget.link, memoryMap)
 
+        self.root_target = rootTarget
         self.arch = 0
         self.core_type = 0
         self.has_fpu = False

--- a/pyOCD/flash/flash_builder.py
+++ b/pyOCD/flash/flash_builder.py
@@ -16,6 +16,7 @@
 """
 
 from ..core.target import Target
+from ..utility.notification import Notification
 import logging
 from struct import unpack
 from time import time
@@ -142,6 +143,9 @@ class FlashBuilder(object):
         Data must have already been added with addData
         """
 
+        # Send notification that we're about to program flash.
+        self.flash.target.notify(Notification(event=Target.EVENT_PRE_FLASH_PROGRAM, source=self))
+
         # Assumptions
         # 1. Page erases must be on page boundaries ( page_erase_addr % page_size == 0 )
         # 2. Page erase can have a different size depending on location
@@ -258,6 +262,9 @@ class FlashBuilder(object):
         self.perf.program_type = flash_operation
 
         logging.info("Programmed %d bytes (%d pages) at %.02f kB/s", program_byte_count, len(self.page_list), ((program_byte_count/1024) / self.perf.program_time))
+
+        # Send notification that we're done programming flash.
+        self.flash.target.notify(Notification(event=Target.EVENT_POST_FLASH_PROGRAM, source=self))
 
         return self.perf
 

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -257,12 +257,15 @@ class GDBServer(threading.Thread):
         self.thread_provider = None
         self.did_init_thread_providers = False
         self.current_thread_id = 0
+        self.first_run_after_reset_or_flash = True
         if self.wss_server == None:
             self.abstract_socket = GDBSocket(self.port, self.packet_size)
             if self.serve_local_only:
                 self.abstract_socket.host = 'localhost'
         else:
             self.abstract_socket = GDBWebSocket(self.wss_server)
+
+        self.target.subscribe(Target.EVENT_POST_RESET, self.event_handler)
 
         # Init semihosting and telnet console.
         if self.semihost_use_syscalls:
@@ -627,6 +630,11 @@ class GDBServer(threading.Thread):
         self.target.resume()
         self.log.debug("target resumed")
 
+        if self.first_run_after_reset_or_flash:
+            self.first_run_after_reset_or_flash = False
+            if self.thread_provider is not None:
+                self.thread_provider.read_from_target = True
+
         val = ''
 
         while True:
@@ -827,6 +835,10 @@ class GDBServer(threading.Thread):
             # Set flash builder to None so that on the next flash command a new
             # object is used.
             self.flashBuilder = None
+
+            self.first_run_after_reset_or_flash = True
+            if self.thread_provider is not None:
+                self.thread_provider.read_from_target = False
 
             return self.createRSPPacket("OK")
 
@@ -1112,6 +1124,9 @@ class GDBServer(threading.Thread):
                 self.step_into_interrupt = (cmdList[2].lower() in ("true", "on", "yes", "1"))
             else:
                 resp = hexEncode("Error: invalid set option")
+        elif cmd == "flush threads":
+            if self.thread_provider is not None:
+                self.thread_provider.invalidate()
         else:
             resultMask = 0x00
             if cmdList[0] == 'help':
@@ -1281,5 +1296,14 @@ class GDBServer(threading.Thread):
     def is_threading_enabled(self):
         return (self.thread_provider is not None) and self.thread_provider.is_enabled \
             and (self.thread_provider.current_thread is not None)
+
+
+    def event_handler(self, notification):
+        if notification.event == Target.EVENT_POST_RESET:
+            # Invalidate threads list if flash is reprogrammed.
+            self.log.debug("Received EVENT_POST_RESET event")
+            self.first_run_after_reset_or_flash = True
+            if self.thread_provider is not None:
+                self.thread_provider.read_from_target = False
 
 

--- a/pyOCD/rtos/provider.py
+++ b/pyOCD/rtos/provider.py
@@ -48,6 +48,7 @@ class ThreadProvider(object):
         self._target = target
         self._target_context = self._target.getTargetContext()
         self._last_run_token = -1
+        self._read_from_target = False
 
     def _lookup_symbols(self, symbolList, symbolProvider):
         syms = {}
@@ -77,7 +78,7 @@ class ThreadProvider(object):
         return True
 
     def update_threads(self):
-        if self._is_thread_list_dirty():
+        if self._is_thread_list_dirty() and self._read_from_target:
             self._build_thread_list()
 
     def get_threads(self):
@@ -85,6 +86,19 @@ class ThreadProvider(object):
 
     def get_thread(self, threadId):
         raise NotImplementedError()
+
+    def invalidate(self):
+        raise NotImplementedError()
+
+    @property
+    def read_from_target(self):
+        return self._read_from_target
+
+    @read_from_target.setter
+    def read_from_target(self, value):
+        if value != self._read_from_target:
+            self.invalidate()
+        self._read_from_target = value
 
     @property
     def is_enabled(self):

--- a/pyOCD/utility/__init__.py
+++ b/pyOCD/utility/__init__.py
@@ -15,6 +15,3 @@
  limitations under the License.
 """
 
-import conversion
-import cmdline
-import mask

--- a/pyOCD/utility/notification.py
+++ b/pyOCD/utility/notification.py
@@ -1,0 +1,67 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2016 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import logging
+
+##
+# @brief Class that holds information about a notification to subscribers.
+class Notification(object):
+    def __init__(self, event, source, data=None):
+        self._event = event
+        self._source = source
+        self._data = data
+
+    @property
+    def event(self):
+        return self._event
+
+    @property
+    def source(self):
+        return self._source
+
+    @property
+    def data(self):
+        return self._data
+
+    def __repr__(self):
+        return "<Notification@0x%08x event=%s source=%s data=%s>" % (id(self), repr(self.event), repr(self.source), repr(self.data))
+
+##
+# @brief
+class Notifier(object):
+    def __init__(self):
+        self._subscribers = {}
+
+    def subscribe(self, events, cb):
+        if not type(events) in (list, tuple):
+            events = [events]
+        for event in events:
+            if self._subscribers.has_key(event):
+                self._subscribers[event].append(cb)
+            else:
+                self._subscribers[event] = [cb]
+
+    def unsubscribe(self, events, cb):
+        pass
+
+    def notify(self, *notifications):
+        for note in notifications:
+            logging.debug("Sending notification: %s", repr(note))
+            for cb in self._subscribers.get(note.event, []):
+                cb(note)
+
+


### PR DESCRIPTION
This change set provides a workaround for stale RTOS information caused by previous firmware builds leaving valid but stale data in RAM across a reset. It also brings in a simple notification system for target events.
