### PR TITLE
Retry SWJ sequence if read of DP IDCODE fails

### DIFF
--- a/pyOCD/coresight/dap.py
+++ b/pyOCD/coresight/dap.py
@@ -110,7 +110,13 @@ class DebugPort(object):
         # Connect to the target.
         self.link.connect()
         self.link.swj_sequence()
-        self.read_id_code()
+        try:
+            self.read_id_code()
+        except DAPAccess.TransferError:
+            # If the read of the DP IDCODE fails, retry SWJ sequence. The DP may have been
+            # in a state where it thought the SWJ sequence was an invalid transfer.
+            self.link.swj_sequence()
+            self.read_id_code()
         self.clear_sticky_err()
 
     def read_id_code(self):


### PR DESCRIPTION
Arm documentation states that the JTAG to SWD switch sequence may be misinterpreted as an invalid transaction in some cases. If this happens, the following read of the DP IDCODE register will fail with a transfer error. The Arm recommended solution is to resend the SWJ sequence and try reading IDCODE again.