### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ htmlcov
 # Common virtualenv environment names
 /env
 /env3
-/venv
+/venv*
 /dev
 /windev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
-language: python
+dist: trusty
 sudo: false
+language: python
 python:
   - "2.7"
+  - "3.6"
 # command to install dependencies
-install: "pip install -r dev-requirements.txt"
+install:
+  - pip install -r dev-requirements.txt
 # command to run tests
-script: pytest --cache-clear
+script:
+  - pytest --cache-clear

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,8 @@
+include pytest.ini
+include Doxyfile
+include dev-requirements.txt
 recursive-include binaries *
 recursive-include elf_files *
-recursive-include pyOCD *.ld *.txt *.c *.bat
+recursive-include src *.ld *.txt *.c *.bat *.py
+recursive-include test *.py *.sh
+global-exclude .DS_Store

--- a/pyOCD/__init__.py
+++ b/pyOCD/__init__.py
@@ -15,14 +15,14 @@
  limitations under the License.
 """
 
-import board
-import core
-import debug
-import flash
-import gdbserver
-import target
-import utility
-import coresight
+from . import board
+from . import core
+from . import debug
+from . import flash
+from . import gdbserver
+from . import target
+from . import utility
+from . import coresight
 
 from ._version import version as __version__
 

--- a/pyOCD/board/__init__.py
+++ b/pyOCD/board/__init__.py
@@ -15,5 +15,5 @@
  limitations under the License.
 """
 
-import mbed_board
-from mbed_board import MbedBoard
+from . import mbed_board
+from .mbed_board import MbedBoard

--- a/pyOCD/board/mbed_board.py
+++ b/pyOCD/board/mbed_board.py
@@ -15,11 +15,13 @@
  limitations under the License.
 """
 
+from __future__ import print_function
 import sys, os
 import logging, array
 from time import sleep
 import colorama
-from board import Board
+import six
+from .board import Board
 from ..pyDAPAccess import DAPAccess
 from .board_ids import BOARD_ID_TO_INFO
 
@@ -97,8 +99,12 @@ class MbedBoard(Board):
         all_mbeds = MbedBoard.getAllConnectedBoards(dap_class, close=True,
                                                     blocking=False)
         if len(all_mbeds) > 0:
+            print(colorama.Fore.BLUE + "## => Board Name | Unique ID")
+            print("-- -- ----------------------")
             for index, mbed in enumerate(sorted(all_mbeds, key=lambda x:x.getInfo())):
-                print("%d => %s boardId => %s" % (index, mbed.getInfo().encode('ascii', 'ignore'), mbed.unique_id))
+                print(colorama.Fore.GREEN + "%2d => %s | %s" % (
+                    index, mbed.getInfo(),
+                    colorama.Fore.CYAN + mbed.unique_id) + colorama.Style.RESET_ALL)
         else:
             print("No available boards are connected")
 
@@ -155,9 +161,9 @@ class MbedBoard(Board):
                 for mbed in all_mbeds:
                     head, sep, tail = mbed.unique_id.lower().rpartition(board_id)
                     highlightedId = head + colorama.Fore.RED + sep + colorama.Style.RESET_ALL + tail
-                    print "%s | %s" % (
-                        mbed.getInfo().encode('ascii', 'ignore'),
-                        highlightedId)
+                    print("%s | %s" % (
+                        mbed.getInfo(),
+                        highlightedId))
                 return None
             all_mbeds = new_mbed_list
 
@@ -173,20 +179,20 @@ class MbedBoard(Board):
         if return_first:
             all_mbeds = all_mbeds[0:1]
 
-        # Ask use to select boards if there is more than 1 left
+        # Ask user to select boards if there is more than 1 left
         if len(all_mbeds) > 1:
             all_mbeds = sorted(all_mbeds, key=lambda x:x.getInfo())
-            print colorama.Fore.BLUE + "## => Board Name | Unique ID"
-            print "-- -- ----------------------"
+            print(colorama.Fore.BLUE + "## => Board Name | Unique ID")
+            print("-- -- ----------------------")
             for index, mbed in enumerate(all_mbeds):
-                print colorama.Fore.GREEN + "%2d => %s | %s" % (
-                    index, mbed.getInfo().encode('ascii', 'ignore'),
-                    colorama.Fore.CYAN + mbed.unique_id)
-            print colorama.Fore.RED + " q => Quit"
+                print(colorama.Fore.GREEN + "%2d => %s | %s" % (
+                    index, mbed.getInfo(),
+                    colorama.Fore.CYAN + mbed.unique_id))
+            print(colorama.Fore.RED + " q => Quit")
             while True:
-                print colorama.Style.RESET_ALL
-                print "Enter the number of the board to connect:"
-                line = raw_input("> ")
+                print(colorama.Style.RESET_ALL)
+                print("Enter the number of the board to connect:")
+                line = six.moves.input("> ")
                 valid = False
                 if line.strip().lower() == 'q':
                     return None
@@ -196,10 +202,10 @@ class MbedBoard(Board):
                 except ValueError:
                     pass
                 if not valid:
-                    print colorama.Fore.YELLOW + "Invalid choice: %s\n" % line
+                    print(colorama.Fore.YELLOW + "Invalid choice: %s\n" % line)
                     for index, mbed in enumerate(all_mbeds):
-                        print colorama.Fore.GREEN + "%d => %s" % (index, mbed.getInfo())
-                    print colorama.Fore.RED + "q => Exit"
+                        print(colorama.Fore.GREEN + "%d => %s" % (index, mbed.getInfo()))
+                    print(colorama.Fore.RED + "q => Exit")
                 else:
                     break
             all_mbeds = all_mbeds[ch:ch + 1]

--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -45,7 +45,7 @@ class CoreSightTarget(Target):
         return self.cores[self._selected_core]
 
     def select_core(self, num):
-        if not self.cores.has_key(num):
+        if num not in self.cores:
             raise ValueError("invalid core number")
         logging.debug("selected core #%d" % num)
         self._selected_core = num

--- a/pyOCD/core/memory_map.py
+++ b/pyOCD/core/memory_map.py
@@ -20,7 +20,7 @@ from xml.etree import ElementTree
 __all__ = ['MemoryRange', 'MemoryRegion', 'MemoryMap', 'RamRegion', 'RomRegion',
             'FlashRegion', 'DeviceRegion', 'AliasRegion']
 
-MAP_XML_HEADER = """<?xml version="1.0"?>
+MAP_XML_HEADER = b"""<?xml version="1.0"?>
 <!DOCTYPE memory-map PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN" "http://sourceware.org/gdb/gdb-memory-map.dtd">
 """
 

--- a/pyOCD/coresight/ap.py
+++ b/pyOCD/coresight/ap.py
@@ -287,7 +287,7 @@ class MEM_AP(AccessPort):
 
         # try to read aligned block of 32bits
         if (size >= 4):
-            mem = self.readBlockMemoryAligned32(addr, size/4)
+            mem = self.readBlockMemoryAligned32(addr, size//4)
             res += conversion.u32leListToByteList(mem)
             size -= 4*len(mem)
             addr += 4*len(mem)

--- a/pyOCD/coresight/dap.py
+++ b/pyOCD/coresight/dap.py
@@ -177,7 +177,7 @@ class DebugPort(object):
                 if idr == 0:
                     break
                 logging.info("AP#%d IDR = 0x%08x", ap_num, idr)
-            except Exception, e:
+            except Exception as e:
                 logging.error("Exception reading AP#%d IDR: %s", ap_num, repr(e))
                 break
             ap_num += 1
@@ -242,7 +242,7 @@ class DebugPort(object):
 
         # Don't need to write CSW if it's not changing value.
         if ap_regaddr == AP_REG['CSW']:
-            if self._csw.has_key(ap_sel) and data == self._csw[ap_sel]:
+            if ap_sel in self._csw and data == self._csw[ap_sel]:
                 if LOG_DAP:
                     self.logger.info("writeAP:%06d cached (addr=0x%08x) = 0x%08x", num, addr, data)
                 return

--- a/pyOCD/debug/breakpoints/manager.py
+++ b/pyOCD/debug/breakpoints/manager.py
@@ -146,18 +146,18 @@ class BreakpointManager(object):
         return bp.type if (bp is not None) else None
 
     def filter_memory(self, addr, size, data):
-        for provider in [p for p in self._providers.itervalues() if p.do_filter_memory]:
+        for provider in [p for p in self._providers.values() if p.do_filter_memory]:
             data = provider.filter_memory(addr, size, data)
         return data
 
     def filter_memory_unaligned_8(self, addr, size, data):
-        for provider in [p for p in self._providers.itervalues() if p.do_filter_memory]:
+        for provider in [p for p in self._providers.values() if p.do_filter_memory]:
             for i, d in enumerate(data):
                 data[i] = provider.filter_memory(addr + i, 8, d)
         return data
 
     def filter_memory_aligned_32(self, addr, size, data):
-        for provider in [p for p in self._providers.itervalues() if p.do_filter_memory]:
+        for provider in [p for p in self._providers.values() if p.do_filter_memory]:
             for i, d in enumerate(data):
                 data[i] = provider.filter_memory(addr + i, 32, d)
         return data
@@ -170,7 +170,7 @@ class BreakpointManager(object):
 
     def _flush_all(self):
         # Flush all providers.
-        for provider in self._providers.itervalues():
+        for provider in self._providers.values():
             provider.flush()
 
     def flush(self):

--- a/pyOCD/debug/cache.py
+++ b/pyOCD/debug/cache.py
@@ -114,7 +114,7 @@ class RegisterCache(object):
         reg_set = set(reg_list)
 
         # Get list of values we have cached.
-        cached_set = set(r for r in reg_list if self._cache.has_key(r))
+        cached_set = set(r for r in reg_list if r in self._cache)
         self._metrics.hits += len(cached_set)
 
         # Read uncached registers from the target.

--- a/pyOCD/debug/semihost.py
+++ b/pyOCD/debug/semihost.py
@@ -24,6 +24,7 @@ import datetime
 import threading
 import socket
 import traceback
+import six
 import pyOCD
 from ..gdbserver.gdb_socket import GDBSocket
 from ..gdbserver.gdb_websocket import GDBWebSocket
@@ -171,7 +172,7 @@ class InternalSemihostIOHandler(SemihostIOHandler):
             }
 
     def _is_valid_fd(self, fd):
-         return self.open_files.has_key(fd) and self.open_files[fd] is not None
+         return fd in self.open_files and self.open_files[fd] is not None
 
     def cleanup(self):
         for f in (self.open_files[k] for k in self.open_files if k > STDERR_FD):
@@ -217,7 +218,7 @@ class InternalSemihostIOHandler(SemihostIOHandler):
         try:
             f = self.open_files[fd]
             if 'b' not in f.mode:
-                data = unicode(data)
+                data = six.text_type(data)
             f.write(data)
             f.flush()
             return 0

--- a/pyOCD/flash/flash.py
+++ b/pyOCD/flash/flash.py
@@ -19,7 +19,7 @@ from ..core.target import Target
 import logging
 from struct import unpack
 from time import time
-from flash_builder import FlashBuilder
+from .flash_builder import FlashBuilder
 
 DEFAULT_PAGE_PROGRAM_WEIGHT = 0.130
 DEFAULT_PAGE_ERASE_WEIGHT = 0.048
@@ -88,7 +88,7 @@ class Flash(object):
             self.min_program_length = flash_algo.get('min_program_length', 0)
 
             # Check for double buffering support.
-            if flash_algo.has_key('page_buffers'):
+            if 'page_buffers' in flash_algo:
                 self.page_buffers = flash_algo['page_buffers']
             else:
                 self.page_buffers = [self.begin_data]

--- a/pyOCD/gdbserver/__init__.py
+++ b/pyOCD/gdbserver/__init__.py
@@ -15,4 +15,4 @@
  limitations under the License.
 """
 
-from gdbserver import GDBServer
+from .gdbserver import GDBServer

--- a/pyOCD/gdbserver/context_facade.py
+++ b/pyOCD/gdbserver/context_facade.py
@@ -18,6 +18,7 @@
 from ..utility import conversion
 from . import signals
 import logging
+import six
 
 # Maps the fault code found in the IPSR to a GDB signal value.
 FAULT = [
@@ -49,12 +50,12 @@ class GDBDebugContextFacade(object):
         return hexadecimal dump of registers as expected by GDB
         """
         logging.debug("GDB getting register context")
-        resp = ''
+        resp = b''
         reg_num_list = [reg.reg_num for reg in self._register_list]
         vals = self._context.readCoreRegistersRaw(reg_num_list)
         #print("Vals: %s" % vals)
         for reg, regValue in zip(self._register_list, vals):
-            resp += conversion.u32beToHex8le(regValue)
+            resp += six.b(conversion.u32beToHex8le(regValue))
             logging.debug("GDB reg: %s = 0x%X", reg.name, regValue)
 
         return resp
@@ -92,7 +93,7 @@ class GDBDebugContextFacade(object):
         if reg < len(self._register_list):
             regName = self._register_list[reg].name
             regValue = self._context.readCoreRegisterRaw(regName)
-            resp = conversion.u32beToHex8le(regValue)
+            resp = six.b(conversion.u32beToHex8le(regValue))
             logging.debug("GDB reg: %s = 0x%X", regName, regValue)
         return resp
 
@@ -103,9 +104,9 @@ class GDBDebugContextFacade(object):
             The current value of the important registers (sp, lr, pc).
         """
         if forceSignal is not None:
-            response = 'T' + conversion.byteToHex2(forceSignal)
+            response = six.b('T' + conversion.byteToHex2(forceSignal))
         else:
-            response = 'T' + conversion.byteToHex2(self.getSignalValue())
+            response = six.b('T' + conversion.byteToHex2(self.getSignalValue()))
 
         # Append fp(r7), sp(r13), lr(r14), pc(r15)
         response += self.getRegIndexValuePairs([7, 13, 14, 15])
@@ -131,10 +132,10 @@ class GDBDebugContextFacade(object):
             for the T response string.  NN is the index of the
             register to follow MMMMMMMM is the value of the register.
         """
-        str = ''
+        str = b''
         regList = self._context.readCoreRegistersRaw(regIndexList)
         for regIndex, reg in zip(regIndexList, regList):
-            str += conversion.byteToHex2(regIndex) + ':' + conversion.u32beToHex8le(reg) + ';'
+            str += six.b(conversion.byteToHex2(regIndex) + ':' + conversion.u32beToHex8le(reg) + ';')
         return str
 
     def getMemoryMapXML(self):

