### PR TITLE
Improved Kinetis connect logic

### DIFF
--- a/pyOCD/coresight/dap.py
+++ b/pyOCD/coresight/dap.py
@@ -154,6 +154,9 @@ class DebugPort(object):
         self._csw = {}
         self._dp_select = -1
 
+    def is_reset_asserted(self):
+        return self.link.is_reset_asserted()
+
     def set_clock(self, frequency):
         self.link.set_clock(frequency)
         

--- a/pyOCD/pyDAPAccess/dap_access_api.py
+++ b/pyOCD/pyDAPAccess/dap_access_api.py
@@ -167,6 +167,10 @@ class DAPAccessIntf(object):
     def assert_reset(self, asserted):
         """Assert or de-assert target reset line"""
         raise NotImplementedError()
+    
+    def is_reset_asserted(self):
+        """Returns True if the target reset line is asserted or False if de-asserted"""
+        raise NotImplementedError()
 
     def set_deferred_transfer(self, enable):
         """Allow reads and writes to be buffered for increased speed"""

--- a/pyOCD/pyDAPAccess/dap_access_cmsis_dap.py
+++ b/pyOCD/pyDAPAccess/dap_access_cmsis_dap.py
@@ -546,6 +546,11 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
             self._protocol.setSWJPins(0, 'nRESET')
         else:
             self._protocol.setSWJPins(0x80, 'nRESET')
+    
+    def is_reset_asserted(self):
+        self.flush()
+        pins = self._protocol.setSWJPins(0, 'None')
+        return (pins & 0x80) == 0
 
     def set_clock(self, frequency):
         self.flush()

--- a/pyOCD/target/family/target_kinetis.py
+++ b/pyOCD/target/family/target_kinetis.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013 ARM Limited
+ Copyright (c) 2006-2018 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ from ...coresight.cortex_m import CortexM
 from ...core.target import Target
 from ...core.coresight_target import CoreSightTarget
 from ...utility.timeout import Timeout
+from ...pyDAPAccess.dap_access_api import DAPAccessIntf
 import logging
 from time import sleep
 
@@ -35,9 +36,15 @@ MDM_STATUS_CORE_HALTED = (1 << 16)
 
 MDM_CTRL_FLASH_MASS_ERASE_IN_PROGRESS = (1 << 0)
 MDM_CTRL_DEBUG_REQUEST = (1 << 2)
+MDM_CTRL_SYSTEM_RESET_REQUEST = (1 << 3)
 MDM_CTRL_CORE_HOLD_RESET = (1 << 4)
 
+HALT_TIMEOUT = 2.0
 MASS_ERASE_TIMEOUT = 10.0
+
+ACCESS_TEST_ATTEMPTS = 10
+
+log = logging.getLogger("target.family.kinetis")
 
 class Kinetis(CoreSightTarget):
 
@@ -75,75 +82,127 @@ class Kinetis(CoreSightTarget):
         if self.mdm_idr != 0 and self.mdm_ap.idr != self.mdm_idr:
             logging.error("%s: bad MDM-AP IDR (is 0x%08x, expected 0x%08x)", self.part_number, self.mdm_ap.idr, self.mdm_idr)
 
+    ## @brief Check security and unlock device.
+    #
+    # This init task determines whether the device is locked (flash security enabled). If it is,
+    # and if auto unlock is enabled, then perform a mass erase to unlock the device.
+    #
+    # This whole sequence is greatly complicated by some behaviour of the device when flash is
+    # blank. If flash is blank and the device does not have a ROM, then it will repeatedly enter
+    # lockup and then reset.
+    #
+    # Immediately after reset asserts, the flash controller begins to initialise. The device is
+    # always locked, and flash security reads as enabled, until the flash controller has finished
+    # its init sequence. Thus, depending on exactly when the debugger reads the MDM-AP status
+    # register, a blank, unlocked device may be detected as locked.
+    #
+    # There is also the possibility that the device will be (correctly) detected as unlocked, but
+    # it resets again before the core can be halted, thus causing connect to fail.
+    #
+    # This init task runs *before* cores are created.
     def check_flash_security(self):
         # check for flash security
         isLocked = self.isLocked()
