### PR TITLE
Add specific Python versions supported to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,10 @@ setup(
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
     ],
     extras_require={
         'dissassembler': ['capstone']


### PR DESCRIPTION
This explicitly lists support for which version of Python the package supports. This helps new users when browsing PyPI know if their Python version supports the package.

I only added 2.7 and 3.6 due to those being the only ones tested in `.travis.yml`. If support for Python 3.4, 3.5, or 3.7 is also considered supported, `.travis.yml` could be updated to add those and they could be called out in `setup.py` as well.