### PR TITLE
Fix TypeError in gdbserver checksum calculation.

### DIFF
--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -47,7 +47,7 @@ LOG_ACK = False # Log ack or nak.
 LOG_PACKETS = False # Log all packets sent and received.
 
 def checksum(data):
-    return b"%02x" % (sum(six.iterbytes(data)) % 256)
+    return ("%02x" % (sum(six.iterbytes(data)) % 256)).encode()
 
 ## @brief De-escapes binary data from Gdb.
 #
@@ -716,7 +716,7 @@ class GDBServer(threading.Thread):
                     pass
                 traceback.print_exc()
                 self.log.debug('Target is unavailable temporarily.')
-                val = b'S%02x' % self.target_facade.getSignalValue()
+                val = ('S%02x' % self.target_facade.getSignalValue()).encode()
                 break
 
         return self.createRSPPacket(val)
@@ -1013,7 +1013,7 @@ class GDBServer(threading.Thread):
                 return self.createRSPPacket(b"QC1")
             else:
                 self.validateDebugContext()
-                return self.createRSPPacket(b"QC%x" % self.current_thread_id)
+                return self.createRSPPacket(("QC%x" % self.current_thread_id).encode())
 
         elif query[0].find(b'Attached') != -1:
             return self.createRSPPacket(b"1")
@@ -1130,7 +1130,7 @@ class GDBServer(threading.Thread):
             for cmd_sub in cmdList:
                 if cmd_sub not in safecmd:
                     self.log.warning("Invalid mon command '%s'", cmd_sub)
-                    resp = b'Invalid Command: "%s"\n' % cmd_sub
+                    resp = ('Invalid Command: "%s"\n' % cmd_sub).encode()
                     resp = hexEncode(resp)
                     return self.createRSPPacket(resp)
                 elif resultMask == 0x80:
@@ -1265,9 +1265,9 @@ class GDBServer(threading.Thread):
             response += b"thread:1;core:0;"
         else:
             if self.current_thread_id in (-1, 0, 1):
-                response += b"thread:%x;core:0;" % self.thread_provider.current_thread.unique_id
+                response += ("thread:%x;core:0;" % self.thread_provider.current_thread.unique_id).encode()
             else:
-                response += b"thread:%x;core:0;" % self.current_thread_id
+                response += ("thread:%x;core:0;" % self.current_thread_id).encode()
         self.log.debug("Tresponse=%s", response)
         return response
 


### PR DESCRIPTION
This commit fixes the following issue seen when debugging Zephyr RTOS binaries (Python 3.4.8, CentOS 7.4):

0000234:INFO:cmsis_dap_core:DAP SWD MODE initialized
0000331:INFO:rom_table:ROM table #0 @ 0xe00ff000 cidr=b105100d pidr=2005c4006
0000346:INFO:rom_table:[0]<e000e000:SCS-M4 cidr=b105e00d, pidr=4000bb00c, class=14>
0000354:INFO:rom_table:[1]<e0001000:DWT cidr=b105e00d, pidr=4003bb002, class=14>
0000362:INFO:rom_table:[2]<e0002000:FPB cidr=b105e00d, pidr=4002bb003, class=14>
0000370:INFO:rom_table:[3]<e0000000:ITM cidr=b105e00d, pidr=4003bb001, class=14>
0000389:INFO:rom_table:[4]<e0040000:TPIU-M4 cidr=b105900d, pidr=4000bb9a1, class=9, devtype=11, devid=ca1>
0000403:INFO:rom_table:[5]<e0041000:ETM-M4 cidr=b105900d, pidr=4000bb925, class=9, devtype=13, devid=0>
0000418:INFO:cortex_m:CPU core is Cortex-M4
0000433:INFO:cortex_m:FPU present
0000442:INFO:fpb:6 hardware breakpoints, 4 literal comparators
0000458:INFO:dwt:4 hardware watchpoints
0000474:INFO:semihost:Telnet: server started on port 4444
0000475:INFO:gdbserver:GDB server started at port:3333
Remote debugging using :3333
0001435:INFO:gdbserver:One client connected!
Exception in thread gdb-packet-thread:
Traceback (most recent call last):
  File "/usr/lib64/python3.4/threading.py", line 911, in _bootstrap_inner
    self.run()
  File "/home/brix/.local/lib/python3.4/site-packages/pyOCD/gdbserver/gdbserver.py", line 172, in run
    self._process_data()
  File "/home/brix/.local/lib/python3.4/site-packages/pyOCD/gdbserver/gdbserver.py", line 229, in _process_data
    self._handling_incoming_packet(pkt)
  File "/home/brix/.local/lib/python3.4/site-packages/pyOCD/gdbserver/gdbserver.py", line 239, in _handling_incoming_packet
    computedCksum = checksum(data)
  File "/home/brix/.local/lib/python3.4/site-packages/pyOCD/gdbserver/gdbserver.py", line 50, in checksum
    return b"%02x" % (sum(six.iterbytes(data)) % 256)
TypeError: unsupported operand type(s) for %: 'bytes' and 'int'