+        
+        # Test whether we can reliably access the memory and the core. This test can fail if flash
+        # is blank and the device is auto-resetting.
+        if isLocked:
+            canAccess = False
+        else:
+            try:
+                for attempt in range(ACCESS_TEST_ATTEMPTS):
+                    self.aps[0].read32(CortexM.DHCSR)
+            except DAPAccessIntf.TransferFaultError:
+                log.debug("Access test failed with fault")
+                canAccess = False
+            else:
+                canAccess = True
+        
+        # Verify locked status under reset. We only want to assert reset if the device looks locked
+        # or accesses fail, otherwise we could not support attach mode debugging.
+        if not canAccess:
+            # Keep the target in reset until is had been erased and halted. It will be deasserted
+            # later, in perform_halt_on_connect().
+            #
+            # Ideally we would use the MDM-AP to hold the device in reset, but SYSTEM_RESET_REQUEST
+            # cannot be written in MDM_CTRL when the device is locked in MDM-AP version 0.
+            self.dp.assert_reset(True)
+
+            # Re-read locked status under reset.
+            isLocked = self.isLocked()
+            
+            # If the device isn't really locked, we have no choice but to halt on connect.
+            if not isLocked and not self.halt_on_connect:
+                log.warning("Forcing halt on connect in order to gain control of device")
+                self.halt_on_connect = True
+        
+        # Only do a mass erase if the device is actually locked.
         if isLocked:
             if self.do_auto_unlock:
-                logging.warning("%s in secure state: will try to unlock via mass erase", self.part_number)
-                # keep the target in reset until is had been erased and halted
-                self.dp.assert_reset(True)
+                log.warning("%s in secure state: will try to unlock via mass erase", self.part_number)
+                
+                # Do the mass erase.
                 if not self.massErase():
                     self.dp.assert_reset(False)
-                    logging.error("%s: mass erase failed", self.part_number)
-                    raise Exception("unable to unlock device")
-                # Use the MDM to keep the target halted after reset has been released
-                self.mdm_ap.write_reg(MDM_CTRL, MDM_CTRL_DEBUG_REQUEST)
-                # Enable debug
-                self.aps[0].writeMemory(CortexM.DHCSR, CortexM.DBGKEY | CortexM.C_DEBUGEN)
-                self.dp.assert_reset(False)
-                while self.mdm_ap.read_reg(MDM_STATUS) & MDM_STATUS_CORE_HALTED != MDM_STATUS_CORE_HALTED:
-                    logging.debug("Waiting for mdm halt (erase)")
-                    sleep(0.01)
-
-                # release MDM halt once it has taken effect in the DHCSR
-                self.mdm_ap.write_reg(MDM_CTRL, 0)
+                    self.mdm_ap.write_reg(MDM_CTRL, 0)
+                    log.error("%s: mass erase failed", self.part_number)
+                    raise RuntimeError("unable to unlock device")
+                
+                # Assert that halt on connect was forced above. Reset will stay asserted
+                # until halt on connect is executed.
+                assert self.halt_on_connect
 
                 isLocked = False
             else:
-                logging.warning("%s in secure state: not automatically unlocking", self.part_number)
+                log.warning("%s in secure state: not automatically unlocking", self.part_number)
         else:
-            logging.info("%s not in secure state", self.part_number)
+            log.info("%s not in secure state", self.part_number)
 
-        # Can't do anything more if the target is secure
-        if isLocked:
-            return
-
+    # This init task runs *after* cores are created.
     def perform_halt_on_connect(self):
         if self.halt_on_connect:
             # Prevent the target from resetting if it has invalid code
-            self.mdm_ap.write_reg(MDM_CTRL, MDM_CTRL_DEBUG_REQUEST | MDM_CTRL_CORE_HOLD_RESET)
-            while self.mdm_ap.read_reg(MDM_CTRL) & (MDM_CTRL_DEBUG_REQUEST | MDM_CTRL_CORE_HOLD_RESET) != (MDM_CTRL_DEBUG_REQUEST | MDM_CTRL_CORE_HOLD_RESET):
-                self.mdm_ap.write_reg(MDM_CTRL, MDM_CTRL_DEBUG_REQUEST | MDM_CTRL_CORE_HOLD_RESET)
+            with Timeout(HALT_TIMEOUT) as to:
+                while to.check():
+                    self.mdm_ap.write_reg(MDM_CTRL, MDM_CTRL_DEBUG_REQUEST | MDM_CTRL_CORE_HOLD_RESET)
+                    if self.mdm_ap.read_reg(MDM_CTRL) & (MDM_CTRL_DEBUG_REQUEST | MDM_CTRL_CORE_HOLD_RESET) == (MDM_CTRL_DEBUG_REQUEST | MDM_CTRL_CORE_HOLD_RESET):
+                        break
+                else:
+                    raise RuntimeError("Timed out attempting to set DEBUG_REQUEST and CORE_HOLD_RESET in MDM-AP")
+
+            # We can now deassert reset.
+            self.dp.assert_reset(False)
+
             # Enable debug
             self.aps[0].writeMemory(CortexM.DHCSR, CortexM.DBGKEY | CortexM.C_DEBUGEN)
