### PR TITLE
Added unimplemented -j and -q options to automated_test.py

### DIFF
--- a/test/automated_test.py
+++ b/test/automated_test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
  mbed CMSIS-DAP debugger
  Copyright (c) 2015-2015 ARM Limited
@@ -55,8 +56,10 @@ def main():
     summary_file = "automated_test_summary.txt"
 
     parser = argparse.ArgumentParser(description='pyOCD automated testing')
-    parser.add_argument('-d', '--debug',
-                        action="store_true", help='Enable debug logging')
+    parser.add_argument('-d', '--debug', action="store_true", help='Enable debug logging')
+    parser.add_argument('-q', '--quiet', action="store_true", help='Hide test progress for 1 job')
+    parser.add_argument('-j', '--jobs', action="store", default=1, type=int, metavar="JOBS",
+        help='Set number of concurrent board tests (default is 1)')
     args = parser.parse_args()
 
     # Setup logging


### PR DESCRIPTION
This change adds compatibility with the command line options added in the parallel test branch, without any implementation behind the options. This will allow updating the Jenkins config to set the number of jobs so the parallel test PR can be tested fully without risking CI stability.

Also made automated_test.py executable and added shebang line, so it can be run directly as an executable on Unix systems.