--- a/pyOCD/gdbserver/context_facade.py
+++ b/pyOCD/gdbserver/context_facade.py
@@ -50,7 +50,7 @@ class GDBDebugContextFacade(object):
         """
         logging.debug("GDB getting register context")
         resp = ''
-        reg_num_list = map(lambda reg:reg.reg_num, self._register_list)
+        reg_num_list = [reg.reg_num for reg in self._register_list]
         vals = self._context.readCoreRegistersRaw(reg_num_list)
         #print("Vals: %s" % vals)
         for reg, regValue in zip(self._register_list, vals):

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2015 ARM Limited
+ Copyright (c) 2006-2018 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ from pyOCD.pyDAPAccess import DAPAccess
 from ..utility.cmdline import convert_vector_catch
 from ..utility.conversion import (hexToByteList, hexEncode, hexDecode, hex8leToU32le)
 from ..utility.progress import print_progress
+from ..utility.py3_helpers import (iter_single_bytes, to_bytes_safe)
 from .gdb_socket import GDBSocket
 from .gdb_websocket import GDBWebSocket
 from .syscall import GDBSyscallIOHandler
@@ -34,10 +35,11 @@ from struct import unpack
 from time import (sleep, time)
 import sys
 import traceback
+import six
 from six.moves import queue
 from xml.etree.ElementTree import (Element, SubElement, tostring)
 
-CTRL_C = '\x03'
+CTRL_C = b'\x03'
 
 # Logging options. Set to True to enable.
 LOG_MEM = False # Log memory accesses.
@@ -45,7 +47,41 @@ LOG_ACK = False # Log ack or nak.
 LOG_PACKETS = False # Log all packets sent and received.
 
 def checksum(data):
-    return "%02x" % (sum([ord(c) for c in data]) % 256)
+    return b"%02x" % (sum(six.iterbytes(data)) % 256)
+
+## @brief De-escapes binary data from Gdb.
+#
+# @param data Bytes-like object with possibly escaped values.
+# @return List of integers in the range 0-255, with all escaped bytes de-escaped.
+def unescape(data):
+    data_idx = 0
+
+    # unpack the data into binary array
+    str_unpack = str(len(data)) + 'B'
+    data = unpack(str_unpack, data)
+    data = list(data)
+
+    # check for escaped characters
+    while data_idx < len(data):
+        if data[data_idx] == 0x7d:
+            data.pop(data_idx)
+            data[data_idx] = data[data_idx] ^ 0x20
+        data_idx += 1
+
+    return data
+
+## @brief Escape binary data to be sent to Gdb.
+#
+# @param data Bytes-like object containing raw binary.
+# @return Bytes object with the characters in '#$}*' escaped as required by Gdb.
+def escape(data):
+    result = b''
+    for c in iter_single_bytes(data):
+        if c in b'#$}*':
+            result += b'}' + six.int2byte(six.byte2int(c) ^ 0x20)
+        else:
+            result += c
+    return result
 
 ## @brief Exception used to signal the GDB server connection closed.
 class ConnectionClosedException(Exception):
@@ -67,10 +103,10 @@ class GDBServerPacketIOThread(threading.Thread):
         self.interrupt_event = threading.Event()
         self.send_acks = True
         self._clear_send_acks = False
-        self._buffer = ''
+        self._buffer = b''
         self._expecting_ack = False
         self.drop_reply = False
-        self._last_packet = ''
+        self._last_packet = b''
         self._closed = False
         self.setDaemon(True)
         self.start()
@@ -154,8 +190,8 @@ class GDBServerPacketIOThread(threading.Thread):
 
     def _check_expected_ack(self):
         # Handle expected ack.
-        c = self._buffer[0]
-        if c in ('+', '-'):
+        c = self._buffer[0:1]
+        if c in (b'+', b'-'):
             self._buffer = self._buffer[1:]
             if LOG_ACK:
                 self.log.debug('got ack: %s', c)
@@ -179,14 +215,14 @@ class GDBServerPacketIOThread(threading.Thread):
                 self._check_expected_ack()
 
             # Check for a ctrl-c.
-            if len(self._buffer) and self._buffer[0] == CTRL_C:
+            if len(self._buffer) and self._buffer[0:1] == CTRL_C:
                 self.interrupt_event.set()
                 self._buffer = self._buffer[1:]
 
             try:
                 # Look for complete packet and extract from buffer.
-                pkt_begin = self._buffer.index("$")
-                pkt_end = self._buffer.index("#") + 2
+                pkt_begin = self._buffer.index(b"$")
+                pkt_end = self._buffer.index(b"#") + 2
                 if pkt_begin >= 0 and pkt_end < len(self._buffer):
                     pkt = self._buffer[pkt_begin:pkt_end + 1]
                     self._buffer = self._buffer[pkt_end + 1:]
@@ -199,12 +235,12 @@ class GDBServerPacketIOThread(threading.Thread):
 
     def _handling_incoming_packet(self, packet):
         # Compute checksum
-        data, cksum = packet[1:].split('#')
+        data, cksum = packet[1:].split(b'#')
         computedCksum = checksum(data)
         goodPacket = (computedCksum.lower() == cksum.lower())
 
         if self.send_acks:
-            ack = '+' if goodPacket else '-'
+            ack = b'+' if goodPacket else b'-'
             self._abstract_socket.write(ack)
             if LOG_ACK:
                 self.log.debug(ack)
@@ -306,31 +342,31 @@ class GDBServer(threading.Thread):
         #
         self.COMMANDS = {
         #       CMD    HANDLER                  START    DESCRIPTION
-                '?' : (self.stopReasonQuery,    0   ), # Stop reason query.
-                'c' : (self.resume,             1   ), # Continue (at addr)
-                'C' : (self.resume,             1   ), # Continue with signal.
-                'D' : (self.detach,             1   ), # Detach.
-                'g' : (self.getRegisters,       0   ), # Read general registers.
-                'G' : (self.setRegisters,       2   ), # Write general registers.
-                'H' : (self.setThread,          2   ), # Set thread for subsequent operations.
-                'k' : (self.kill,               0   ), # Kill.
-                'm' : (self.getMemory,          2   ), # Read memory.
-                'M' : (self.writeMemoryHex,     2   ), # Write memory (hex).
-                'p' : (self.readRegister,       2   ), # Read register.
-                'P' : (self.writeRegister,      2   ), # Write register.
-                'q' : (self.handleQuery,        2   ), # General query.
-                'Q' : (self.handleGeneralSet,   2   ), # General set.
-                's' : (self.step,               1   ), # Single step.
-                'S' : (self.step,               1   ), # Step with signal.
-                'T' : (self.isThreadAlive,      1   ), # Thread liveness query.
-                'v' : (self.vCommand,           2   ), # v command.
-                'X' : (self.writeMemory,        2   ), # Write memory (binary).
-                'z' : (self.breakpoint,         1   ), # Insert breakpoint/watchpoint.
-                'Z' : (self.breakpoint,         1   ), # Remove breakpoint/watchpoint.
+                b'?' : (self.stopReasonQuery,    0   ), # Stop reason query.
+                b'c' : (self.resume,             1   ), # Continue (at addr)
+                b'C' : (self.resume,             1   ), # Continue with signal.
+                b'D' : (self.detach,             1   ), # Detach.
+                b'g' : (self.getRegisters,       0   ), # Read general registers.
+                b'G' : (self.setRegisters,       2   ), # Write general registers.
+                b'H' : (self.setThread,          2   ), # Set thread for subsequent operations.
+                b'k' : (self.kill,               0   ), # Kill.
+                b'm' : (self.getMemory,          2   ), # Read memory.
+                b'M' : (self.writeMemoryHex,     2   ), # Write memory (hex).
+                b'p' : (self.readRegister,       2   ), # Read register.
+                b'P' : (self.writeRegister,      2   ), # Write register.
+                b'q' : (self.handleQuery,        2   ), # General query.
+                b'Q' : (self.handleGeneralSet,   2   ), # General set.
+                b's' : (self.step,               1   ), # Single step.
+                b'S' : (self.step,               1   ), # Step with signal.
+                b'T' : (self.isThreadAlive,      1   ), # Thread liveness query.
+                b'v' : (self.vCommand,           2   ), # v command.
+                b'X' : (self.writeMemory,        2   ), # Write memory (binary).
+                b'z' : (self.breakpoint,         1   ), # Insert breakpoint/watchpoint.
+                b'Z' : (self.breakpoint,         1   ), # Remove breakpoint/watchpoint.
             }
 
         # Commands that kill the connection to gdb.
-        self.DETACH_COMMANDS = ('D', 'k')
+        self.DETACH_COMMANDS = (b'D', b'k')
 
         self.setDaemon(True)
         self.start()
@@ -482,28 +518,28 @@ class GDBServer(threading.Thread):
 
     def handleMsg(self, msg):
         try:
-            assert msg[0] == '$', "invalid first char of message (!= $"
+            assert msg[0:1] == b'$', "invalid first char of message (!= $"
 
             try:
-                handler, msgStart = self.COMMANDS[msg[1]]
+                handler, msgStart = self.COMMANDS[msg[1:2]]
                 if msgStart == 0:
                     reply = handler()
                 else:
                     reply = handler(msg[msgStart:])
-                detach = 1 if msg[1] in self.DETACH_COMMANDS else 0
+                detach = 1 if msg[1:2] in self.DETACH_COMMANDS else 0
                 return reply, detach
             except (KeyError, IndexError):
                 self.log.error("Unknown RSP packet: %s", msg)
-                return self.createRSPPacket(""), 0
+                return self.createRSPPacket(b""), 0
 
         except Exception as e:
             self.log.error("Unhandled exception in handleMsg: %s", e)
             traceback.print_exc()
-            return self.createRSPPacket("E01"), 0
+            return self.createRSPPacket(b"E01"), 0
 
     def detach(self, data):
         self.log.info("Client detached")
-        resp = "OK"
+        resp = b"OK"
         return self.createRSPPacket(resp)
 
     def kill(self):
@@ -512,66 +548,66 @@ class GDBServer(threading.Thread):
         if not self.persist:
             self.board.target.setVectorCatch(Target.CATCH_NONE)
             self.board.target.resume()
-        return self.createRSPPacket("")
+        return self.createRSPPacket(b"")
 
     def breakpoint(self, data):
         # handle breakpoint/watchpoint commands
-        split = data.split('#')[0].split(',')
+        split = data.split(b'#')[0].split(b',')
         addr = int(split[1], 16)
-        self.log.debug("GDB breakpoint %s%d @ %x" % (data[0], int(data[1]), addr))
+        self.log.debug("GDB breakpoint %s%d @ %x" % (data[0:1], int(data[1:2]), addr))
 
         # handle software breakpoint Z0/z0
-        if data[1] == '0' and not self.soft_bkpt_as_hard:
-            if data[0] == 'Z':
+        if data[1:2] == b'0' and not self.soft_bkpt_as_hard:
+            if data[0:1] == b'Z':
                 if not self.target.setBreakpoint(addr, Target.BREAKPOINT_SW):
-                    return self.createRSPPacket('E01') #EPERM
+                    return self.createRSPPacket(b'E01') #EPERM
             else:
                 self.target.removeBreakpoint(addr)
-            return self.createRSPPacket("OK")
+            return self.createRSPPacket(b"OK")
 
         # handle hardware breakpoint Z1/z1
-        if data[1] == '1' or (self.soft_bkpt_as_hard and data[1] == '0'):
-            if data[0] == 'Z':
+        if data[1:2] == b'1' or (self.soft_bkpt_as_hard and data[1:2] == b'0'):
+            if data[0:1] == b'Z':
                 if self.target.setBreakpoint(addr, Target.BREAKPOINT_HW) == False:
-                    return self.createRSPPacket('E01') #EPERM
+                    return self.createRSPPacket(b'E01') #EPERM
             else:
                 self.target.removeBreakpoint(addr)
-            return self.createRSPPacket("OK")
+            return self.createRSPPacket(b"OK")
 
         # handle hardware watchpoint Z2/z2/Z3/z3/Z4/z4
-        if data[1] == '2':
+        if data[1:2] == b'2':
             # Write-only watch
             watchpoint_type = Target.WATCHPOINT_WRITE
-        elif data[1] == '3':
+        elif data[1:2] == b'3':
             # Read-only watch
             watchpoint_type = Target.WATCHPOINT_READ
-        elif data[1] == '4':
+        elif data[1:2] == b'4':
             # Read-Write watch
             watchpoint_type = Target.WATCHPOINT_READ_WRITE
         else:
-            return self.createRSPPacket('E01') #EPERM
+            return self.createRSPPacket(b'E01') #EPERM
 
         size = int(split[2], 16)
-        if data[0] == 'Z':
+        if data[0:1] == b'Z':
             if self.target.setWatchpoint(addr, size, watchpoint_type) == False:
-                return self.createRSPPacket('E01') #EPERM
+                return self.createRSPPacket(b'E01') #EPERM
         else:
             self.target.removeWatchpoint(addr, size, watchpoint_type)
-        return self.createRSPPacket("OK")
+        return self.createRSPPacket(b"OK")
 
     def setThread(self, data):
         if not self.is_threading_enabled():
-            return self.createRSPPacket('OK')
+            return self.createRSPPacket(b'OK')
 
         self.log.debug("setThread:%s", data)
-        op = data[0]
+        op = data[0:1]
         thread_id = int(data[1:-3], 16)
         if not (thread_id in (0, -1) or self.thread_provider.is_valid_thread_id(thread_id)):
-            return self.createRSPPacket('E01')
+            return self.createRSPPacket(b'E01')
 
-        if op == 'c':
+        if op == b'c':
             pass
-        elif op == 'g':
+        elif op == b'g':
             if thread_id == -1:
                 self.target_facade.set_context(self.target_context)
             else:
@@ -582,10 +618,10 @@ class GDBServer(threading.Thread):
                     thread = self.thread_provider.get_thread(thread_id)
                 self.target_facade.set_context(thread.context)
         else:
-            return self.createRSPPacket('E01')
+            return self.createRSPPacket(b'E01')
 
         self.current_thread_id = thread_id
-        return self.createRSPPacket('OK')
+        return self.createRSPPacket(b'OK')
 
     def isThreadAlive(self, data):
         threadId = int(data[1:-3], 16)
@@ -596,10 +632,10 @@ class GDBServer(threading.Thread):
             isAlive = (threadId == 1)
 
         if isAlive:
-            return self.createRSPPacket('OK')
+            return self.createRSPPacket(b'OK')
         else:
             self.validateDebugContext()
-            return self.createRSPPacket('E00')
+            return self.createRSPPacket(b'E00')
 
     def validateDebugContext(self):
         if self.is_threading_enabled():
@@ -616,22 +652,22 @@ class GDBServer(threading.Thread):
     def stopReasonQuery(self):
         # In non-stop mode, if no threads are stopped we need to reply with OK.
         if self.non_stop and self.is_target_running:
-            return self.createRSPPacket("OK")
+            return self.createRSPPacket(b"OK")
 
         return self.createRSPPacket(self.getTResponse())
 
     def _get_resume_step_addr(self, data):
         if data is None:
             return None
-        data = data.split('#')[0]
-        if ';' not in data:
+        data = data.split(b'#')[0]
+        if b';' not in data:
             return None
         # c[;addr]
-        if data[0] in ('c', 's'):
+        if data[0:1] in (b'c', b's'):
             addr = int(data[2:], base=16)
         # Csig[;addr]
-        elif data[0] in ('C', 'S'):
-            addr = int(data[1:].split(';')[1], base=16)
+        elif data[0:1] in (b'C', b'S'):
+            addr = int(data[1:].split(b';')[1], base=16)
         return addr
 
     def resume(self, data):
@@ -644,7 +680,7 @@ class GDBServer(threading.Thread):
             if self.thread_provider is not None:
                 self.thread_provider.read_from_target = True
 
-        val = ''
+        val = b''
 
         while True:
             if self.shutdown_event.isSet():
@@ -680,7 +716,7 @@ class GDBServer(threading.Thread):
                     pass
                 traceback.print_exc()
                 self.log.debug('Target is unavailable temporarily.')
-                val = 'S%02x' % self.target_facade.getSignalValue()
+                val = b'S%02x' % self.target_facade.getSignalValue()
                 break
 
         return self.createRSPPacket(val)
@@ -697,36 +733,36 @@ class GDBServer(threading.Thread):
 
     def sendStopNotification(self, forceSignal=None):
         data = self.getTResponse(forceSignal=forceSignal)
-        packet = '%Stop:' + data + '#' + checksum(data)
+        packet = b'%Stop:' + data + b'#' + checksum(data)
         self.packet_io.send(packet)
 
     def vCommand(self, data):
-        cmd = data.split('#')[0]
+        cmd = data.split(b'#')[0]
 
         # Flash command.
-        if cmd.startswith('Flash'):
+        if cmd.startswith(b'Flash'):
             return self.flashOp(data)
 
         # vCont capabilities query.
-        elif 'Cont?' == cmd:
-            return self.createRSPPacket("vCont;c;C;s;S;t")
+        elif b'Cont?' == cmd:
+            return self.createRSPPacket(b"vCont;c;C;s;S;t")
 
         # vCont, thread action command.
-        elif cmd.startswith('Cont'):
+        elif cmd.startswith(b'Cont'):
             return self.vCont(cmd)
 
         # vStopped, part of thread stop state notification sequence.
-        elif 'Stopped' in cmd:
+        elif b'Stopped' in cmd:
             # Because we only support one thread for now, we can just reply OK to vStopped.
-            return self.createRSPPacket("OK")
+            return self.createRSPPacket(b"OK")
 
-        return self.createRSPPacket("")
+        return self.createRSPPacket(b"")
 
     # Example: $vCont;s:1;c#c1
     def vCont(self, cmd):
-        ops = cmd.split(';')[1:] # split and remove 'Cont' from list
+        ops = cmd.split(b';')[1:] # split and remove 'Cont' from list
         if not ops:
-            return self.createRSPPacket("OK")
+            return self.createRSPPacket(b"OK")
 
         if self.is_threading_enabled():
             thread_actions = {}
@@ -740,7 +776,7 @@ class GDBServer(threading.Thread):
         default_action = None
 
         for op in ops:
-            args = op.split(':')
+            args = op.split(b':')
             action = args[0]
             if len(args) > 1:
                 thread_id = int(args[1], 16)
@@ -755,50 +791,50 @@ class GDBServer(threading.Thread):
         # Only the current thread is supported at the moment.
         if thread_actions[currentThread] is None:
             if default_action is None:
-                return self.createRSPPacket('E01')
+                return self.createRSPPacket(b'E01')
             thread_actions[currentThread] = default_action
 
-        if thread_actions[currentThread][0] in ('c', 'C'):
+        if thread_actions[currentThread][0:1] in (b'c', b'C'):
             if self.non_stop:
                 self.target.resume()
                 self.is_target_running = True
-                return self.createRSPPacket("OK")
+                return self.createRSPPacket(b"OK")
             else:
                 return self.resume(None)
-        elif thread_actions[currentThread][0] in ('s', 'S'):
+        elif thread_actions[currentThread][0:1] in (b's', b'S'):
             if self.non_stop:
                 self.target.step(not self.step_into_interrupt)
-                self.packet_io.send(self.createRSPPacket("OK"))
+                self.packet_io.send(self.createRSPPacket(b"OK"))
                 self.sendStopNotification()
                 return None
             else:
                 return self.step(None)
-        elif thread_actions[currentThread] == 't':
+        elif thread_actions[currentThread] == b't':
             # Must ignore t command in all-stop mode.
             if not self.non_stop:
-                return self.createRSPPacket("")
-            self.packet_io.send(self.createRSPPacket("OK"))
+                return self.createRSPPacket(b"")
+            self.packet_io.send(self.createRSPPacket(b"OK"))
             self.target.halt()
             self.is_target_running = False
             self.sendStopNotification(forceSignal=0)
         else:
-            self.log.error("Unsupported vCont action '%s'" % thread_actions[1])
+            self.log.error("Unsupported vCont action '%s'" % thread_actions[1:2])
 
     def flashOp(self, data):
-        ops = data.split(':')[0]
+        ops = data.split(b':')[0]
         self.log.debug("flash op: %s", ops)
 
-        if ops == 'FlashErase':
-            return self.createRSPPacket("OK")
+        if ops == b'FlashErase':
+            return self.createRSPPacket(b"OK")
 
-        elif ops == 'FlashWrite':
-            write_addr = int(data.split(':')[1], 16)
+        elif ops == b'FlashWrite':
+            write_addr = int(data.split(b':')[1], 16)
             self.log.debug("flash write addr: 0x%x", write_addr)
             # search for second ':' (beginning of data encoded in the message)
             second_colon = 0
             idx_begin = 0
             while second_colon != 2:
-                if data[idx_begin] == ':':
+                if data[idx_begin] == b':':
                     second_colon += 1
                 idx_begin += 1
 
@@ -807,13 +843,12 @@ class GDBServer(threading.Thread):
                 self.flashBuilder = self.flash.getFlashBuilder()
 
             # Add data to flash builder
-            self.flashBuilder.addData(write_addr, self.unescape(data[idx_begin:len(data) - 3]))
+            self.flashBuilder.addData(write_addr, unescape(data[idx_begin:len(data) - 3]))
 
-
-            return self.createRSPPacket("OK")
+            return self.createRSPPacket(b"OK")
 
         # we need to flash everything
-        elif 'FlashDone' in ops :
+        elif b'FlashDone' in ops :
             if self.hide_programming_progress:
                 progress_cb = None
             else:
@@ -829,71 +864,45 @@ class GDBServer(threading.Thread):
             if self.thread_provider is not None:
                 self.thread_provider.read_from_target = False
 
-            return self.createRSPPacket("OK")
+            return self.createRSPPacket(b"OK")
 
         return None
 
-    def unescape(self, data):
-        data_idx = 0
-
-        # unpack the data into binary array
-        str_unpack = str(len(data)) + 'B'
-        data = unpack(str_unpack, data)
-        data = list(data)
-
-        # check for escaped characters
-        while data_idx < len(data):
-            if data[data_idx] == 0x7d:
-                data.pop(data_idx)
-                data[data_idx] = data[data_idx] ^ 0x20
-            data_idx += 1
-
-        return data
-
-    def escape(self, data):
-        result = ''
-        for c in data:
-            if c in '#$}*':
-                result += '}' + chr(ord(c) ^ 0x20)
-            else:
-                result += c
-        return result
-
     def getMemory(self, data):
-        split = data.split(',')
+        split = data.split(b',')
         addr = int(split[0], 16)
-        length = split[1].split('#')[0]
+        length = split[1].split(b'#')[0]
         length = int(length, 16)
 
         if LOG_MEM:
             self.log.debug("GDB getMem: addr=%x len=%x", addr, length)
 
         try:
-            val = ''
+            val = b''
             mem = self.target_context.readBlockMemoryUnaligned8(addr, length)
             # Flush so an exception is thrown now if invalid memory was accesses
             self.target_context.flush()
             for x in mem:
                 if x >= 0x10:
-                    val += hex(x)[2:4]
+                    val += six.b(hex(x)[2:4])
                 else:
-                    val += '0' + hex(x)[2:3]
+                    val += b'0' + six.b(hex(x)[2:3])
         except DAPAccess.TransferError:
             self.log.debug("getMemory failed at 0x%x" % addr)
-            val = 'E01' #EPERM
+            val = b'E01' #EPERM
         except MemoryAccessError as e:
             logging.debug("getMemory failed at 0x%x: %s", addr, str(e))
-            val = 'E01' #EPERM
+            val = b'E01' #EPERM
         return self.createRSPPacket(val)
 
     def writeMemoryHex(self, data):
-        split = data.split(',')
+        split = data.split(b',')
         addr = int(split[0], 16)
 
-        split = split[1].split(':')
+        split = split[1].split(b':')
         length = int(split[0], 16)
 
-        split = split[1].split('#')
+        split = split[1].split(b'#')
         data = hexToByteList(split[0])
 
         if LOG_MEM:
@@ -904,46 +913,40 @@ class GDBServer(threading.Thread):
                 self.target_context.writeBlockMemoryUnaligned8(addr, data)
                 # Flush so an exception is thrown now if invalid memory was accessed
                 self.target_context.flush()
-            resp = "OK"
+            resp = b"OK"
         except DAPAccess.TransferError:
             self.log.debug("writeMemory failed at 0x%x" % addr)
-            resp = 'E01' #EPERM
+            resp = b'E01' #EPERM
         except MemoryAccessError as e:
             logging.debug("getMemory failed at 0x%x: %s", addr, str(e))
-            val = 'E01' #EPERM
+            val = b'E01' #EPERM
 
         return self.createRSPPacket(resp)
 
     def writeMemory(self, data):
-        split = data.split(',')
+        split = data.split(b',')
         addr = int(split[0], 16)
-        length = int(split[1].split(':')[0], 16)
+        length = int(split[1].split(b':')[0], 16)
 
         if LOG_MEM:
             self.log.debug("GDB writeMem: addr=%x len=%x", addr, length)
 
-        idx_begin = 0
-        for i in range(len(data)):
-            if data[i] == ':':
-                idx_begin += 1
-                break
-            idx_begin += 1
-
+        idx_begin = data.index(b':') + 1
         data = data[idx_begin:len(data) - 3]
-        data = self.unescape(data)
+        data = unescape(data)
 
         try:
             if length > 0:
                 self.target_context.writeBlockMemoryUnaligned8(addr, data)
                 # Flush so an exception is thrown now if invalid memory was accessed
                 self.target_context.flush()
-            resp = "OK"
+            resp = b"OK"
         except DAPAccess.TransferError:
             self.log.debug("writeMemory failed at 0x%x" % addr)
-            resp = 'E01' #EPERM
+            resp = b'E01' #EPERM
         except MemoryAccessError as e:
             logging.debug("getMemory failed at 0x%x: %s", addr, str(e))
-            val = 'E01' #EPERM
+            val = b'E01' #EPERM
 
         return self.createRSPPacket(resp)
 
@@ -951,91 +954,91 @@ class GDBServer(threading.Thread):
         return self.createRSPPacket(self.target_facade.gdbGetRegister(which))
 
     def writeRegister(self, data):
-        reg = int(data.split('=')[0], 16)
-        val = data.split('=')[1].split('#')[0]
+        reg = int(data.split(b'=')[0], 16)
+        val = data.split(b'=')[1].split(b'#')[0]
         self.target_facade.setRegister(reg, val)
-        return self.createRSPPacket("OK")
+        return self.createRSPPacket(b"OK")
 
     def getRegisters(self):
         return self.createRSPPacket(self.target_facade.getRegisterContext())
 
     def setRegisters(self, data):
         self.target_facade.setRegisterContext(data)
-        return self.createRSPPacket("OK")
+        return self.createRSPPacket(b"OK")
 
     def handleQuery(self, msg):
-        query = msg.split(':')
+        query = msg.split(b':')
         self.log.debug('GDB received query: %s', query)
 
         if query is None:
             self.log.error('GDB received query packet malformed')
             return None
 
-        if query[0] == 'Supported':
+        if query[0] == b'Supported':
             # Save features sent by gdb.
-            self.gdb_features = query[1].split(';')
+            self.gdb_features = query[1].split(b';')
 
             # Build our list of features.
-            features = ['qXfer:features:read+', 'QStartNoAckMode+', 'qXfer:threads:read+', 'QNonStop+']
-            features.append('PacketSize=' + hex(self.packet_size)[2:])
+            features = [b'qXfer:features:read+', b'QStartNoAckMode+', b'qXfer:threads:read+', b'QNonStop+']
+            features.append(b'PacketSize=' + six.b(hex(self.packet_size))[2:])
             if self.target_facade.getMemoryMapXML() is not None:
-                features.append('qXfer:memory-map:read+')
-            resp = ';'.join(features)
+                features.append(b'qXfer:memory-map:read+')
+            resp = b';'.join(features)
             return self.createRSPPacket(resp)
 
-        elif query[0] == 'Xfer':
+        elif query[0] == b'Xfer':
 
-            if query[1] == 'features' and query[2] == 'read' and \
-               query[3] == 'target.xml':
-                data = query[4].split(',')
-                resp = self.handleQueryXML('read_feature', int(data[0], 16), int(data[1].split('#')[0], 16))
+            if query[1] == b'features' and query[2] == b'read' and \
+               query[3] == b'target.xml':
+                data = query[4].split(b',')
+                resp = self.handleQueryXML(b'read_feature', int(data[0], 16), int(data[1].split(b'#')[0], 16))
                 return self.createRSPPacket(resp)
 
-            elif query[1] == 'memory-map' and query[2] == 'read':
-                data = query[4].split(',')
-                resp = self.handleQueryXML('memory_map', int(data[0], 16), int(data[1].split('#')[0], 16))
+            elif query[1] == b'memory-map' and query[2] == b'read':
+                data = query[4].split(b',')
+                resp = self.handleQueryXML(b'memory_map', int(data[0], 16), int(data[1].split(b'#')[0], 16))
                 return self.createRSPPacket(resp)
 
-            elif query[1] == 'threads' and query[2] == 'read':
-                data = query[4].split(',')
-                resp = self.handleQueryXML('threads', int(data[0], 16), int(data[1].split('#')[0], 16))
+            elif query[1] == b'threads' and query[2] == b'read':
+                data = query[4].split(b',')
+                resp = self.handleQueryXML(b'threads', int(data[0], 16), int(data[1].split(b'#')[0], 16))
                 return self.createRSPPacket(resp)
 
             else:
                 self.log.debug("Unsupported qXfer request: %s:%s:%s:%s", query[1], query[2], query[3], query[4])
                 return None
 
-        elif query[0].startswith('C'):
+        elif query[0].startswith(b'C'):
             if not self.is_threading_enabled():
-                return self.createRSPPacket("QC1")
+                return self.createRSPPacket(b"QC1")
             else:
                 self.validateDebugContext()
-                return self.createRSPPacket("QC%x" % self.current_thread_id)
+                return self.createRSPPacket(b"QC%x" % self.current_thread_id)
 
-        elif query[0].find('Attached') != -1:
-            return self.createRSPPacket("1")
+        elif query[0].find(b'Attached') != -1:
+            return self.createRSPPacket(b"1")
 
-        elif query[0].find('TStatus') != -1:
-            return self.createRSPPacket("")
+        elif query[0].find(b'TStatus') != -1:
+            return self.createRSPPacket(b"")
 
-        elif query[0].find('Tf') != -1:
-            return self.createRSPPacket("")
+        elif query[0].find(b'Tf') != -1:
+            return self.createRSPPacket(b"")
 
-        elif 'Offsets' in query[0]:
-            resp = "Text=0;Data=0;Bss=0"
+        elif b'Offsets' in query[0]:
+            resp = b"Text=0;Data=0;Bss=0"
             return self.createRSPPacket(resp)
 
-        elif 'Symbol' in query[0]:
+        elif b'Symbol' in query[0]:
             if self.did_init_thread_providers:
-                return self.createRSPPacket("OK")
+                return self.createRSPPacket(b"OK")
             return self.initThreadProviders()
 
-        elif query[0].startswith('Rcmd,'):
-            cmd = hexDecode(query[0][5:].split('#')[0])
+        elif query[0].startswith(b'Rcmd,'):
+            cmd = hexDecode(query[0][5:].split(b'#')[0])
             return self.handleRemoteCommand(cmd)
 
         else:
-            return self.createRSPPacket("")
+            return self.createRSPPacket(b"")
 
     def initThreadProviders(self):
         symbol_provider = GDBSymbolProvider(self)
@@ -1055,11 +1058,11 @@ class GDBServer(threading.Thread):
         self.did_init_thread_providers = True
 
         # Done with symbol processing.
-        return self.createRSPPacket("OK")
+        return self.createRSPPacket(b"OK")
 
     def getSymbol(self, name):
         # Send the symbol request.
-        request = self.createRSPPacket('qSymbol:' + hexEncode(name))
+        request = self.createRSPPacket(b'qSymbol:' + hexEncode(name))
         self.packet_io.send(request)
 
         # Read a packet.
@@ -1067,10 +1070,10 @@ class GDBServer(threading.Thread):
 
         # Parse symbol value reply packet.
         packet = packet[1:-3]
-        if not packet.startswith('qSymbol:'):
+        if not packet.startswith(b'qSymbol:'):
             raise RuntimeError("Got unexpected response from gdb when asking for symbol value")
         packet = packet[8:]
-        symValue, symName = packet.split(':')
+        symValue, symName = packet.split(b':')
 
         symName = hexDecode(symName)
         if symName != name:
@@ -1086,39 +1089,39 @@ class GDBServer(threading.Thread):
         self.log.debug('Remote command: %s', cmd)
 
         safecmd = {
-            'init'  : ['Init reset sequence', 0x1],
-            'reset' : ['Reset and halt the target', 0x2],
-            'halt'  : ['Halt target', 0x4],
+            b'init'  : [b'Init reset sequence', 0x1],
+            b'reset' : [b'Reset and halt the target', 0x2],
+            b'halt'  : [b'Halt target', 0x4],
             # 'resume': ['Resume target', 0x8],
-            'help'  : ['Display this help', 0x80],
+            b'help'  : [b'Display this help', 0x80],
         }
 
         cmdList = cmd.split()
-        resp = 'OK'
-        if cmd == 'help':
-            resp = ''.join(['%s\t%s\n' % (k, v[0]) for k, v in safecmd.items()])
+        resp = b'OK'
+        if cmd == b'help':
+            resp = b''.join([b'%s\t%s\n' % (k, v[0]) for k, v in safecmd.items()])
             resp = hexEncode(resp)
-        elif cmd.startswith('arm semihosting'):
-            self.enable_semihosting = 'enable' in cmd
+        elif cmd.startswith(b'arm semihosting'):
+            self.enable_semihosting = b'enable' in cmd
             self.log.info("Semihosting %s", ('enabled' if self.enable_semihosting else 'disabled'))
-        elif cmdList[0] == 'set':
+        elif cmdList[0] == b'set':
             if len(cmdList) < 3:
                 resp = hexEncode("Error: invalid set command")
-            elif cmdList[1] == 'vector-catch':
+            elif cmdList[1] == b'vector-catch':
                 try:
                     self.target.setVectorCatch(convert_vector_catch(cmdList[2]))
                 except ValueError as e:
                     resp = hexEncode("Error: " + str(e))
-            elif cmdList[1] == 'step-into-interrupt':
-                self.step_into_interrupt = (cmdList[2].lower() in ("true", "on", "yes", "1"))
+            elif cmdList[1] == b'step-into-interrupt':
+                self.step_into_interrupt = (cmdList[2].lower() in (b"true", b"on", b"yes", b"1"))
             else:
                 resp = hexEncode("Error: invalid set option")
-        elif cmd == "flush threads":
+        elif cmd == b"flush threads":
             if self.thread_provider is not None:
                 self.thread_provider.invalidate()
         else:
             resultMask = 0x00
-            if cmdList[0] == 'help':
+            if cmdList[0] == b'help':
                 # a 'help' is only valid as the first cmd, and only
                 # gives info on the second cmd if it is valid
                 resultMask |= 0x80
@@ -1127,13 +1130,13 @@ class GDBServer(threading.Thread):
             for cmd_sub in cmdList:
                 if cmd_sub not in safecmd:
                     self.log.warning("Invalid mon command '%s'", cmd_sub)
-                    resp = 'Invalid Command: "%s"\n' % cmd_sub
+                    resp = b'Invalid Command: "%s"\n' % cmd_sub
                     resp = hexEncode(resp)
                     return self.createRSPPacket(resp)
                 elif resultMask == 0x80:
                     # if the first command was a 'help', we only need
                     # to return info about the first cmd after it
-                    resp = hexEncode(safecmd[cmd_sub][0]+'\n')
+                    resp = hexEncode(safecmd[cmd_sub][0]+b'\n')
                     return self.createRSPPacket(resp)
                 resultMask |= safecmd[cmd_sub][1]
 
@@ -1160,37 +1163,37 @@ class GDBServer(threading.Thread):
         return self.createRSPPacket(resp)
 
     def handleGeneralSet(self, msg):
-        feature = msg.split('#')[0]
+        feature = msg.split(b'#')[0]
         self.log.debug("GDB general set: %s", feature)
 
-        if feature == 'StartNoAckMode':
+        if feature == b'StartNoAckMode':
             # Disable acks after the reply and ack.
             self.packet_io.set_send_acks(False)
-            return self.createRSPPacket("OK")
+            return self.createRSPPacket(b"OK")
 
-        elif feature.startswith('NonStop'):
-            enable = feature.split(':')[1]
-            self.non_stop = (enable == '1')
-            return self.createRSPPacket("OK")
+        elif feature.startswith(b'NonStop'):
+            enable = feature.split(b':')[1]
+            self.non_stop = (enable == b'1')
+            return self.createRSPPacket(b"OK")
 
         else:
-            return self.createRSPPacket("")
+            return self.createRSPPacket(b"")
 
     def handleQueryXML(self, query, offset, size):
         self.log.debug('GDB query %s: offset: %s, size: %s', query, offset, size)
         xml = ''
-        if query == 'memory_map':
+        if query == b'memory_map':
             xml = self.target_facade.getMemoryMapXML()
-        elif query == 'read_feature':
+        elif query == b'read_feature':
             xml = self.target.getTargetXML()
-        elif query == 'threads':
+        elif query == b'threads':
             xml = self.getThreadsXML()
         else:
             raise RuntimeError("Invalid XML query (%s)" % query)
 
         size_xml = len(xml)
 
-        prefix = 'm'
+        prefix = b'm'
 
         if offset > size_xml:
             self.log.error('GDB: xml offset > size for %s!', query)
@@ -1202,21 +1205,22 @@ class GDBServer(threading.Thread):
         nbBytesAvailable = size_xml - offset
 
         if size > nbBytesAvailable:
-            prefix = 'l'
+            prefix = b'l'
             size = nbBytesAvailable
 
-        resp = prefix + self.escape(xml[offset:offset + size])
+        resp = prefix + escape(xml[offset:offset + size])
 
         return resp
 
 
     def createRSPPacket(self, data):
-        resp = '$' + data + '#' + checksum(data)
+        resp = b'$' + data + b'#' + checksum(data)
         return resp
 
     def syscall(self, op):
+        op = to_bytes_safe(op)
         self.log.debug("GDB server syscall: %s", op)
-        request = self.createRSPPacket('F' + op)
+        request = self.createRSPPacket(b'F' + op)
         self.packet_io.send(request)
 
         while not self.packet_io.interrupt_event.is_set():
@@ -1227,13 +1231,13 @@ class GDBServer(threading.Thread):
                 continue
 
             # Check for file I/O response.
-            if packet[0] == '$' and packet[1] == 'F':
+            if packet[0:1] == b'$' and packet[1:2] == b'F':
                 self.log.debug("Syscall: got syscall response " + packet)
-                args = packet[2:packet.index('#')].split(',')
+                args = packet[2:packet.index(b'#')].split(b',')
                 result = int(args[0], base=16)
                 errno = int(args[1], base=16) if len(args) > 1 else 0
-                ctrl_c = args[2] if len(args) > 2 else ''
-                if ctrl_c == 'C':
+                ctrl_c = args[2] if len(args) > 2 else b''
+                if ctrl_c == b'C':
                     self.packet_io.interrupt_event.set()
                     self.packet_io.drop_reply = True
                 return result, errno
@@ -1258,12 +1262,12 @@ class GDBServer(threading.Thread):
 
         # Append thread and core
         if not self.is_threading_enabled():
-            response += "thread:1;core:0;"
+            response += b"thread:1;core:0;"
         else:
             if self.current_thread_id in (-1, 0, 1):
-                response += "thread:%x;core:0;" % self.thread_provider.current_thread.unique_id
+                response += b"thread:%x;core:0;" % self.thread_provider.current_thread.unique_id
             else:
-                response += "thread:%x;core:0;" % self.current_thread_id
+                response += b"thread:%x;core:0;" % self.current_thread_id
         self.log.debug("Tresponse=%s", response)
         return response
 
@@ -1289,7 +1293,7 @@ class GDBServer(threading.Thread):
                     desc = thread.name
                 t.text = desc
 
-        return '<?xml version="1.0"?><!DOCTYPE feature SYSTEM "threads.dtd">' + tostring(root)
+        return b'<?xml version="1.0"?><!DOCTYPE feature SYSTEM "threads.dtd">' + tostring(root)
 
     def is_threading_enabled(self):
         return (self.thread_provider is not None) and self.thread_provider.is_enabled \

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -18,23 +18,23 @@
 from ..core.target import Target
 from pyOCD.pyDAPAccess import DAPAccess
 from ..utility.cmdline import convert_vector_catch
-from ..utility.conversion import hexToByteList, hexEncode, hexDecode, hex8leToU32le
+from ..utility.conversion import (hexToByteList, hexEncode, hexDecode, hex8leToU32le)
 from ..utility.progress import print_progress
-from gdb_socket import GDBSocket
-from gdb_websocket import GDBWebSocket
-from syscall import GDBSyscallIOHandler
+from .gdb_socket import GDBSocket
+from .gdb_websocket import GDBWebSocket
+from .syscall import GDBSyscallIOHandler
 from ..debug import semihost
 from ..debug.cache import MemoryAccessError
 from .context_facade import GDBDebugContextFacade
 from .symbols import GDBSymbolProvider
 from ..rtos import RTOS
-import signals
+from . import signals
 import logging, threading, socket
 from struct import unpack
-from time import sleep, time
+from time import (sleep, time)
 import sys
 import traceback
-import Queue
+from six.moves import queue
 from xml.etree.ElementTree import (Element, SubElement, tostring)
 
 CTRL_C = '\x03'
@@ -62,7 +62,7 @@ class GDBServerPacketIOThread(threading.Thread):
         super(GDBServerPacketIOThread, self).__init__(name="gdb-packet-thread")
         self.log = logging.getLogger('gdbpacket.%d' % abstract_socket.port)
         self._abstract_socket = abstract_socket
-        self._receive_queue = Queue.Queue()
+        self._receive_queue = queue.Queue()
         self._shutdown_event = threading.Event()
         self.interrupt_event = threading.Event()
         self.send_acks = True
@@ -103,7 +103,7 @@ class GDBServerPacketIOThread(threading.Thread):
                 # are no packets in the queue. Same if block is true and it times out
                 # waiting on an empty queue.
                 return self._receive_queue.get(block, 0.1)
-            except Queue.Empty:
+            except queue.Empty:
                 # Only exit the loop if block is false or connection closed.
                 if not block:
                     return None
@@ -1040,7 +1040,7 @@ class GDBServer(threading.Thread):
     def initThreadProviders(self):
         symbol_provider = GDBSymbolProvider(self)
 
-        for rtosName, rtosClass in RTOS.iteritems():
+        for rtosName, rtosClass in RTOS.items():
             try:
                 self.log.info("Attempting to load %s", rtosName)
                 rtos = rtosClass(self.target)

--- a/pyOCD/gdbserver/symbols.py
+++ b/pyOCD/gdbserver/symbols.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2016 ARM Limited
+ Copyright (c) 2016-2018 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 """
 
 from ..debug.symbols import SymbolProvider