+
             # Disable holding the core in reset, leave MDM halt on
             self.mdm_ap.write_reg(MDM_CTRL, MDM_CTRL_DEBUG_REQUEST)
 
             # Wait until the target is halted
-            while self.mdm_ap.read_reg(MDM_STATUS) & MDM_STATUS_CORE_HALTED != MDM_STATUS_CORE_HALTED:
-                logging.debug("Waiting for mdm halt")
-                sleep(0.01)
+            with Timeout(HALT_TIMEOUT) as to:
+                while to.check():
+                    if self.mdm_ap.read_reg(MDM_STATUS) & MDM_STATUS_CORE_HALTED == MDM_STATUS_CORE_HALTED:
+                        break
+                    log.debug("Waiting for mdm halt")
+                    sleep(0.01)
+                else:
+                    raise RuntimeError("Timed out waiting for core to halt")
 
             # release MDM halt once it has taken effect in the DHCSR
             self.mdm_ap.write_reg(MDM_CTRL, 0)
 
             # sanity check that the target is still halted
             if self.getState() == Target.TARGET_RUNNING:
-                raise Exception("Target failed to stay halted during init sequence")
+                raise RuntimeError("Target failed to stay halted during init sequence")
 
     def isLocked(self):
+        self._wait_for_flash_init()
+        
         val = self.mdm_ap.read_reg(MDM_STATUS)
-        if val & MDM_STATUS_SYSTEM_SECURITY:
-            return True
-        else:
-            return False
+        return (val & MDM_STATUS_SYSTEM_SECURITY) != 0
 
-    ## @brief Perform a mass erase operation.
-    # @note Reset should be held for the duration of this function
-    # @return True Mass erase succeeded.
-    # @return False Mass erase failed or is disabled.
-    def massErase(self):
+    def _wait_for_flash_init(self):
         # Wait until flash is inited.
         with Timeout(MASS_ERASE_TIMEOUT) as to:
             while to.check():
@@ -151,14 +210,37 @@ class Kinetis(CoreSightTarget):
                 if status & MDM_STATUS_FLASH_READY:
                     break
                 sleep(0.01)
-        if to.did_time_out:
-            logging.error("Mass erase timeout waiting for flash to finish init")
+        return not to.did_time_out
+
+    ## @brief Perform a mass erase operation.
+    # @note Reset is held for the duration of this function.
+    # @return True Mass erase succeeded.
+    # @return False Mass erase failed or is disabled.
+    def massErase(self):
+        # Read current reset state so we can restore it, then assert reset if needed.
+        wasResetAsserted = self.dp.is_reset_asserted()
+        if not wasResetAsserted:
+            self.dp.assert_reset(True)
+            
+        # Perform the erase.
+        result = self._mass_erase()
+
+        # Restore previous reset state.
+        if not wasResetAsserted:
+            self.dp.assert_reset(False)
+        return result
+
+    ## @brief Private mass erase routine.
+    def _mass_erase(self):
+        # Flash must finish initing before we can mass erase.
+        if not self._wait_for_flash_init():
+            log.error("Mass erase timeout waiting for flash to finish init")
             return False
 
         # Check if mass erase is enabled.
         status = self.mdm_ap.read_reg(MDM_STATUS)
         if not (status & MDM_STATUS_MASS_ERASE_ENABLE):
-            logging.error("Mass erase disabled. MDM status: 0x%x", status)
+            log.error("Mass erase disabled. MDM status: 0x%x", status)
             return False
 
         # Set Flash Mass Erase in Progress bit to start erase.
