### PR TITLE
Fix some Python3 compatibility bugs

### DIFF
--- a/pyOCD/board/mbed_board.py
+++ b/pyOCD/board/mbed_board.py
@@ -28,6 +28,9 @@ from .board_ids import BOARD_ID_TO_INFO
 mbed_vid = 0x0d28
 mbed_pid = 0x0204
 
+# Init colorama here since this is currently the only module that uses it.
+colorama.init()
+
 class MbedBoard(Board):
     """
     This class inherits from Board and is specific to mbed boards.

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -834,7 +834,7 @@ class GDBServer(threading.Thread):
             second_colon = 0
             idx_begin = 0
             while second_colon != 2:
-                if data[idx_begin] == b':':
+                if data[idx_begin:idx_begin+1] == b':':
                     second_colon += 1
                 idx_begin += 1
 

--- a/pyOCD/test/test_cmdline.py
+++ b/pyOCD/test/test_cmdline.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2015 ARM Limited
+ Copyright (c) 2015,2018 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,9 +15,16 @@
  limitations under the License.
 """
 
-from pyOCD.utility.cmdline import split_command_line
+from pyOCD.utility.cmdline import (
+    split_command_line,
+    convert_vector_catch,
+    VECTOR_CATCH_CHAR_MAP
+    )
+from pyOCD.core.target import Target
+import pytest
+import six
 
-class TestSplitCommandLine:
+class TestSplitCommandLine(object):
     def test_split(self):
         assert split_command_line('foo') == ['foo']
         assert split_command_line(['foo']) == ['foo']
@@ -38,3 +45,26 @@ class TestSplitCommandLine:
         assert split_command_line('a\nb') == ['a', 'b']
         assert split_command_line('a   \tb') == ['a', 'b']
 
+class TestConvertVectorCatch(object):
+    def test_none_str(self):
+        assert convert_vector_catch('none') == 0
+
+    def test_all_str(self):
+        assert convert_vector_catch('all') == Target.CATCH_ALL
+
+    def test_none_b(self):
+        assert convert_vector_catch(b'none') == 0
+
+    def test_all_b(self):
+        assert convert_vector_catch(b'all') == Target.CATCH_ALL
+
+    @pytest.mark.parametrize(("vc", "msk"),
+        list(VECTOR_CATCH_CHAR_MAP.items()))
+    def test_vc_str(self, vc, msk):
+        assert convert_vector_catch(vc) == msk
+
+    @pytest.mark.parametrize(("vc", "msk"),
+        [(six.b(x), y) for x,y in VECTOR_CATCH_CHAR_MAP.items()])
+    def test_vc_b(self, vc, msk):
+        assert convert_vector_catch(vc) == msk
+        

--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -334,7 +334,7 @@ def hex_width(value, width):
 def dumpHexData(data, startAddress=0, width=8):
     i = 0
     while i < len(data):