+from ..utility.py3_helpers import to_bytes_safe
 
 ## @brief Request symbol information from gdb.
 class GDBSymbolProvider(SymbolProvider):
@@ -23,4 +24,4 @@ class GDBSymbolProvider(SymbolProvider):
         self._gdbserver = gdbserver
 
     def get_symbol_value(self, name):
-        return self._gdbserver.getSymbol(name)
+        return self._gdbserver.getSymbol(to_bytes_safe(name))

--- a/pyOCD/gdbserver/syscall.py
+++ b/pyOCD/gdbserver/syscall.py
@@ -65,7 +65,7 @@ class GDBSyscallIOHandler(SemihostIOHandler):
             else:
                 modeval |= O_WRONLY | O_APPEND | O_CREAT
 
-        result, self._errno = self._server.syscall('open,%x/%x,%x,%x' % (fnptr, fnlen + 1, modeval, 0777))
+        result, self._errno = self._server.syscall('open,%x/%x,%x,%x' % (fnptr, fnlen + 1, modeval, 0o777))
         if result != -1:
             result += FD_OFFSET
         return result

--- a/pyOCD/pyDAPAccess/dap_access_api.py
+++ b/pyOCD/pyDAPAccess/dap_access_api.py
@@ -14,7 +14,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from __future__ import absolute_import
+
 
 from enum import Enum
 