@@ -170,28 +252,28 @@ class Kinetis(CoreSightTarget):
                 val = self.mdm_ap.read_reg(MDM_STATUS)
                 if val & MDM_STATUS_FLASH_MASS_ERASE_ACKNOWLEDGE:
                     break
-                sleep(0.01)
-        if to.did_time_out:
-            logging.error("Mass erase timeout waiting for Flash Mass Erase Ack to set")
-            return False
+                sleep(0.1)
+            else: #if to.did_time_out:
+                log.error("Mass erase timeout waiting for Flash Mass Erase Ack to set")
+                return False
 
         # Wait for Flash Mass Erase in Progress bit to clear when erase is completed.
         with Timeout(MASS_ERASE_TIMEOUT) as to:
             while to.check():
                 val = self.mdm_ap.read_reg(MDM_CTRL)
-                if (val == 0):
+                if ((val & MDM_CTRL_FLASH_MASS_ERASE_IN_PROGRESS) == 0):
                     break
-                sleep(0.01)
-        if to.did_time_out:
-            logging.error("Mass erase timeout waiting for Flash Mass Erase in Progress to clear")
-            return False
+                sleep(0.1)
+            else: #if to.did_time_out:
+                log.error("Mass erase timeout waiting for Flash Mass Erase in Progress to clear")
+                return False
 
         # Confirm the part was unlocked
         val = self.mdm_ap.read_reg(MDM_STATUS)
         if (val & MDM_STATUS_SYSTEM_SECURITY) == 0:
-            logging.warning("%s secure state: unlocked successfully", self.part_number)
+            log.warning("%s secure state: unlocked successfully", self.part_number)
             return True
         else:
-            logging.error("Failed to unlock. MDM status: 0x%x", val)
+            log.error("Failed to unlock. MDM status: 0x%x", val)
             return False
 

--- a/pyOCD/target/family/target_kinetis.py
+++ b/pyOCD/target/family/target_kinetis.py
@@ -19,7 +19,7 @@ from ...coresight import (dap, ap)
 from ...coresight.cortex_m import CortexM
 from ...core.target import Target
 from ...core.coresight_target import CoreSightTarget
-from ...utility.timeout import (Timeout, TimeoutException)
+from ...utility.timeout import Timeout
 import logging
 from time import sleep
 

