### PR TITLE
Clean up rtos logging

### DIFF
--- a/pyOCD/rtos/argon.py
+++ b/pyOCD/rtos/argon.py
@@ -328,9 +328,6 @@ class ArgonThreadProvider(ThreadProvider):
         self._all_threads = None
         self._threads = {}
 
-        self._target.root_target.subscribe(Target.EVENT_POST_FLASH_PROGRAM, self.event_handler)
-        self._target.subscribe(Target.EVENT_POST_RESET, self.event_handler)
-
     def init(self, symbolProvider):
         self.g_ar = symbolProvider.get_symbol_value("g_ar")
         if self.g_ar is None:
@@ -343,6 +340,9 @@ class ArgonThreadProvider(ThreadProvider):
         log.debug("Argon: g_ar_objects = 0x%08x", self.g_ar_objects)
 
         self._all_threads = self.g_ar_objects + ALL_OBJECTS_THREADS_OFFSET
+
+        self._target.root_target.subscribe(Target.EVENT_POST_FLASH_PROGRAM, self.event_handler)
+        self._target.subscribe(Target.EVENT_POST_RESET, self.event_handler)
 
         return True
 

--- a/pyOCD/rtos/freertos.py
+++ b/pyOCD/rtos/freertos.py
@@ -382,7 +382,7 @@ class FreeRTOSThreadProvider(ThreadProvider):
 
     def event_handler(self, notification):
         # Invalidate threads list if flash is reprogrammed.
-        log.info("FreeRTOS: invalidating threads list: %s" % (repr(notification)))
+        log.debug("FreeRTOS: invalidating threads list: %s" % (repr(notification)))
         self.invalidate();
 
     def _build_thread_list(self):

--- a/pyOCD/rtos/freertos.py
+++ b/pyOCD/rtos/freertos.py
@@ -332,9 +332,6 @@ class FreeRTOSThreadProvider(ThreadProvider):
         self._total_priorities = 0
         self._threads = {}
 
-        self._target.root_target.subscribe(Target.EVENT_POST_FLASH_PROGRAM, self.event_handler)
-        self._target.subscribe(Target.EVENT_POST_RESET, self.event_handler)
-
     def init(self, symbolProvider):
         # Lookup required symbols.
         self._symbols = self._lookup_symbols(self.FREERTOS_SYMBOLS, symbolProvider)
@@ -374,6 +371,9 @@ class FreeRTOSThreadProvider(ThreadProvider):
             log.warning("FreeRTOS: number of priorities is too large (%d)", self._total_priorities)
             return False
         log.debug("FreeRTOS: number of priorities is %d", self._total_priorities)
+
+        self._target.root_target.subscribe(Target.EVENT_POST_FLASH_PROGRAM, self.event_handler)
+        self._target.subscribe(Target.EVENT_POST_RESET, self.event_handler)
 
         return True
 

--- a/pyOCD/rtos/zephyr.py
+++ b/pyOCD/rtos/zephyr.py
@@ -307,7 +307,7 @@ class ZephyrThreadProvider(ThreadProvider):
 
     def event_handler(self, notification):
         if notification.event == Target.EVENT_POST_RESET:
-            log.info("Invalidating threads list: %s" % (repr(notification)))
+            log.debug("Invalidating threads list: %s" % (repr(notification)))
             self.invalidate();
 
         elif notification.event == Target.EVENT_POST_FLASH_PROGRAM:


### PR DESCRIPTION
- Cleans up rtos modules to consistently use the debug logging level (there were a few stray usages of the info logging level)
- Eliminates unrelated rtos logging messages (e.g., freertos logging messages when debugging a zephyr application)