-        print("%08x: " % (startAddress + (i * (width / 8))), end=' ')
+        print("%08x: " % (startAddress + (i * (width // 8))), end=' ')
 
         while i < len(data):
             d = data[i]

--- a/pyOCD/utility/cmdline.py
+++ b/pyOCD/utility/cmdline.py
@@ -16,6 +16,7 @@
 """
 
 from ..core.target import Target
+from ..utility.py3_helpers import to_str_safe
 
 ## @brief Split command line by whitespace, supporting quoted strings.
 #
@@ -71,7 +72,7 @@ VECTOR_CATCH_CHAR_MAP = {
 # @exception ValueError Raised if an invalid vector catch character is encountered.
 def convert_vector_catch(value):
     # Make case insensitive.
-    value = value.lower()
+    value = to_str_safe(value).lower()
 
     # Handle special vector catch options.
     if value == 'all':

--- a/pyOCD/utility/py3_helpers.py
+++ b/pyOCD/utility/py3_helpers.py
@@ -44,3 +44,19 @@ else:
         else:
             return v
 
+# to_str_safe() converts a bytes object to a unicode string by decoding from
+# latin-1. It will also accept a value that is already a str object and
+# return it unmodified.
+if PY3:
+    def to_str_safe(v):
+        if type(v) is str:
+            return v
+        else:
+            return v.decode('latin-1')
+else:
+    def to_str_safe(v):
+        if type(v) is unicode:
+            return v.decode('latin-1')
+        else:
+            return v
+

--- a/test/gdb_script.py
+++ b/test/gdb_script.py
@@ -83,10 +83,10 @@ monitor_commands = [
     "halt",
     "arm semihosting enable",
     "arm semihosting disable",
-#     "set vector-catch all",
-#     "set vector-catch none",
-#     "set step-into-interrupt on",
-#     "set step-into-interrupt off",
+    "set vector-catch n",
+    "set vector-catch a",
+    "set step-into-interrupt on",
+    "set step-into-interrupt off",
     # Invalid Command
     "fawehfawoefhad"
 ]
@@ -229,6 +229,9 @@ def run_test():
         for command in monitor_commands:
             gdb_execute("mon %s" % command)
 
+        # Load target-specific test program into flash.
+        gdb_execute("load %s" % target_test_elf)
+
         # Reset the target and let it run so it has
         # a chance to disable the watchdog
         gdb_execute("mon reset halt")
@@ -237,9 +240,6 @@ def run_test():
         if not is_event_signal(event, "SIGINT"):
             fail_count += 1
             print("Error - target not interrupted as expected")
-
-        # Load target-specific test program into flash.
-        gdb_execute("load %s" % target_test_elf)
 
         # Load test program and symbols
         test_binary = "../src/gdb_test_program/gdb_test.bin"

--- a/test/gdb_script.py
+++ b/test/gdb_script.py
@@ -192,6 +192,7 @@ def run_test():
     invalid_addr = test_params["invalid_start"]
     error_on_invalid_access = test_params["expect_error_on_invalid_access"]
     ignore_hw_bkpt_result = test_params["ignore_hw_bkpt_result"]
+    target_test_elf = test_params["test_elf"]
 
     assert ram_length >= MAX_TEST_SIZE
     stack_addr = ram_start + STACK_OFFSET
@@ -236,6 +237,9 @@ def run_test():
         if not is_event_signal(event, "SIGINT"):
             fail_count += 1
             print("Error - target not interrupted as expected")
+
+        # Load target-specific test program into flash.
+        gdb_execute("load %s" % target_test_elf)
 
         # Load test program and symbols
         test_binary = "../src/gdb_test_program/gdb_test.bin"

--- a/test/gdb_test.py
+++ b/test/gdb_test.py
@@ -27,10 +27,11 @@ from __future__ import print_function
 import os
 import json
 import sys
-from subprocess import Popen, STDOUT, PIPE
+from subprocess import Popen, STDOUT, PIPE, check_call
 import argparse
 import logging
 import traceback
+import tempfile
 
 from pyOCD.tools.gdb_server import GDBServerTool
 from pyOCD.board import MbedBoard
@@ -42,7 +43,7 @@ from test_util import Test, TestResult
 TEST_PARAM_FILE = "test_params.txt"
 TEST_RESULT_FILE = "test_results.txt"
 PYTHON_GDB = "arm-none-eabi-gdb-py"
-
+OBJCOPY = "arm-none-eabi-objcopy"
 
 parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -83,6 +84,7 @@ TEST_RESULT_KEYS = [
 
 
 def test_gdb(board_id=None):
+    temp_test_elf_name = None
     result = GdbTestResult()
     with MbedBoard.chooseBoard(board_id=board_id) as board:
         memory_map = board.target.getMemoryMap()
@@ -113,6 +115,11 @@ def test_gdb(board_id=None):
         board.flash.flashBinary(binary_file, rom_region.start)
         board.uninit(False)
 
+    # Generate an elf from the binary test file.
+    temp_test_elf_name = tempfile.mktemp('.elf')
+    check_call([OBJCOPY, "-v", "-I", "binary", "-O", "elf32-littlearm", "-B", "arm", "-S",
+        "--set-start", "0x%x" % rom_region.start, binary_file, temp_test_elf_name])
+
     # Write out the test configuration
     test_params = {}
     test_params["rom_start"] = rom_region.start
@@ -123,6 +130,7 @@ def test_gdb(board_id=None):
     test_params["invalid_length"] = 0x1000
     test_params["expect_error_on_invalid_access"] = error_on_invalid_access
     test_params["ignore_hw_bkpt_result"] = ignore_hw_bkpt_result
+    test_params["test_elf"] = temp_test_elf_name
     with open(TEST_PARAM_FILE, "w") as f:
         f.write(json.dumps(test_params))
 
@@ -154,6 +162,8 @@ def test_gdb(board_id=None):
         result.passed = False
 
     # Cleanup
+    if temp_test_elf_name and os.path.exists(temp_test_elf_name):
+        os.remove(temp_test_elf_name)
     os.remove(TEST_RESULT_FILE)
     os.remove(TEST_PARAM_FILE)
 

--- a/test/gdb_test.py
+++ b/test/gdb_test.py
@@ -119,6 +119,9 @@ def test_gdb(board_id=None):
     temp_test_elf_name = tempfile.mktemp('.elf')
     check_call([OBJCOPY, "-v", "-I", "binary", "-O", "elf32-littlearm", "-B", "arm", "-S",
         "--set-start", "0x%x" % rom_region.start, binary_file, temp_test_elf_name])
+    # Need to escape backslashes on Windows.
+    if sys.platform.startswith('win'):
+        temp_test_elf_name = temp_test_elf_name.replace('\\', '\\\\')
 
     # Write out the test configuration
     test_params = {}


### PR DESCRIPTION
- Corrected an issue with the gdb server vFlashWrite command when running in Python 3.
- Extended `gdb_test.py` to validate flash programming via gdb. `arm-none-eabi-objcopy` is used to generate a temporary ELF from the board's test binary. This is then passed to `gdb_script.py`, which writes it to flash by a gbd `load` command.
- Fixed a case of non-integer divide in `dumpHexData()` in `pyocd-tool`.
- Fixed str/bytes issue in `pyOCD.utility.cmdline.convert_vector_catch()` when called from `GDBServer`.
- Enabled `set vector-catch` and `set step-into-interrupt` monitor command tests in `gdb_test.py`.
- In addition to the above Python 3 related changes, a missing call to `colorama.init()` was inserted so that color escape sequences work properly on Windows and are filtered out for non-TTY outputs.