--- a/pyOCD/target/target_K32W042S1M2xxx.py
+++ b/pyOCD/target/target_K32W042S1M2xxx.py
@@ -177,7 +177,6 @@ class K32W042S(Kinetis):
 
     def __init__(self, link):
         super(K32W042S, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0040
 
         svdPath = os.path.join(os.path.dirname(__file__), "K32W042S1M2_M4.xml")
         if os.path.exists(svdPath):

--- a/pyOCD/target/target_MK20DX128xxx5.py
+++ b/pyOCD/target/target_MK20DX128xxx5.py
@@ -88,6 +88,5 @@ class K20D50M(Kinetis):
 
     def __init__(self, link):
         super(K20D50M, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0000
         self._svd_location = SVDFile(vendor="Freescale", filename="MK20D5.svd", is_local=False)
 

--- a/pyOCD/target/target_MK22FN1M0Axxx12.py
+++ b/pyOCD/target/target_MK22FN1M0Axxx12.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013 ARM Limited
+ Copyright (c) 2006-2018 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import logging
 SIM_FCFG1 = 0x4004804C
 SIM_FCFG2 = 0x40048050
 SIM_FCFG2_PFLSH = (1 << 23)
+
+log = logging.getLogger("target.k22fa12")
 
 flash_algo = {
     'load_address' : 0x20000000,
@@ -119,6 +121,9 @@ class K22FA12(Kinetis):
         # If the device has FlexNVM, then it has half-sized program flash.
         fcfg2 = self.dp.aps[0].read32(SIM_FCFG2)
         if (fcfg2 & SIM_FCFG2_PFLSH) == 0:
+            log.debug("%s: device has FlexNVM", self.part_number)
             rgn = self.memory_map.getRegionForAddress(0)
             rgn._end = 0x7ffff
+        else:
+            log.debug("%s: device does not have FlexNVM", self.part_number)
 

--- a/pyOCD/target/target_MK22FN1M0Axxx12.py
+++ b/pyOCD/target/target_MK22FN1M0Axxx12.py
@@ -104,7 +104,6 @@ class K22FA12(Kinetis):
 
     def __init__(self, link):
         super(K22FA12, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0000
         self._svd_location = SVDFile(vendor="Freescale", filename="MK22FA12.svd", is_local=False)
 
     def create_init_sequence(self):

--- a/pyOCD/target/target_MK22FN512xxx12.py
+++ b/pyOCD/target/target_MK22FN512xxx12.py
@@ -90,6 +90,5 @@ class K22F(Kinetis):
 
     def __init__(self, link):
         super(K22F, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0000
         self._svd_location = SVDFile(vendor="Freescale", filename="MK22F51212.svd", is_local=False)
 

--- a/pyOCD/target/target_MK28FN2M0xxx15.py
+++ b/pyOCD/target/target_MK28FN2M0xxx15.py
@@ -91,6 +91,5 @@ class K28F15(Kinetis):
 
     def __init__(self, transport):
         super(K28F15, self).__init__(transport, self.memoryMap)
-        self.mdm_idr = 0x001c0000
         self._svd_location = SVDFile(vendor="Freescale", filename="MK28F15.svd")
 

--- a/pyOCD/target/target_MK64FN1M0xxx12.py
+++ b/pyOCD/target/target_MK64FN1M0xxx12.py
@@ -88,6 +88,5 @@ class K64F(Kinetis):
 
     def __init__(self, link):
         super(K64F, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0000
         self._svd_location = SVDFile(vendor="Freescale", filename="MK64F12.svd", is_local=False)
 

--- a/pyOCD/target/target_MK66FN2M0xxx18.py
+++ b/pyOCD/target/target_MK66FN2M0xxx18.py
@@ -90,6 +90,5 @@ class K66F18(Kinetis):
 
     def __init__(self, transport):
         super(K66F18, self).__init__(transport, self.memoryMap)
-        self.mdm_idr = 0x001c0000
         self._svd_location = SVDFile(vendor="Freescale", filename="MK66F18.svd")
 

--- a/pyOCD/target/target_MK82FN256xxx15.py
+++ b/pyOCD/target/target_MK82FN256xxx15.py
@@ -96,6 +96,5 @@ class K82F25615(Kinetis):
         )
     def __init__(self, transport):
         super(K82F25615, self).__init__(transport, self.memoryMap)
-        self.mdm_idr = 0x001c0000
         self._svd_location = SVDFile(vendor="Freescale", filename="MK82F25615.svd")
 

--- a/pyOCD/target/target_MKE15Z256xxx7.py
+++ b/pyOCD/target/target_MKE15Z256xxx7.py
@@ -97,7 +97,6 @@ class KE15Z7(Kinetis):
 
     def __init__(self, link):
         super(KE15Z7, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKE15Z7.svd")
 
     def create_init_sequence(self):

--- a/pyOCD/target/target_MKE18F256xxx16.py
+++ b/pyOCD/target/target_MKE18F256xxx16.py
@@ -98,7 +98,6 @@ class KE18F16(Kinetis):
 
     def __init__(self, link):
         super(KE18F16, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0000
         self._svd_location = SVDFile(vendor="Freescale", filename="MKE18F16.svd")
 
     def create_init_sequence(self):

--- a/pyOCD/target/target_MKL02Z32xxx4.py
+++ b/pyOCD/target/target_MKL02Z32xxx4.py
@@ -100,6 +100,5 @@ class KL02Z(Kinetis):
 
     def __init__(self, link):
         super(KL02Z, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKL02Z4.svd", is_local=False)
 

--- a/pyOCD/target/target_MKL05Z32xxx4.py
+++ b/pyOCD/target/target_MKL05Z32xxx4.py
@@ -100,6 +100,5 @@ class KL05Z(Kinetis):
 
     def __init__(self, link):
         super(KL05Z, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKL05Z4.svd", is_local=False)
 

--- a/pyOCD/target/target_MKL25Z128xxx4.py
+++ b/pyOCD/target/target_MKL25Z128xxx4.py
@@ -102,6 +102,5 @@ class KL25Z(Kinetis):
 
     def __init__(self, link):
         super(KL25Z, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKL25Z4.svd", is_local=False)
 

--- a/pyOCD/target/target_MKL26Z256xxx4.py
+++ b/pyOCD/target/target_MKL26Z256xxx4.py
@@ -102,6 +102,5 @@ class KL26Z(Kinetis):
 
     def __init__(self, link):
         super(KL26Z, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKL26Z4.svd", is_local=False)
 

--- a/pyOCD/target/target_MKL27Z256xxx4.py
+++ b/pyOCD/target/target_MKL27Z256xxx4.py
@@ -104,6 +104,5 @@ class KL27Z4(Kinetis):
 
     def __init__(self, transport):
         super(KL27Z4, self).__init__(transport, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKL27Z644.svd")
 

--- a/pyOCD/target/target_MKL28Z512xxx7.py
+++ b/pyOCD/target/target_MKL28Z512xxx7.py
@@ -168,7 +168,6 @@ class KL28x(Kinetis):
 
     def __init__(self, link):
         super(KL28x, self).__init__(link, self.singleMap)
-        self.mdm_idr = 0x001c0020
         self.is_dual_core = False
 
         self._svd_location = SVDFile(vendor="Freescale", filename="MKL28T7_CORE0.svd", is_local=False)

--- a/pyOCD/target/target_MKL43Z256xxx4.py
+++ b/pyOCD/target/target_MKL43Z256xxx4.py
@@ -105,6 +105,5 @@ class KL43Z4(Kinetis):
 
     def __init__(self, transport):
         super(KL43Z4, self).__init__(transport, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKL43Z4.svd")
 

--- a/pyOCD/target/target_MKL46Z256xxx4.py
+++ b/pyOCD/target/target_MKL46Z256xxx4.py
@@ -102,6 +102,5 @@ class KL46Z(Kinetis):
 
     def __init__(self, link):
         super(KL46Z, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKL46Z4.svd", is_local=False)
 

--- a/pyOCD/target/target_MKL82Z128xxx7.py
+++ b/pyOCD/target/target_MKL82Z128xxx7.py
@@ -100,7 +100,6 @@ class KL82Z7(Kinetis):
 
     def __init__(self, link):
         super(KL82Z7, self).__init__(link, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKL82Z7.svd", is_local=False)
 
 

--- a/pyOCD/target/target_MKV10Z128xxx7.py
+++ b/pyOCD/target/target_MKV10Z128xxx7.py
@@ -106,6 +106,5 @@ class KV10Z7(Kinetis):
 
     def __init__(self, transport):
         super(KV10Z7, self).__init__(transport, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKV10Z7.svd")
 

--- a/pyOCD/target/target_MKV11Z128xxx7.py
+++ b/pyOCD/target/target_MKV11Z128xxx7.py
@@ -107,6 +107,5 @@ class KV11Z7(Kinetis):
 
     def __init__(self, transport):
         super(KV11Z7, self).__init__(transport, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKV11Z7.svd")
 

--- a/pyOCD/target/target_MKW01Z128xxx4.py
+++ b/pyOCD/target/target_MKW01Z128xxx4.py
@@ -105,6 +105,5 @@ class KW01Z4(Kinetis):
 
     def __init__(self, transport):
         super(KW01Z4, self).__init__(transport, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKW01Z4.svd")
 

--- a/pyOCD/target/target_MKW24D512xxx5.py
+++ b/pyOCD/target/target_MKW24D512xxx5.py
@@ -96,6 +96,5 @@ class KW24D5(Kinetis):
 
     def __init__(self, transport):
         super(KW24D5, self).__init__(transport, self.memoryMap)
-        self.mdm_idr = 0x001c0000
         self._svd_location = SVDFile(vendor="Freescale", filename="MKW24D5.svd")
 

--- a/pyOCD/target/target_MKW40Z160xxx4.py
+++ b/pyOCD/target/target_MKW40Z160xxx4.py
@@ -106,6 +106,5 @@ class KW40Z4(Kinetis):
 
     def __init__(self, transport):
         super(KW40Z4, self).__init__(transport, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKW40Z4.svd")
 

--- a/pyOCD/target/target_MKW41Z512xxx4.py
+++ b/pyOCD/target/target_MKW41Z512xxx4.py
@@ -94,6 +94,5 @@ class KW41Z4(Kinetis):
 
     def __init__(self, transport):
         super(KW41Z4, self).__init__(transport, self.memoryMap)
-        self.mdm_idr = 0x001c0020
         self._svd_location = SVDFile(vendor="Freescale", filename="MKW41Z4.svd")
 

--- a/pyOCD/test/test_timeout.py
+++ b/pyOCD/test/test_timeout.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2017 ARM Limited
+ Copyright (c) 2017-2018 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,28 +15,53 @@
  limitations under the License.
 """
 
-from pyOCD.utility.timeout import (Timeout, TimeoutException)
+from pyOCD.utility.timeout import Timeout
 from time import (time, sleep)
 import pytest
 
 class TestTimeout:
     def test_no_timeout(self):
-        with Timeout(0.5) as to:
+        with Timeout(0.05) as to:
+            cnt = 0
             while to.check():
-                sleep(0.4)
-                break
+                sleep(0.01)
+                cnt += 1
+                if cnt == 4:
+                    break
+            else:
+                assert False
         assert not to.did_time_out
 
     def test_timeout_a(self):
         s = time()
-        with Timeout(0.5) as to:
+        with Timeout(0.05) as to:
             while to.check():
-                sleep(0.1)
+                sleep(0.01)
         assert to.did_time_out
-        assert (time() - s) >= 0.5
-
-    def test_pass_exception(self):
-        with pytest.raises(RuntimeError):
-            with Timeout(0.5) as to:
-                raise RuntimeError()
+        assert (time() - s) >= 0.05
+    
+    def test_timeout_b(self):
+        timedout = False
+        s = time()
+        with Timeout(0.05) as to:
+            cnt = 0
+            while cnt < 10:
+                if to.did_time_out:
+                    timedout = True
+                sleep(0.02)
+                cnt += 1
+        assert timedout
+        assert to.did_time_out
+        assert (time() - s) >= 0.05
+    
+    def test_timeout_c(self):
+        timedout = False
+        with Timeout(0.05) as to:
+            cnt = 0
+            while cnt < 10:
+                if to.did_time_out:
+                    timedout = True
+                cnt += 1
+        assert not timedout
+        assert not to.did_time_out
 

--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -295,6 +295,10 @@ INFO_HELP = {
             'aliases' : ['si'],
             'help' : "Display whether interrupts are enabled when single stepping."
             },
+        'nreset' : {
+            'aliases' : [],
+            'help' : "Current nRESET signal state.",
+            },
         }
 
 OPTION_HELP = {
@@ -521,6 +525,7 @@ class PyOCDTool(object):
                 'vc' :                  self.handle_show_vectorcatch,
                 'step-into-interrupt' : self.handle_show_step_interrupts,
                 'si' :                  self.handle_show_step_interrupts,
+                'nreset' :              self.handle_show_nreset,
             }
         self.option_list = {
                 'vector-catch' :        self.handle_set_vectorcatch,
@@ -1105,7 +1110,7 @@ class PyOCDTool(object):
             return
         exists = coresight.ap.AccessPort.probe(self.target.dp, apsel)
         if not exists:
-            print("Error: no AP with APSEL={}} exists".format(apsel))
+            print("Error: no AP with APSEL={} exists".format(apsel))
             return
         ap = coresight.ap.AccessPort.create(self.target.dp, apsel)
         self.target.dp.aps[apsel] = ap
@@ -1222,6 +1227,10 @@ class PyOCDTool(object):
         print_fields('UFSR', ufsr, UFSR_fields, showAll)
         print_fields('HFSR', hfsr, HFSR_fields, showAll)
         print_fields('DFSR', dfsr, DFSR_fields, showAll)
+
+    def handle_show_nreset(self, args):
+        rst = int(not self.target.link.is_reset_asserted())
+        print("nRESET = {}".format(rst))
 
     def handle_set(self, args):
         if len(args) < 1:


### PR DESCRIPTION
This PR is primarily intended to fix an issue where a Kinetis device could incorrectly be determined to be locked. This would happen most often on certain individual devices where the flash controller takes longer than average to finish initialisation, most likely due to process differences. (The flash controller must complete its init before the security state flash in the MDM-AP is cleared.) However, there is the possibility that it would happen on any device if timing was just right.

In addition, there are a handful of related changes:
- `DebugPort` and the lower-level `DAPAccessAPI` and `DAPAccessCMSISDAP` classes get an `is_reset_asserted()` method that returns the current status of the nRESET signal.
- New `show nreset` command for pyocd-tool.
- Improved `Timeout` utility class usage, taking advantage of **else** clauses on **while** loops.
- Kinetis targets don't need to declare the expected MDM-AP IDR values anymore. The `Kinetis` family class accepts any version of MDM-AP.