### PR TITLE
Fix flashing of hex format files

### DIFF
--- a/pyOCD/tools/flash_tool.py
+++ b/pyOCD/tools/flash_tool.py
@@ -113,7 +113,7 @@ def setup_logging(args):
 
 
 def ranges(i):
-    for a, b in itertools.groupby(enumerate(i), lambda x, y: y - x):
+    for a, b in itertools.groupby(enumerate(i), lambda x: x[1] - x[0]):
         b = list(b)
         yield b[0][1], b[-1][1]
 


### PR DESCRIPTION
When trying to flash a hex format file we get a TypeError from the lambda
function:

flash_tool.py", line 116, in ranges
    for a, b in itertools.groupby(enumerate(i), lambda x, y: y - x):
TypeError: <lambda>() takes exactly 2 arguments (1 given)

This was introduced when the codebase was updated to support python3.  Make
the lambda function lambda x: x[1] - x[0].

Fixes #378

Signed-off-by: Kumar Gala <kumar.gala@gmail.com>