### PR TITLE
Update README example to be compatible with both 2.7 & 3.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,24 +188,24 @@ Hello World example code
     target.resume()
     target.halt()
 
-    print "pc: 0x%X" % target.readCoreRegister("pc")
+    print("pc: 0x%X" % target.readCoreRegister("pc"))
     #    pc: 0xA64
 
     target.step()
-    print "pc: 0x%X" % target.readCoreRegister("pc")
+    print("pc: 0x%X" % target.readCoreRegister("pc"))
     #    pc: 0xA30
 
     target.step()
-    print "pc: 0x%X" % target.readCoreRegister("pc")
+    print("pc: 0x%X" % target.readCoreRegister("pc"))
     #   pc: 0xA32
 
     flash.flashBinary("binaries/l1_lpc1768.bin")
-    print "pc: 0x%X" % target.readCoreRegister("pc")
+    print("pc: 0x%X" % target.readCoreRegister("pc"))
     #   pc: 0x10000000
 
     target.reset()
     target.halt()
-    print "pc: 0x%X" % target.readCoreRegister("pc")
+    print("pc: 0x%X" % target.readCoreRegister("pc"))
     #   pc: 0xAAC
 
     board.uninit()


### PR DESCRIPTION
Since #374 has landed, Python 3 is supported. This PR wraps all `print` calls with `( )` so that is it compatible with **both** Python 2.7 & Python 3. This should be one less thing for new users that are using Python 3 to trip on.

Note this is different than `__future__.print_function` which makes Python 2.7 actually use the real `print` function. That isn't needed here for these simple examples where wrapping in `( )` simply works in both in the simple case you are printing a single string.