--- a/pyOCD/pyDAPAccess/dap_access_cmsis_dap.py
+++ b/pyOCD/pyDAPAccess/dap_access_cmsis_dap.py
@@ -14,7 +14,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from __future__ import absolute_import
+
 
 import re
 import logging

--- a/pyOCD/pyDAPAccess/interface/__init__.py
+++ b/pyOCD/pyDAPAccess/interface/__init__.py
@@ -17,10 +17,10 @@
 
 import os
 import logging
-from hidapi_backend import HidApiUSB
-from pyusb_backend import PyUSB
-from pywinusb_backend import PyWinUSB
-from ws_backend import WebSocketInterface
+from .hidapi_backend import HidApiUSB
+from .pyusb_backend import PyUSB
+from .pywinusb_backend import PyWinUSB
+from .ws_backend import WebSocketInterface
 
 INTERFACE = {
              'hidapiusb': HidApiUSB,
@@ -35,7 +35,7 @@ usb_backend = os.getenv('PYOCD_USB_BACKEND', "")
 ws_backend = "ws"
 
 # Check validity of backend env var.
-if usb_backend and ((usb_backend not in INTERFACE.keys()) or (not INTERFACE[usb_backend].isAvailable)):
+if usb_backend and ((usb_backend not in INTERFACE) or (not INTERFACE[usb_backend].isAvailable)):
     logging.error("Invalid USB backend specified in PYOCD_USB_BACKEND: " + usb_backend)
     usb_backend = ""
 

--- a/pyOCD/pyDAPAccess/interface/hidapi_backend.py
+++ b/pyOCD/pyDAPAccess/interface/hidapi_backend.py
@@ -15,7 +15,7 @@
  limitations under the License.
 """
 
-from interface import Interface
+from .interface import Interface
 import logging, os
 from ..dap_access_api import DAPAccessIntf
 

--- a/pyOCD/pyDAPAccess/interface/pyusb_backend.py
+++ b/pyOCD/pyDAPAccess/interface/pyusb_backend.py
@@ -15,7 +15,7 @@
  limitations under the License.
 """
 
-from interface import Interface
+from .interface import Interface
 import logging, os, threading
 from ..dap_access_api import DAPAccessIntf
 

--- a/pyOCD/pyDAPAccess/interface/pywinusb_backend.py
+++ b/pyOCD/pyDAPAccess/interface/pywinusb_backend.py
@@ -15,7 +15,7 @@
  limitations under the License.
 """
 
-from interface import Interface
+from .interface import Interface
 import logging, os, collections
 from time import time
 from ..dap_access_api import DAPAccessIntf

--- a/pyOCD/pyDAPAccess/interface/ws_backend.py
+++ b/pyOCD/pyDAPAccess/interface/ws_backend.py
@@ -1,10 +1,10 @@
-from __future__ import print_function
+
 from future.utils import bytes_to_native_str
 from future.builtins import bytes
 
 from base64 import b64encode, b64decode
 from websocket import create_connection
-from interface import Interface
+from .interface import Interface
 
 class WebSocketInterface(Interface):
     def __init__(self, host='localhost', port=8081):

--- a/pyOCD/rtos/argon.py
+++ b/pyOCD/rtos/argon.py
@@ -384,7 +384,7 @@ class ArgonThreadProvider(ThreadProvider):
         if not self.is_enabled:
             return []
         self.update_threads()
-        return self._threads.values()
+        return list(self._threads.values())
 
     def get_thread(self, threadId):
         if not self.is_enabled:

--- a/pyOCD/rtos/freertos.py
+++ b/pyOCD/rtos/freertos.py
@@ -418,9 +418,9 @@ class FreeRTOSThreadProvider(ThreadProvider):
         listsToRead.append((self._symbols['xDelayedTaskList1'], FreeRTOSThread.BLOCKED))
         listsToRead.append((self._symbols['xDelayedTaskList2'], FreeRTOSThread.BLOCKED))
         listsToRead.append((self._symbols['xPendingReadyList'], FreeRTOSThread.READY))
-        if self._symbols.has_key('xSuspendedTaskList'):
+        if 'xSuspendedTaskList' in self._symbols:
             listsToRead.append((self._symbols['xSuspendedTaskList'], FreeRTOSThread.SUSPENDED))
-        if self._symbols.has_key('xTasksWaitingTermination'):
+        if 'xTasksWaitingTermination' in self._symbols:
             listsToRead.append((self._symbols['xTasksWaitingTermination'], FreeRTOSThread.DELETED))
 
         for listPtr, state in listsToRead:
@@ -462,7 +462,7 @@ class FreeRTOSThreadProvider(ThreadProvider):
         if not self.is_enabled:
             return []
         self.update_threads()
-        return self._threads.values()
+        return list(self._threads.values())
 
     def get_thread(self, threadId):
         if not self.is_enabled:

--- a/pyOCD/rtos/zephyr.py
+++ b/pyOCD/rtos/zephyr.py
@@ -352,7 +352,7 @@ class ZephyrThreadProvider(ThreadProvider):
         if not self.is_enabled:
             return []
         self.update_threads()
-        return self._threads.values()
+        return list(self._threads.values())
 
     def get_thread(self, threadId):
         if not self.is_enabled:

--- a/pyOCD/target/__init__.py
+++ b/pyOCD/target/__init__.py
@@ -17,53 +17,53 @@
 
 from ..core.coresight_target import CoreSightTarget
 from .family import (target_kinetis, flash_cortex_m)
-import target_MKE15Z256xxx7
-import target_MKE18F256xxx16
-import target_MKL02Z32xxx4
-import target_MKL05Z32xxx4
-import target_MKL25Z128xxx4
-import target_MKL26Z256xxx4
-import target_MKL27Z256xxx4
-import target_MKL28Z512xxx7
-import target_MKL43Z256xxx4
-import target_MKL46Z256xxx4
-import target_MKL82Z128xxx7
-import target_MKV10Z128xxx7
-import target_MKV11Z128xxx7
-import target_MKW01Z128xxx4
-import target_MKW24D512xxx5
-import target_MKW40Z160xxx4
-import target_MKW41Z512xxx4
-import target_MK22FN1M0Axxx12
-import target_MK22FN512xxx12
-import target_MK28FN2M0xxx15
-import target_MK64FN1M0xxx12
-import target_MK66FN2M0xxx18
-import target_MK82FN256xxx15
-import target_MK20DX128xxx5
-import target_K32W042S1M2xxx
-import target_lpc800
-import target_LPC11U24FBD64_401
-import target_LPC1768
-import target_LPC4330
-import target_nRF51822_xxAA
-import target_nRF52832_xxAA
-import target_nRF52840_xxAA
-import target_STM32F103RC
-import target_STM32F051T8
-import target_maxwsnenv
-import target_max32600mbed
-import target_w7500
-import target_LPC1114FN28_102
-import target_LPC824M201JHI33
-import target_LPC54114J256BD64
-import target_LPC54608J512ET180
-import target_ncs36510
-import target_LPC4088FBD144
-import target_lpc4088qsb
-import target_lpc4088dm
-import target_RTL8195AM
-import target_CC3220SF
+from . import target_MKE15Z256xxx7
+from . import target_MKE18F256xxx16
+from . import target_MKL02Z32xxx4
+from . import target_MKL05Z32xxx4
+from . import target_MKL25Z128xxx4
+from . import target_MKL26Z256xxx4
+from . import target_MKL27Z256xxx4
+from . import target_MKL28Z512xxx7
+from . import target_MKL43Z256xxx4
+from . import target_MKL46Z256xxx4
+from . import target_MKL82Z128xxx7
+from . import target_MKV10Z128xxx7
+from . import target_MKV11Z128xxx7
+from . import target_MKW01Z128xxx4
+from . import target_MKW24D512xxx5
+from . import target_MKW40Z160xxx4
+from . import target_MKW41Z512xxx4
+from . import target_MK22FN1M0Axxx12
+from . import target_MK22FN512xxx12
+from . import target_MK28FN2M0xxx15
+from . import target_MK64FN1M0xxx12
+from . import target_MK66FN2M0xxx18
+from . import target_MK82FN256xxx15
+from . import target_MK20DX128xxx5
+from . import target_K32W042S1M2xxx
+from . import target_lpc800
+from . import target_LPC11U24FBD64_401
+from . import target_LPC1768
+from . import target_LPC4330
+from . import target_nRF51822_xxAA
+from . import target_nRF52832_xxAA
+from . import target_nRF52840_xxAA
+from . import target_STM32F103RC
+from . import target_STM32F051T8
+from . import target_maxwsnenv
+from . import target_max32600mbed
+from . import target_w7500
+from . import target_LPC1114FN28_102
+from . import target_LPC824M201JHI33
+from . import target_LPC54114J256BD64
+from . import target_LPC54608J512ET180
+from . import target_ncs36510
+from . import target_LPC4088FBD144
+from . import target_lpc4088qsb
+from . import target_lpc4088dm
+from . import target_RTL8195AM
+from . import target_CC3220SF
 
 TARGET = {
           'cortex_m': CoreSightTarget,

--- a/pyOCD/test/conftest.py
+++ b/pyOCD/test/conftest.py
@@ -17,7 +17,7 @@
 
 import pytest
 import logging
-from mockcore import MockCore
+from .mockcore import MockCore
 
 @pytest.fixture(scope='function')
 def mockcore():

--- a/pyOCD/test/test_conversion.py
+++ b/pyOCD/test/test_conversion.py
@@ -38,7 +38,7 @@ import six
 class TestConversionUtilities(object):
     def test_byteListToU32leList(self):
         data = range(32)
-        self.assertEqual(byteListToU32leList(data), [
+        assert byteListToU32leList(data) == [
             0x03020100,
             0x07060504,
             0x0B0A0908,
@@ -47,7 +47,7 @@ class TestConversionUtilities(object):
             0x17161514,
             0x1B1A1918,
             0x1F1E1D1C,
-        ])
+        ]
 
     def test_u32leListToByteList(self):
         data = [
@@ -60,50 +60,47 @@ class TestConversionUtilities(object):
             0x1B1A1918,
             0x1F1E1D1C,
         ]
-        self.assertEqual(u32leListToByteList(data), range(32))
+        assert u32leListToByteList(data) == list(range(32))
 
     def test_u16leListToByteList(self):
         data = [0x3412, 0xFEAB]
-        self.assertEqual(u16leListToByteList(data), [
+        assert u16leListToByteList(data) == [
             0x12,
             0x34,
             0xAB,
             0xFE
-        ])
+        ]
 
     def test_byteListToU16leList(self):
         data = [0x01, 0x00, 0xAB, 0xCD, ]
-        self.assertEqual(byteListToU16leList(data), [
+        assert byteListToU16leList(data) == [
             0x0001,
             0xCDAB,
-        ])
+        ]
 
     def test_u32BEToFloat32BE(self):
-        self.assertEqual(u32BEToFloat32BE(0x012345678), 5.690456613903524e-28)
+        assert u32BEToFloat32BE(0x012345678) == 5.690456613903524e-28
 
     def test_float32beToU32be(self):
-        self.assertEqual(float32beToU32be(5.690456613903524e-28), 0x012345678)
+        assert float32beToU32be(5.690456613903524e-28) == 0x012345678
 
     def test_u32beToHex8le(self):
-        self.assertEqual(u32beToHex8le(0x0102ABCD), "cdab0201")
+        assert u32beToHex8le(0x0102ABCD) == "cdab0201"
 
     def test_hex8leToU32be(self):
-        self.assertEqual(hex8leToU32be("0102ABCD"), 0xCDAB0201)
+        assert hex8leToU32be("0102ABCD") == 0xCDAB0201
 
     def test_byteToHex2(self):
-        self.assertEqual(byteToHex2(0xC3), "c3")
+        assert byteToHex2(0xC3) == "c3"
 
     def test_hexToByteList(self):
-        self.assertEqual(hexToByteList("ABCDEF1234"),
-                         [0xAB, 0xCD, 0xEF, 0x12, 0x34])
+        assert hexToByteList("ABCDEF1234") == [0xAB, 0xCD, 0xEF, 0x12, 0x34]
 
     def test_hexDecode(self):
-        self.assertEqual(hexDecode('ABCDEF1234'),
-                         '\xab\xcd\xef\x12\x34')
+        assert hexDecode('ABCDEF1234') == b'\xab\xcd\xef\x12\x34'
 
     def test_hexEncode(self):
-        self.assertEqual(hexEncode('\xab\xcd\xef\x12\x34'),
-                         'abcdef1234')
+        assert hexEncode(b'\xab\xcd\xef\x12\x34') == b'abcdef1234'
 
 # Characters that must be escaped.
 ESCAPEES = (0x23, 0x24, 0x2a, 0x7d) # == ('#', '$', '}', '*')

--- a/pyOCD/test/test_memcache.py
+++ b/pyOCD/test/test_memcache.py
@@ -81,7 +81,7 @@ class TestMemoryCache:
 
     def test_11_full_overlap(self, mockcore, memcache):
         memcache.writeBlockMemoryUnaligned8(0, range(8))
-        assert memcache.readBlockMemoryUnaligned8(0, 8) == range(8)
+        assert memcache.readBlockMemoryUnaligned8(0, 8) == list(range(8))
 
     def test_12_begin(self, mockcore, memcache):
         memcache.writeBlockMemoryUnaligned8(8, [1, 2, 3, 4])

--- a/pyOCD/test/test_mockcore.py
+++ b/pyOCD/test/test_mockcore.py
@@ -21,7 +21,7 @@ from pyOCD.utility import conversion
 from pyOCD.utility import mask
 import pytest
 import logging
-from mockcore import MockCore
+from .mockcore import MockCore
 
 # @pytest.fixture(scope='function')
 # def mockcore():

--- a/pyOCD/test/test_semihosting.py
+++ b/pyOCD/test/test_semihosting.py
@@ -108,20 +108,20 @@ class RecordingSemihostIOHandler(semihost.SemihostIOHandler):
         self._in_data[fd] = data
 
     def get_output_data(self, fd):
-        if self._out_data.has_key(fd):
+        if fd in self._out_data:
             return self._out_data[fd]
         else:
             return None
 
     def write(self, fd, ptr, length):
-        if not self._out_data.has_key(fd):
+        if fd not in self._out_data:
             self._out_data[fd] = ''
         s = self.agent._get_string(ptr, length)
         self._out_data[fd] += s
         return 0
 
     def read(self, fd, ptr, length):
-        if not self._in_data.has_key(fd):
+        if fd not in self._in_data:
             return length
         d = self._in_data[fd][:length]
         self._in_data[fd] = self._in_data[fd][length:]
@@ -129,7 +129,7 @@ class RecordingSemihostIOHandler(semihost.SemihostIOHandler):
         return length - len(d)
 
     def readc(self):
-        if not self._in_data.has_key(semihost.STDIN_FD):
+        if semihost.STDIN_FD not in self._in_data:
             return -1
         d = self._in_data[semihost.STDIN_FD][:1]
         self._in_data[semihost.STDIN_FD] = self._in_data[semihost.STDIN_FD][1:]

--- a/pyOCD/tools/flash_tool.py
+++ b/pyOCD/tools/flash_tool.py
@@ -30,11 +30,11 @@ try:
 except ImportError:
     intelhex_available = False
 
-import pyOCD
-from pyOCD import __version__
-from pyOCD.board import MbedBoard
-from pyOCD.pyDAPAccess import DAPAccess
-from pyOCD.utility.progress import print_progress
+from .. import __version__
+from .. import target
+from ..board.mbed_board import MbedBoard
+from ..pyDAPAccess import DAPAccess
+from ..utility.progress import print_progress
 
 LEVELS = {
     'debug': logging.DEBUG,
@@ -47,10 +47,10 @@ LEVELS = {
 board = None
 
 supported_formats = ['bin', 'hex']
-supported_targets = pyOCD.target.TARGET.keys()
+supported_targets = list(target.TARGET.keys())
 supported_targets.remove('cortex_m')  # No generic programming
 
-debug_levels = LEVELS.keys()
+debug_levels = list(LEVELS.keys())
 
 def int_base_0(x):
     return int(x, base=0)
@@ -113,7 +113,7 @@ def setup_logging(args):
 
 
 def ranges(i):
-    for a, b in itertools.groupby(enumerate(i), lambda (x, y): y - x):
+    for a, b in itertools.groupby(enumerate(i), lambda x, y: y - x):
         b = list(b)
         yield b[0][1], b[-1][1]
 

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -24,15 +24,14 @@ import argparse
 import json
 import pkg_resources
 
-import pyOCD.board.mbed_board
-from pyOCD import __version__
-from pyOCD.debug.svd import isCmsisSvdAvailable
-from pyOCD.gdbserver import GDBServer
-from pyOCD.board import MbedBoard
-from pyOCD.utility.cmdline import (split_command_line, VECTOR_CATCH_CHAR_MAP, convert_vector_catch)
-from pyOCD.pyDAPAccess.dap_access_cmsis_dap import DAPAccessCMSISDAP
-import pyOCD.board.mbed_board
-from pyOCD.pyDAPAccess import DAPAccess
+from .. import __version__
+from .. import target
+from ..debug.svd import isCmsisSvdAvailable
+from ..gdbserver import GDBServer
+from ..board.mbed_board import MbedBoard
+from ..utility.cmdline import (split_command_line, VECTOR_CATCH_CHAR_MAP, convert_vector_catch)
+from ..pyDAPAccess.dap_access_cmsis_dap import DAPAccessCMSISDAP
+from ..pyDAPAccess import DAPAccess
 
 LEVELS = {
     'debug': logging.DEBUG,
@@ -42,8 +41,8 @@ LEVELS = {
     'critical': logging.CRITICAL
 }
 
-supported_targets = pyOCD.target.TARGET.keys()
-debug_levels = LEVELS.keys()
+supported_targets = list(target.TARGET.keys())
+debug_levels = list(LEVELS.keys())
 
 class InvalidArgumentError(RuntimeError):
     pass
@@ -191,18 +190,20 @@ class GDBServerTool(object):
     def list_boards(self):
         self.disable_logging()
 
-        try:
-            all_mbeds = MbedBoard.getAllConnectedBoards(close=True, blocking=False)
-            status = 0
-            error = ""
-        except Exception as e:
-            all_mbeds = []
-            status = 1
-            error = str(e)
-            if not self.args.output_json:
-                raise
+        if not self.args.output_json:
+            MbedBoard.listConnectedBoards()
+        else:
+            try:
+                all_mbeds = MbedBoard.getAllConnectedBoards(close=True, blocking=False)
+                status = 0
+                error = ""
+            except Exception as e:
+                all_mbeds = []
+                status = 1
+                error = str(e)
+                if not self.args.output_json:
+                    raise
 
-        if self.args.output_json:
             boards = []
             obj = {
                 'pyocd_version' : __version__,
@@ -237,14 +238,14 @@ class GDBServerTool(object):
                 boards.append(d)
 
             print(json.dumps(obj, indent=4))
-        else:
-            index = 0
-            if len(all_mbeds) > 0:
-                for mbed in all_mbeds:
-                    print("%d => %s boardId => %s" % (index, mbed.getInfo().encode('ascii', 'ignore'), mbed.unique_id))
-                    index += 1
-            else:
-                print("No available boards are connected")
+#         else:
+#             index = 0
+#             if len(all_mbeds) > 0:
+#                 for mbed in all_mbeds:
+#                     print("%d => %s boardId => %s" % (index, mbed.getInfo(), mbed.unique_id))
+#                     index += 1
+#             else:
+#                 print("No available boards are connected")
 
     def list_targets(self):
         self.disable_logging()
@@ -259,7 +260,7 @@ class GDBServerTool(object):
                 }
 
             for name in supported_targets:
-                t = pyOCD.target.TARGET[name](None)
+                t = target.TARGET[name](None)
                 d = {
                     'name' : name,
                     'part_number' : t.part_number,
@@ -306,7 +307,7 @@ class GDBServerTool(object):
                         return 1
                     with board_selected as board:
                         baseTelnetPort = self.gdb_server_settings['telnet_port']
-                        for core_number, core in board.target.cores.iteritems():
+                        for core_number, core in board.target.cores.items():
                             self.gdb_server_settings['telnet_port'] = baseTelnetPort + core_number
                             gdb = GDBServer(board, self.args.port_number + core_number, self.gdb_server_settings, core=core_number)
                             gdbs.append(gdb)

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -238,14 +238,6 @@ class GDBServerTool(object):
                 boards.append(d)
 
             print(json.dumps(obj, indent=4))
-#         else:
-#             index = 0
-#             if len(all_mbeds) > 0:
-#                 for mbed in all_mbeds:
-#                     print("%d => %s boardId => %s" % (index, mbed.getInfo(), mbed.unique_id))
-#                     index += 1
-#             else:
-#                 print("No available boards are connected")
 
     def list_targets(self):
         self.disable_logging()

--- a/pyOCD/utility/conversion.py
+++ b/pyOCD/utility/conversion.py
@@ -17,7 +17,7 @@
 
 import struct
 import binascii
-
+import six
 
 def byteListToU32leList(data):
     """Convert a list of bytes to a list of 32-bit integers (little endian)"""
@@ -96,7 +96,7 @@ def byteToHex2(val):
 
 def hexToByteList(data):
     """Convert string of hex bytes to list of integers"""
-    return [ord(i) for i in binascii.unhexlify(data)]
+    return list(six.iterbytes(binascii.unhexlify(data)))
 
 
 def hexDecode(cmd):

--- a/pyOCD/utility/notification.py
+++ b/pyOCD/utility/notification.py
@@ -50,7 +50,7 @@ class Notifier(object):
         if not type(events) in (list, tuple):
             events = [events]
         for event in events:
-            if self._subscribers.has_key(event):
+            if event in self._subscribers:
                 self._subscribers[event].append(cb)
             else:
                 self._subscribers[event] = [cb]

--- a/pyOCD/utility/py3_helpers.py
+++ b/pyOCD/utility/py3_helpers.py
@@ -1,0 +1,46 @@
+# pyOCD debugger
+# Copyright (c) 2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import functools
+
+PY3 = sys.version_info[0] == 3
+
+# iter_single_bytes() returns an iterator over a bytes object that produces
+# single-byte bytes objects for each byte in the passed in value. Normally on
+# py3 iterating over a bytes will give you ints for each byte, while on py3
+# you'll get single-char strs.
+if PY3:
+    iter_single_bytes = functools.partial(map, lambda v: bytes((v,)))
+else:
+    iter_single_bytes = iter
+
+# to_bytes_safe() converts a unicode string to a bytes object by encoding as
+# latin-1. It will also accept a value that is already a bytes object and
+# return it unmodified.
+if PY3:
+    def to_bytes_safe(v):
+        if type(v) is str:
+            return v.encode('latin-1')
+        else:
+            return v
+else:
+    def to_bytes_safe(v):
+        if type(v) is unicode:
+            return v.encode('latin-1')
+        else:
+            return v
+

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
             'pyocd-tool = pyOCD.tools.pyocd:main',
         ],
     },
-    use_2to3=True,
     packages=find_packages(),
     include_package_data=True,  # include files from MANIFEST.in
 )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ if sys.platform.startswith('linux'):
 elif sys.platform.startswith('win'):
     install_requires.extend([
         'pywinusb>=0.4.0',
-        'hidapi',
     ])
 elif sys.platform.startswith('darwin'):
     install_requires.extend([

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,15 @@
 from setuptools import setup, find_packages
 import sys
 
-install_requires = ['intelhex', 'six', 'enum34', 'future', 'websocket-client', 'intervaltree', 'colorama']
+install_requires = [
+    'intelhex',
+    'six',
+    'enum34',
+    'future',
+    'websocket-client',
+    'intervaltree',
+    'colorama',
+    ]
 if sys.platform.startswith('linux'):
     install_requires.extend([
         'pyusb>=1.0.0b2',
@@ -26,6 +34,7 @@ if sys.platform.startswith('linux'):
 elif sys.platform.startswith('win'):
     install_requires.extend([
         'pywinusb>=0.4.0',
+        'hidapi',
     ])
 elif sys.platform.startswith('darwin'):
     install_requires.extend([
@@ -38,7 +47,7 @@ setup(
         'local_scheme': 'dirty-tag',
         'write_to': 'pyOCD/_version.py'
     },
-    setup_requires=['setuptools_scm!=1.5.3,!=1.5.4'],
+    setup_requires=['setuptools_scm!=1.5.3,!=1.5.4', 'setuptools_scm_git_archive'],
     description="CMSIS-DAP debugger for Python",
     long_description=open('README.rst', 'Ur').read(),
     author="Chris Reed, Martin Kojtal, Russ Butler",

--- a/test/automated_test.py
+++ b/test/automated_test.py
@@ -43,7 +43,7 @@ def print_summary(test_list, result_list, test_time, output_file=None):
 
     Test.print_results(result_list, output_file=output_file)
     print("", file=output_file)
-    print("Test Time: %s" % test_time, file=output_file)
+    print("Test Time: %.3f" % test_time, file=output_file)
     if Test.all_tests_pass(result_list):
         print("All tests passed", file=output_file)
     else:
@@ -99,7 +99,7 @@ def main():
     test_time = (stop - start)
 
     print_summary(test_list, result_list, test_time)
-    with open(summary_file, "wb") as output_file:
+    with open(summary_file, "w") as output_file:
         print_summary(test_list, result_list, test_time, output_file)
 
     exit_val = 0 if Test.all_tests_pass(result_list) else -1

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -14,6 +14,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from __future__ import print_function
 
 import argparse, os, sys
 from time import sleep
@@ -42,7 +43,7 @@ def basic_test(board_id, file):
         else:
             binary_file = file
 
-        print "binary file: %s" % binary_file
+        print("binary file: %s" % binary_file)
 
         memory_map = board.target.getMemoryMap()
         ram_regions = [region for region in memory_map if region.type == 'ram']
@@ -59,107 +60,107 @@ def basic_test(board_id, file):
         flash = board.flash
 
 
-        print "\r\n\r\n------ GET Unique ID ------"
-        print "Unique ID: %s" % board.getUniqueID()
+        print("\n\n------ GET Unique ID ------")
+        print("Unique ID: %s" % board.getUniqueID())
 
-        print "\r\n\r\n------ TEST READ / WRITE CORE REGISTER ------"
+        print("\n\n------ TEST READ / WRITE CORE REGISTER ------")
         pc = target.readCoreRegister('pc')
-        print "initial pc: 0x%X" % target.readCoreRegister('pc')
+        print("initial pc: 0x%X" % target.readCoreRegister('pc'))
         # write in pc dummy value
         target.writeCoreRegister('pc', 0x3D82)
-        print "now pc: 0x%X" % target.readCoreRegister('pc')
+        print("now pc: 0x%X" % target.readCoreRegister('pc'))
         # write initial pc value
         target.writeCoreRegister('pc', pc)
-        print "initial pc value rewritten: 0x%X" % target.readCoreRegister('pc')
+        print("initial pc value rewritten: 0x%X" % target.readCoreRegister('pc'))
 
         msp = target.readCoreRegister('msp')
         psp = target.readCoreRegister('psp')
-        print "MSP = 0x%08x; PSP = 0x%08x" % (msp, psp)
+        print("MSP = 0x%08x; PSP = 0x%08x" % (msp, psp))
 
         control = target.readCoreRegister('control')
         faultmask = target.readCoreRegister('faultmask')
         basepri = target.readCoreRegister('basepri')
         primask = target.readCoreRegister('primask')
-        print "CONTROL = 0x%02x; FAULTMASK = 0x%02x; BASEPRI = 0x%02x; PRIMASK = 0x%02x" % (control, faultmask, basepri, primask)
+        print("CONTROL = 0x%02x; FAULTMASK = 0x%02x; BASEPRI = 0x%02x; PRIMASK = 0x%02x" % (control, faultmask, basepri, primask))
 
         target.writeCoreRegister('primask', 1)
         newPrimask = target.readCoreRegister('primask')
-        print "New PRIMASK = 0x%02x" % newPrimask
+        print("New PRIMASK = 0x%02x" % newPrimask)
         target.writeCoreRegister('primask', primask)
         newPrimask = target.readCoreRegister('primask')
-        print "Restored PRIMASK = 0x%02x" % newPrimask
+        print("Restored PRIMASK = 0x%02x" % newPrimask)
 
         if target.has_fpu:
             s0 = target.readCoreRegister('s0')
-            print "S0 = %g (0x%08x)" % (s0, float32beToU32be(s0))
+            print("S0 = %g (0x%08x)" % (s0, float32beToU32be(s0)))
             target.writeCoreRegister('s0', math.pi)
             newS0 = target.readCoreRegister('s0')
-            print "New S0 = %g (0x%08x)" % (newS0, float32beToU32be(newS0))
+            print("New S0 = %g (0x%08x)" % (newS0, float32beToU32be(newS0)))
             target.writeCoreRegister('s0', s0)
             newS0 = target.readCoreRegister('s0')
-            print "Restored S0 = %g (0x%08x)" % (newS0, float32beToU32be(newS0))
+            print("Restored S0 = %g (0x%08x)" % (newS0, float32beToU32be(newS0)))
 
 
-        print "\r\n\r\n------ TEST HALT / RESUME ------"
+        print("\n\n------ TEST HALT / RESUME ------")
 
-        print "resume"
+        print("resume")
         target.resume()
         sleep(0.2)
 
-        print "halt"
+        print("halt")
         target.halt()
-        print "HALT: pc: 0x%X" % target.readCoreRegister('pc')
+        print("HALT: pc: 0x%X" % target.readCoreRegister('pc'))
         sleep(0.2)
 
 
-        print "\r\n\r\n------ TEST STEP ------"
+        print("\n\n------ TEST STEP ------")
 
-        print "reset and halt"
+        print("reset and halt")
         target.resetStopOnReset()
         currentPC = target.readCoreRegister('pc')
-        print "HALT: pc: 0x%X" % currentPC
+        print("HALT: pc: 0x%X" % currentPC)
         sleep(0.2)
 
         for i in range(4):
-            print "step"
+            print("step")
             target.step()
             newPC = target.readCoreRegister('pc')
-            print "STEP: pc: 0x%X" % newPC
+            print("STEP: pc: 0x%X" % newPC)
             currentPC = newPC
             sleep(0.2)
 
 
-        print "\r\n\r\n------ TEST READ / WRITE MEMORY ------"
+        print("\n\n------ TEST READ / WRITE MEMORY ------")
         target.halt()
-        print "READ32/WRITE32"
+        print("READ32/WRITE32")
         val = randrange(0, 0xffffffff)
-        print "write32 0x%X at 0x%X" % (val, addr)
+        print("write32 0x%X at 0x%X" % (val, addr))
         target.writeMemory(addr, val)
         res = target.readMemory(addr)
-        print "read32 at 0x%X: 0x%X" % (addr, res)
+        print("read32 at 0x%X: 0x%X" % (addr, res))
         if res != val:
-            print "ERROR in READ/WRITE 32"
+            print("ERROR in READ/WRITE 32")
 
-        print "\r\nREAD16/WRITE16"
+        print("\nREAD16/WRITE16")
         val = randrange(0, 0xffff)
-        print "write16 0x%X at 0x%X" % (val, addr + 2)
+        print("write16 0x%X at 0x%X" % (val, addr + 2))
         target.writeMemory(addr + 2, val, 16)
         res = target.readMemory(addr + 2, 16)
-        print "read16 at 0x%X: 0x%X" % (addr + 2, res)
+        print("read16 at 0x%X: 0x%X" % (addr + 2, res))
         if res != val:
-            print "ERROR in READ/WRITE 16"
+            print("ERROR in READ/WRITE 16")
 
-        print "\r\nREAD8/WRITE8"
+        print("\nREAD8/WRITE8")
         val = randrange(0, 0xff)
-        print "write8 0x%X at 0x%X" % (val, addr + 1)
+        print("write8 0x%X at 0x%X" % (val, addr + 1))
         target.writeMemory(addr + 1, val, 8)
         res = target.readMemory(addr + 1, 8)
-        print "read8 at 0x%X: 0x%X" % (addr + 1, res)
+        print("read8 at 0x%X: 0x%X" % (addr + 1, res))
         if res != val:
-            print "ERROR in READ/WRITE 8"
+            print("ERROR in READ/WRITE 8")
 
 
-        print "\r\n\r\n------ TEST READ / WRITE MEMORY BLOCK ------"
+        print("\n\n------ TEST READ / WRITE MEMORY BLOCK ------")
         data = [randrange(1, 50) for x in range(size)]
         target.writeBlockMemoryUnaligned8(addr, data)
         block = target.readBlockMemoryUnaligned8(addr, size)
@@ -167,23 +168,23 @@ def basic_test(board_id, file):
         for i in range(len(block)):
             if (block[i] != data[i]):
                 error = True
-                print "ERROR: 0x%X, 0x%X, 0x%X!!!" % ((addr + i), block[i], data[i])
+                print("ERROR: 0x%X, 0x%X, 0x%X!!!" % ((addr + i), block[i], data[i]))
         if error:
-            print "TEST FAILED"
+            print("TEST FAILED")
         else:
-            print "TEST PASSED"
+            print("TEST PASSED")
 
 
-        print "\r\n\r\n------ TEST RESET ------"
+        print("\n\n------ TEST RESET ------")
         target.reset()
         sleep(0.1)
         target.halt()
 
         for i in range(5):
             target.step()
-            print "pc: 0x%X" % target.readCoreRegister('pc')
+            print("pc: 0x%X" % target.readCoreRegister('pc'))
 
-        print "\r\n\r\n------ TEST PROGRAM/ERASE PAGE ------"
+        print("\n\n------ TEST PROGRAM/ERASE PAGE ------")
         # Fill 3 pages with 0x55
         page_size = flash.getPageInfo(addr_flash).size
         fill = [0x55] * page_size
@@ -203,11 +204,11 @@ def basic_test(board_id, file):
         data = target.readBlockMemoryUnaligned8(addr_flash, page_size * 3)
         expected = fill + [0xFF] * page_size + fill
         if data == expected:
-            print "TEST PASSED"
+            print("TEST PASSED")
         else:
-            print "TEST FAILED"
+            print("TEST FAILED")
 
-        print "\r\n\r\n----- FLASH NEW BINARY -----"
+        print("\n\n----- FLASH NEW BINARY -----")
         flash.flashBinary(binary_file, addr_bin)
 
         target.reset()

--- a/test/blank_test.py
+++ b/test/blank_test.py
@@ -15,7 +15,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-
+from __future__ import print_function
 import os, sys
 from time import sleep
 from random import randrange
@@ -30,7 +30,7 @@ import logging
 
 logging.basicConfig(level=logging.INFO)
 
-print "\r\n\r\n------ Test attaching to locked board ------"
+print("\n\n------ Test attaching to locked board ------")
 for i in range(0, 10):
     with MbedBoard.chooseBoard() as board:
         # Erase and then reset - This locks Kinetis devices
@@ -38,7 +38,7 @@ for i in range(0, 10):
         board.flash.eraseAll()
         board.target.reset()
 
-print "\r\n\r\n------ Testing Attaching to board ------"
+print("\n\n------ Testing Attaching to board ------")
 for i in range(0, 100):
     with MbedBoard.chooseBoard() as board:
         board.target.halt()
@@ -46,12 +46,12 @@ for i in range(0, 100):
         board.target.resume()
         sleep(0.01)
 
-print "\r\n\r\n------ Flashing new code ------"
+print("\n\n------ Flashing new code ------")
 with MbedBoard.chooseBoard() as board:
     binary_file = os.path.join(parentdir, 'binaries', board.getTestBinary())
     board.flash.flashBinary(binary_file)
 
-print "\r\n\r\n------ Testing Attaching to regular board ------"
+print("\n\n------ Testing Attaching to regular board ------")
 for i in range(0, 10):
     with MbedBoard.chooseBoard() as board:
         board.target.resetStopOnReset()

--- a/test/cortex_test.py
+++ b/test/cortex_test.py
@@ -14,12 +14,14 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from __future__ import print_function
 
 import argparse, os, sys
 from time import sleep, time
 from random import randrange
 import math
 import argparse
+import traceback
 
 parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, parentdir)
@@ -52,6 +54,7 @@ class CortexTest(Test):
             result = CortexTestResult()
             result.passed = False
             print("Exception %s when testing board %s" % (e, board.getUniqueID()))
+            traceback.print_exc(file=sys.stdout)
         result.board = board
         result.test = self
         return result
@@ -111,7 +114,7 @@ def cortex_test(board_id):
         debugContext = target.getTargetContext()
         gdbFacade = pyOCD.gdbserver.context_facade.GDBDebugContextFacade(debugContext)
 
-        print "\r\n\r\n----- FLASH NEW BINARY BEFORE TEST -----"
+        print("\n\n----- FLASH NEW BINARY BEFORE TEST -----")
         flash.flashBinary(binary_file, addr_bin)
         # Let the target run for a bit so it
         # can initialize the watchdog if it needs to
@@ -119,10 +122,10 @@ def cortex_test(board_id):
         sleep(0.2)
         target.halt()
 
-        print "PROGRAMMING COMPLETE"
+        print("PROGRAMMING COMPLETE")
 
 
-        print "\r\n\r\n----- TESTING CORTEX-M PERFORMANCE -----"
+        print("\n\n----- TESTING CORTEX-M PERFORMANCE -----")
         test_time = test_function(board, gdbFacade.getTResponse)
         print("Function getTResponse time: %f" % test_time)
 
@@ -173,7 +176,7 @@ def cortex_test(board_id):
         print("TEST PASSED")
 
 
-        print "\r\n\r\n------ Testing Invalid Memory Access Recovery ------"
+        print("\n\n------ Testing Invalid Memory Access Recovery ------")
         memory_access_pass = True
         try:
             target.readBlockMemoryUnaligned8(addr_invalid, 0x1000)
@@ -217,7 +220,7 @@ def cortex_test(board_id):
         target.writeBlockMemoryUnaligned8(addr, data)
         block = target.readBlockMemoryUnaligned8(addr, size)
         if same(data, block):
-            print "Aligned access pass"
+            print("Aligned access pass")
         else:
             print("Memory read does not match memory written")
             memory_access_pass = False
@@ -226,7 +229,7 @@ def cortex_test(board_id):
         target.writeBlockMemoryUnaligned8(addr + 1, data)
         block = target.readBlockMemoryUnaligned8(addr + 1, size)
         if same(data, block):
-            print "Unaligned access pass"
+            print("Unaligned access pass")
         else:
             print("Unaligned memory read does not match memory written")
             memory_access_pass = False
@@ -234,11 +237,11 @@ def cortex_test(board_id):
         test_count += 1
         if memory_access_pass:
             test_pass_count += 1
-            print "TEST PASSED"
+            print("TEST PASSED")
         else:
-            print "TEST FAILED"
+            print("TEST FAILED")
 
-        print "\r\n\r\n------ Testing Software Breakpoints ------"
+        print("\n\n------ Testing Software Breakpoints ------")
         test_passed = True
         orig8x2 = target.readBlockMemoryUnaligned8(addr, 2)
         orig8 = target.read8(addr)
@@ -250,9 +253,9 @@ def cortex_test(board_id):
             test_passed = True
             filtered = target.readBlockMemoryUnaligned8(addr, 2)
             if same(orig8x2, filtered):
-                print "2 byte unaligned passed"
+                print("2 byte unaligned passed")
             else:
-                print "2 byte unaligned failed (read %x-%x, expected %x-%x)" % (filtered[0], filtered[1], orig8x2[0], orig8x2[1])
+                print("2 byte unaligned failed (read %x-%x, expected %x-%x)" % (filtered[0], filtered[1], orig8x2[0], orig8x2[1]))
                 test_passed = False
 
             for now in (True, False):
@@ -260,51 +263,51 @@ def cortex_test(board_id):
                 if not now:
                     filtered = filtered()
                 if filtered == orig8:
-                    print "8-bit passed [now=%s]" % now
+                    print("8-bit passed [now=%s]" % now)
                 else:
-                    print "8-bit failed [now=%s] (read %x, expected %x)" % (now, filtered, orig8)
+                    print("8-bit failed [now=%s] (read %x, expected %x)" % (now, filtered, orig8))
                     test_passed = False
 
                 filtered = target.read16(addr & ~1, now)
                 if not now:
                     filtered = filtered()
                 if filtered == orig16:
-                    print "16-bit passed [now=%s]" % now
+                    print("16-bit passed [now=%s]" % now)
                 else:
-                    print "16-bit failed [now=%s] (read %x, expected %x)" % (now, filtered, orig16)
+                    print("16-bit failed [now=%s] (read %x, expected %x)" % (now, filtered, orig16))
                     test_passed = False
 
                 filtered = target.read32(addr & ~3, now)
                 if not now:
                     filtered = filtered()
                 if filtered == orig32:
-                    print "32-bit passed [now=%s]" % now
+                    print("32-bit passed [now=%s]" % now)
                 else:
-                    print "32-bit failed [now=%s] (read %x, expected %x)" % (now, filtered, orig32)
+                    print("32-bit failed [now=%s] (read %x, expected %x)" % (now, filtered, orig32))
                     test_passed = False
 
             filtered = target.readBlockMemoryAligned32(addr & ~3, 1)
             if same(filtered, origAligned32):
-                print "32-bit aligned passed"
+                print("32-bit aligned passed")
             else:
-                print "32-bit aligned failed (read %x, expected %x)" % (filtered[0], origAligned32[0])
+                print("32-bit aligned failed (read %x, expected %x)" % (filtered[0], origAligned32[0]))
                 test_passed = False
             return test_passed
 
-        print "Installed software breakpoint at 0x%08x" % addr
+        print("Installed software breakpoint at 0x%08x" % addr)
         target.setBreakpoint(addr, pyOCD.core.target.Target.BREAKPOINT_SW)
         test_passed = test_filters() and test_passed
 
-        print "Removed software breakpoint"
+        print("Removed software breakpoint")
         target.removeBreakpoint(addr)
         test_passed = test_filters() and test_passed
 
         test_count += 1
         if test_passed:
             test_pass_count += 1
-            print "TEST PASSED"
+            print("TEST PASSED")
         else:
-            print "TEST FAILED"
+            print("TEST FAILED")
 
         target.reset()
 

--- a/test/flash_test.py
+++ b/test/flash_test.py
@@ -58,17 +58,17 @@ class FlashTest(Test):
         super(FlashTest, self).__init__("Flash Test", flash_test)
 
     def print_perf_info(self, result_list, output_file=None):
-        result_list = filter(lambda x: isinstance(x, FlashTestResult), result_list)
+        result_list = list(filter(lambda x: isinstance(x, FlashTestResult), result_list))
 
-        print("\r\n\r\n------ Analyzer Performance ------", file=output_file)
+        print("\n\n------ Analyzer Performance ------", file=output_file)
         perf_format_str = "{:<10}{:<12}{:<18}{:<18}"
         print(perf_format_str.format("Target", "Analyzer", "Rate", "Time"),
               file=output_file)
         print("", file=output_file)
         for result in result_list:
             if result.passed:
-                analyze_rate = "%f KB/s" % (result.analyze_rate / float(1000))
-                analyze_time = "%s s" % result.analyze_time
+                analyze_rate = "%.3f KB/s" % (result.analyze_rate / float(1000))
+                analyze_time = "%.3f s" % result.analyze_time
             else:
                 analyze_rate = "Fail"
                 analyze_time = "Fail"
@@ -78,7 +78,7 @@ class FlashTest(Test):
                   file=output_file)
         print("", file=output_file)
 
-        print("\r\n\r\n------ Test Rate ------", file=output_file)
+        print("\n\n------ Test Rate ------", file=output_file)
         rate_format_str = "{:<10}{:<20}{:<20}{:<20}"
         print(rate_format_str.format("Target", "Chip Erase", "Page Erase",
                                      "Page Erase (Same data)"),
@@ -86,9 +86,9 @@ class FlashTest(Test):
         print("", file=output_file)
         for result in result_list:
             if result.passed:
-                chip_erase_rate = "%f KB/s" % (result.chip_erase_rate / float(1000))
-                page_erase_rate = "%f KB/s" % (result.page_erase_rate / float(1000))
-                page_erase_rate_same = "%f KB/s" % (result.page_erase_rate_same / float(1000))
+                chip_erase_rate = "%.3f KB/s" % (result.chip_erase_rate / float(1000))
+                page_erase_rate = "%.3f KB/s" % (result.page_erase_rate / float(1000))
+                page_erase_rate_same = "%.3f KB/s" % (result.page_erase_rate_same / float(1000))
             else:
                 chip_erase_rate = "Fail"
                 page_erase_rate = "Fail"
@@ -160,7 +160,7 @@ def flash_test(board_id):
             rom_start = rom_region.start
             rom_size = rom_region.length
 
-            print("\r\n\r\n===== Testing flash region '%s' from 0x%08x to 0x%08x ====" % (rom_region.name, rom_region.start, rom_region.end))
+            print("\n\n===== Testing flash region '%s' from 0x%08x to 0x%08x ====" % (rom_region.name, rom_region.start, rom_region.end))
 
             binary_file = os.path.join(parentdir, 'binaries', board.getTestBinary())
             with open(binary_file, "rb") as f:
@@ -179,7 +179,7 @@ def flash_test(board_id):
             # Turn on extra checks for the next 4 tests
             flash.setFlashAlgoDebug(True)
 
-            print("\r\n\r\n------ Test Basic Page Erase ------")
+            print("\n------ Test Basic Page Erase ------")
             info = flash.flashBlock(addr, data, False, False, progress_cb=print_progress())
             data_flashed = target.readBlockMemoryUnaligned8(addr, size)
             if same(data_flashed, data) and info.program_type is FlashBuilder.FLASH_PAGE_ERASE:
@@ -189,7 +189,7 @@ def flash_test(board_id):
                 print("TEST FAILED")
             test_count += 1
 
-            print("\r\n\r\n------ Test Basic Chip Erase ------")
+            print("\n------ Test Basic Chip Erase ------")
             info = flash.flashBlock(addr, data, False, True, progress_cb=print_progress())
             data_flashed = target.readBlockMemoryUnaligned8(addr, size)
             if same(data_flashed, data) and info.program_type is FlashBuilder.FLASH_CHIP_ERASE:
@@ -199,7 +199,7 @@ def flash_test(board_id):
                 print("TEST FAILED")
             test_count += 1
 
-            print("\r\n\r\n------ Test Smart Page Erase ------")
+            print("\n------ Test Smart Page Erase ------")
             info = flash.flashBlock(addr, data, True, False, progress_cb=print_progress())
             data_flashed = target.readBlockMemoryUnaligned8(addr, size)
             if same(data_flashed, data) and info.program_type is FlashBuilder.FLASH_PAGE_ERASE:
@@ -209,7 +209,7 @@ def flash_test(board_id):
                 print("TEST FAILED")
             test_count += 1
 
-            print("\r\n\r\n------ Test Smart Chip Erase ------")
+            print("\n------ Test Smart Chip Erase ------")
             info = flash.flashBlock(addr, data, True, True, progress_cb=print_progress())
             data_flashed = target.readBlockMemoryUnaligned8(addr, size)
             if same(data_flashed, data) and info.program_type is FlashBuilder.FLASH_CHIP_ERASE:
@@ -221,7 +221,7 @@ def flash_test(board_id):
 
             flash.setFlashAlgoDebug(False)
 
-            print("\r\n\r\n------ Test Basic Page Erase (Entire region) ------")
+            print("\n------ Test Basic Page Erase (Entire region) ------")
             new_data = list(data)
             new_data.extend(unused * [0x77])
             info = flash.flashBlock(addr, new_data, False, False, progress_cb=print_progress())
@@ -233,7 +233,7 @@ def flash_test(board_id):
                 print("TEST FAILED")
             test_count += 1
 
-            print("\r\n\r\n------ Test Fast Verify ------")
+            print("\n------ Test Fast Verify ------")
             info = flash.flashBlock(addr, new_data, progress_cb=print_progress(), fast_verify=True)
             if info.program_type == FlashBuilder.FLASH_PAGE_ERASE:
                 print("TEST PASSED")
@@ -242,8 +242,8 @@ def flash_test(board_id):
                 print("TEST FAILED")
             test_count += 1
 
-            print("\r\n\r\n------ Test Offset Write ------")
-            addr = rom_start + rom_size / 2
+            print("\n------ Test Offset Write ------")
+            addr = rom_start + rom_size // 2
             page_size = flash.getPageInfo(addr).size
             new_data = [0x55] * page_size * 2
             info = flash.flashBlock(addr, new_data, progress_cb=print_progress())
@@ -255,11 +255,11 @@ def flash_test(board_id):
                 print("TEST FAILED")
             test_count += 1
 
-            print("\r\n\r\n------ Test Multiple Block Writes ------")
-            addr = rom_start + rom_size / 2
+            print("\n------ Test Multiple Block Writes ------")
+            addr = rom_start + rom_size // 2
             page_size = flash.getPageInfo(addr).size
             more_data = [0x33] * page_size * 2
-            addr = (rom_start + rom_size / 2) + 1 #cover multiple pages
+            addr = (rom_start + rom_size // 2) + 1 #cover multiple pages
             fb = flash.getFlashBuilder()
             fb.addData(rom_start, data)
             fb.addData(addr, more_data)
@@ -273,9 +273,9 @@ def flash_test(board_id):
                 print("TEST FAILED")
             test_count += 1
 
-            print("\r\n\r\n------ Test Overlapping Blocks ------")
+            print("\n------ Test Overlapping Blocks ------")
             test_pass = False
-            addr = (rom_start + rom_size / 2) #cover multiple pages
+            addr = (rom_start + rom_size // 2) #cover multiple pages
             page_size = flash.getPageInfo(addr).size
             new_data = [0x33] * page_size
             fb = flash.getFlashBuilder()
@@ -292,7 +292,7 @@ def flash_test(board_id):
                 print("TEST FAILED")
             test_count += 1
 
-            print("\r\n\r\n------ Test Empty Block Write ------")
+            print("\n------ Test Empty Block Write ------")
             # Freebee if nothing asserts
             fb = flash.getFlashBuilder()
             fb.program()
@@ -300,7 +300,7 @@ def flash_test(board_id):
             test_pass_count += 1
             test_count += 1
 
-            print("\r\n\r\n------ Test Missing Progress Callback ------")
+            print("\n------ Test Missing Progress Callback ------")
             # Freebee if nothing asserts
             addr = rom_start
             flash.flashBlock(rom_start, data, True)
@@ -310,7 +310,7 @@ def flash_test(board_id):
 
             # Only run test if the reset handler can be programmed (rom start at address 0)
             if rom_start == 0:
-                print("\r\n\r\n------ Test Non-Thumb reset handler ------")
+                print("\n------ Test Non-Thumb reset handler ------")
                 non_thumb_data = list(data)
                 # Clear bit 0 of 2nd word - reset handler
                 non_thumb_data[4] = non_thumb_data[4] & ~1
@@ -324,7 +324,7 @@ def flash_test(board_id):
             # depend on the previous state of the flash
 
             if rom_start == flash_info.rom_start:
-                print("\r\n\r\n------ Test Chip Erase Decision ------")
+                print("\n------ Test Chip Erase Decision ------")
                 new_data = list(data)
                 new_data.extend([0xff] * unused) # Pad with 0xFF
                 info = flash.flashBlock(addr, new_data, progress_cb=print_progress())
@@ -336,7 +336,7 @@ def flash_test(board_id):
                     print("TEST FAILED")
                 test_count += 1
 
-                print("\r\n\r\n------ Test Chip Erase Decision 2 ------")
+                print("\n------ Test Chip Erase Decision 2 ------")
                 new_data = list(data)
                 new_data.extend([0x00] * unused) # Pad with 0x00
                 info = flash.flashBlock(addr, new_data, progress_cb=print_progress())
@@ -348,7 +348,7 @@ def flash_test(board_id):
                     print("TEST FAILED")
                 test_count += 1
 
-            print("\r\n\r\n------ Test Page Erase Decision ------")
+            print("\n------ Test Page Erase Decision ------")
             new_data = list(data)
             new_data.extend([0x00] * unused) # Pad with 0x00
             info = flash.flashBlock(addr, new_data, progress_cb=print_progress())
@@ -363,9 +363,9 @@ def flash_test(board_id):
                 print("TEST FAILED")
             test_count += 1
 
-            print("\r\n\r\n------ Test Page Erase Decision 2 ------")
+            print("\n------ Test Page Erase Decision 2 ------")
             new_data = list(data)
-            size_same = unused * 5 / 6
+            size_same = unused * 5 // 6
             size_differ = unused - size_same
             new_data.extend([0x00] * size_same) # Pad 5/6 with 0x00 and 1/6 with 0xFF
             new_data.extend([0x55] * size_differ)
@@ -377,7 +377,7 @@ def flash_test(board_id):
                 print("TEST FAILED")
             test_count += 1
 
-        print("\r\n\r\nTest Summary:")
+        print("\n\nTest Summary:")
         print("Pass count %i of %i tests" % (test_pass_count, test_count))
         if test_pass_count == test_count:
             print("FLASH TEST SCRIPT PASSED")

--- a/test/gdb_server_json_test.py
+++ b/test/gdb_server_json_test.py
@@ -14,6 +14,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from __future__ import print_function
 
 import argparse, os, sys
 from time import sleep, time
@@ -22,6 +23,7 @@ import math
 import argparse
 import subprocess
 import json
+import traceback
 
 parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, parentdir)
@@ -53,6 +55,7 @@ class GdbServerJsonTest(Test):
             result = GdbServerJsonTestResult()
             result.passed = False
             print("Exception %s when testing board %s" % (e, board.getUniqueID()))
+            traceback.print_exc(file=sys.stdout)
         result.board = board
         result.test = self
         return result
@@ -65,53 +68,53 @@ def gdb_server_json_test(board_id):
     def validate_basic_keys(data):
         did_pass = True
 
-        print 'pyocd_version',
-        p = data.has_key('pyocd_version')
+        print('pyocd_version', end=' ')
+        p = 'pyocd_version' in data
         if p:
             p = data['pyocd_version'] == __version__
         if p:
-            print "PASSED"
+            print("PASSED")
         else:
             did_pass = False
-            print"FAILED"
+            print("FAILED")
 
-        print 'version',
-        p = data.has_key('version')
+        print('version', end=' ')
+        p = 'version' in data
         if p:
             v = data['version']
-            p = v.has_key('major') and v.has_key('minor')
+            p = 'major' in v and 'minor' in v
         if p:
             p = v['major'] == 1 and v['minor'] == 0
         if p:
-            print "PASSED"
+            print("PASSED")
         else:
             did_pass = False
-            print"FAILED"
+            print("FAILED")
 
-        print 'status',
-        p = data.has_key('status')
+        print('status', end=' ')
+        p = 'status' in data
         if p:
             p = data['status'] == 0
         if p:
-            print "PASSED"
+            print("PASSED")
         else:
             did_pass = False
-            print"FAILED"
+            print("FAILED")
 
         return did_pass
 
     def validate_boards(data):
         did_pass = True
 
-        print 'boards',
-        p = data.has_key('boards') and type(data['boards']) is list
+        print('boards', end=' ')
+        p = 'boards' in data and type(data['boards']) is list
         if p:
             b = data['boards']
         if p:
-            print "PASSED"
+            print("PASSED")
         else:
             did_pass = False
-            print"FAILED"
+            print("FAILED")
 
         try:
             all_mbeds = MbedBoard.getAllConnectedBoards(close=True, blocking=False)
@@ -122,19 +125,20 @@ def gdb_server_json_test(board_id):
                     for brd in b:
                         if mbed.unique_id == brd['unique_id']:
                             matching_boards += 1
-                            p = brd.has_key('info') and brd.has_key('target') and brd.has_key('board_name')
+                            p = 'info' in brd and 'target' in brd and 'board_name' in brd
                             if not p:
                                 break
                     if not p:
                         break
                 p = matching_boards == len(all_mbeds)
             if p:
-                print "PASSED"
+                print("PASSED")
             else:
                 did_pass = False
-                print"FAILED"
-        except Exception:
-            print "FAILED"
+                print("FAILED")
+        except Exception as e:
+            print("FAILED")
+            traceback.print_exc(file=sys.stdout)
             did_pass = False
 
         return did_pass
@@ -142,26 +146,26 @@ def gdb_server_json_test(board_id):
     def validate_targets(data):
         did_pass = True
 
-        print 'targets',
-        p = data.has_key('targets') and type(data['targets']) is list
+        print('targets', end=' ')
+        p = 'targets' in data and type(data['targets']) is list
         if p:
             targets = data['targets']
             for t in targets:
-                p = t.has_key('name') and t.has_key('part_number')
+                p = 'name' in t and 'part_number' in t
                 if not p:
                     break
         if p:
-            print "PASSED"
+            print("PASSED")
         else:
             did_pass = False
-            print"FAILED"
+            print("FAILED")
 
         return did_pass
 
 
     result = GdbServerJsonTestResult()
 
-    print "\r\n\r\n----- TESTING BOARDS LIST -----"
+    print("\n\n----- TESTING BOARDS LIST -----")
     out = subprocess.check_output(['pyocd-gdbserver', '--list', '--json'])
     data = json.loads(out)
     test_count += 2
@@ -170,7 +174,7 @@ def gdb_server_json_test(board_id):
     if validate_boards(data):
         test_pass_count += 1
 
-    print "\r\n\r\n----- TESTING TARGETS LIST -----"
+    print("\n\n----- TESTING TARGETS LIST -----")
     out = subprocess.check_output(['pyocd-gdbserver', '--list-targets', '--json'])
     data = json.loads(out)
     test_count += 2

--- a/test/gdb_test.py
+++ b/test/gdb_test.py
@@ -14,6 +14,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from __future__ import print_function
 
 # Note
 #  To run this script GNU Tools ARM Embedded must be installed,
@@ -29,6 +30,7 @@ import sys
 from subprocess import Popen, STDOUT, PIPE
 import argparse
 import logging
+import traceback
 
 from pyOCD.tools.gdb_server import GDBServerTool
 from pyOCD.board import MbedBoard
@@ -65,6 +67,7 @@ class GdbTest(Test):
             result.passed = False
             print("Exception %s when testing board %s" %
                   (e, board.getUniqueID()))
+            traceback.print_exc(file=sys.stdout)
         result.board = board
         result.test = self
         return result
@@ -120,12 +123,12 @@ def test_gdb(board_id=None):
     test_params["invalid_length"] = 0x1000
     test_params["expect_error_on_invalid_access"] = error_on_invalid_access
     test_params["ignore_hw_bkpt_result"] = ignore_hw_bkpt_result
-    with open(TEST_PARAM_FILE, "wb") as f:
+    with open(TEST_PARAM_FILE, "w") as f:
         f.write(json.dumps(test_params))
 
     # Run the test
     gdb = [PYTHON_GDB, "--command=gdb_script.py"]
-    with open("output.txt", "wb") as f:
+    with open("output.txt", "w") as f:
         program = Popen(gdb, stdin=PIPE, stdout=f, stderr=STDOUT)
         args = ['-p=%i' % test_port, "-f=%i" % test_clock, "-b=%s" % board_id]
         server = GDBServerTool()
@@ -133,7 +136,7 @@ def test_gdb(board_id=None):
         program.wait()
 
     # Read back the result
-    with open(TEST_RESULT_FILE, "rb") as f:
+    with open(TEST_RESULT_FILE, "r") as f:
         test_result = json.loads(f.read())
 
     # Print results

--- a/test/speed_test.py
+++ b/test/speed_test.py
@@ -31,8 +31,6 @@ from pyOCD.pyDAPAccess import DAPAccess
 from test_util import Test, TestResult
 import logging
 
-USB_TEST_XFER_COUNT = 128 * 1024 / 64  # 128 KB = 2K usb packets
-
 class SpeedTestResult(TestResult):
     def __init__(self):
         super(SpeedTestResult, self).__init__(None, None, None)
@@ -44,14 +42,14 @@ class SpeedTest(Test):
     def print_perf_info(self, result_list, output_file=None):
         format_str = "{:<10}{:<16}{:<16}"
         result_list = filter(lambda x: isinstance(x, SpeedTestResult), result_list)
-        print("\r\n\r\n------ Speed Test Performance ------", file=output_file)
+        print("\n\n------ Speed Test Performance ------", file=output_file)
         print(format_str.format("Target", "Read Speed", "Write Speed"),
               file=output_file)
         print("", file=output_file)
         for result in result_list:
             if result.passed:
-                read_speed = "%f KB/s" % (float(result.read_speed) / float(1000))
-                write_speed = "%f KB/s" % (float(result.write_speed) / float(1000))
+                read_speed = "%.3f KB/s" % (float(result.read_speed) / float(1000))
+                write_speed = "%.3f KB/s" % (float(result.write_speed) / float(1000))
             else:
                 read_speed = "Fail"
                 write_speed = "Fail"
@@ -108,7 +106,7 @@ def speed_test(board_id):
         link.set_clock(test_clock)
         link.set_deferred_transfer(True)
 
-        print("\r\n\r\n------ TEST RAM READ / WRITE SPEED ------")
+        print("\n\n------ TEST RAM READ / WRITE SPEED ------")
         test_addr = ram_start
         test_size = ram_size
         data = [randrange(1, 50) for x in range(test_size)]
@@ -118,14 +116,14 @@ def speed_test(board_id):
         stop = time()
         diff = stop - start
         result.write_speed = test_size / diff
-        print("Writing %i byte took %s seconds: %s B/s" % (test_size, diff, result.write_speed))
+        print("Writing %i byte took %.3f seconds: %.3f B/s" % (test_size, diff, result.write_speed))
         start = time()
         block = target.readBlockMemoryUnaligned8(test_addr, test_size)
         target.flush()
         stop = time()
         diff = stop - start
         result.read_speed = test_size / diff
-        print("Reading %i byte took %s seconds: %s B/s" % (test_size, diff, result.read_speed))
+        print("Reading %i byte took %.3f seconds: %.3f B/s" % (test_size, diff, result.read_speed))
         error = False
         for i in range(len(block)):
             if (block[i] != data[i]):
@@ -138,7 +136,7 @@ def speed_test(board_id):
             test_pass_count += 1
         test_count += 1
 
-        print("\r\n\r\n------ TEST ROM READ SPEED ------")
+        print("\n\n------ TEST ROM READ SPEED ------")
         test_addr = rom_start
         test_size = rom_size
         start = time()
@@ -146,7 +144,7 @@ def speed_test(board_id):
         target.flush()
         stop = time()
         diff = stop - start
-        print("Reading %i byte took %s seconds: %s B/s" % (test_size, diff, test_size / diff))
+        print("Reading %i byte took %.3f seconds: %.3f B/s" % (test_size, diff, test_size / diff))
         print("TEST PASSED")
         test_pass_count += 1
         test_count += 1

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import pyOCD
 import logging, os, sys
+import traceback
 
 class Logger(object):
     def __init__(self, filename="Default.log"):
@@ -57,6 +58,7 @@ class Test(object):
             passed = True
         except Exception as e:
             print("Exception %s when testing board %s" % (e, board.getUniqueID()))
+            traceback.print_exc(file=sys.stdout)
         return TestResult(board, self, passed)
 
     def print_perf_info(self, result_list, output_file=None):
@@ -68,7 +70,7 @@ class Test(object):
     @staticmethod
     def print_results(result_list, output_file=None):
         msg_format_str = "{:<15}{:<21}{:<15}{:<15}"
-        print("\r\n\r\n------ TEST RESULTS ------")
+        print("\n\n------ TEST RESULTS ------")
         print(msg_format_str .format("Target", "Test", "Result", "Time"),
               file=output_file)
         print("", file=output_file)
@@ -76,7 +78,7 @@ class Test(object):
             status_str = "Pass" if result.passed else "Fail"
             print(msg_format_str.format(result.board.target_type,
                                         result.test.name,
-                                        status_str, result.time),
+                                        status_str, "%.3f" % result.time),
                   file=output_file)
 
     @staticmethod


### PR DESCRIPTION
Numerous changes in order to support running pyOCD in Python 3.

The biggest areas of change are:

1. The most involved changes are in the gdb server, where all `str` objects were changed to `bytes`. 
2. The other most noticeable change is that all module imports within pyOCD must now be relative.
3. Replaced all uses of `has_key()` with the `in` or `not in` operators.

All tests pass both on Python 2.7.15 and 3.6.5. Travis CI config is updated to test on 2.7, 3.6.