### PR TITLE
Fixed param for creating CortexM in dual core parts

### DIFF
--- a/pyOCD/target/target_K32W042S1M2xxx.py
+++ b/pyOCD/target/target_K32W042S1M2xxx.py
@@ -252,7 +252,7 @@ class K32W042S(Kinetis):
         self.add_ap(core1_ap)
 
         # Add second core. It is held in reset until released by software.
-        core1 = CortexM(self.link, self.dp, core1_ap, self.memory_map, core_num=1)
+        core1 = CortexM(self, self.dp, core1_ap, self.memory_map, core_num=1)
         core1.init()
         self.add_core(core1)
 

--- a/pyOCD/target/target_LPC54114J256BD64.py
+++ b/pyOCD/target/target_LPC54114J256BD64.py
@@ -108,6 +108,6 @@ class LPC54114(CoreSightTarget):
             self.core1_ap.init(True)
 
             # Add second core.
-            self.core1 = CortexM(self.link, self.dp, self.core1_ap, self.memory_map, core_num=1)
+            self.core1 = CortexM(self, self.dp, self.core1_ap, self.memory_map, core_num=1)
             self.cores[1] = self.core1
             self.core1.init()

--- a/pyOCD/target/target_MKL28Z512xxx7.py
+++ b/pyOCD/target/target_MKL28Z512xxx7.py
@@ -192,7 +192,7 @@ class KL28x(Kinetis):
             self.add_ap(core1_ap)
 
             # Add second core. It is held in reset until released by software.
-            core1 = CortexM(self.link, self.dp, core1_ap, self.memory_map, core_num=1)
+            core1 = CortexM(self, self.dp, core1_ap, self.memory_map, core_num=1)
             core1.init()
             self.add_core(core1)
 


### PR DESCRIPTION
Commit 9e4ac93 changed the first parameter of the `CortexM` ctor to be a `Target` and not a link object. This patch passes the correct object when creating secondary core `CortexM` instances for a few multicore devices. (Currently any secondary cores must be manually created. This will change.)