### PR TITLE
ELF file support

### DIFF
--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -20,6 +20,7 @@ from ..coresight import (dap, cortex_m, rom_table)
 from ..debug.svd import (SVDFile, SVDLoader)
 from ..debug.context import DebugContext
 from ..debug.cache import CachingDebugContext
+from ..debug.elf.elf import ELFBinaryFile
 from ..utility.notification import Notification
 from ..utility.sequencer import CallSequence
 import logging
@@ -47,10 +48,23 @@ class CoreSightTarget(Target):
         self._svd_load_thread = None
         self._root_contexts = {}
         self._new_core_num = 0
+        self._elf = None
 
     @property
     def selected_core(self):
         return self.cores[self._selected_core]
+
+    @property
+    def elf(self):
+        return self._elf
+
+    @elf.setter
+    def elf(self, filename):
+        if filename is None:
+            self._elf = None
+        else:
+            self._elf = ELFBinaryFile(filename, self.cores[0])
+            self.cores[0].elf = self._elf
 
     def select_core(self, num):
         if num not in self.cores:

--- a/pyOCD/core/coresight_target.py
+++ b/pyOCD/core/coresight_target.py
@@ -21,6 +21,7 @@ from ..debug.svd import (SVDFile, SVDLoader)
 from ..debug.context import DebugContext
 from ..debug.cache import CachingDebugContext
 from ..debug.elf.elf import ELFBinaryFile
+from ..debug.elf.flash_reader import FlashReaderContext
 from ..utility.notification import Notification
 from ..utility.sequencer import CallSequence
 import logging
@@ -63,8 +64,9 @@ class CoreSightTarget(Target):
         if filename is None:
             self._elf = None
         else:
-            self._elf = ELFBinaryFile(filename, self.cores[0])
+            self._elf = ELFBinaryFile(filename, self.memory_map)
             self.cores[0].elf = self._elf
+            self.cores[0].setTargetContext(FlashReaderContext(self.cores[0].getTargetContext(), self._elf))
 
     def select_core(self, num):
         if num not in self.cores:

--- a/pyOCD/coresight/cortex_m.py
+++ b/pyOCD/coresight/cortex_m.py
@@ -314,6 +314,7 @@ class CortexM(Target, CoreSightComponent):
         self.core_number = core_num
         self._run_token = 0
         self._target_context = None
+        self._elf = None
 
         # Set up breakpoints manager.
         self.sw_bp = SoftwareBreakpointProvider(self)
@@ -327,6 +328,14 @@ class CortexM(Target, CoreSightComponent):
             self.bp_manager.add_provider(cmp, Target.BREAKPOINT_HW)
         elif isinstance(cmp, DWT):
             self.dwt = cmp
+
+    @property
+    def elf(self):
+        return self._elf
+
+    @elf.setter
+    def elf(self, elffile):
+        self._elf = elffile
 
     def init(self):
         """

--- a/pyOCD/debug/elf/__init__.py
+++ b/pyOCD/debug/elf/__init__.py
@@ -1,0 +1,17 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2017 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+

--- a/pyOCD/debug/elf/decoder.py
+++ b/pyOCD/debug/elf/decoder.py
@@ -1,0 +1,229 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2017 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import sys
+import os
+from elftools.elf.elffile import ELFFile
+from elftools.dwarf.constants import DW_LNE_set_address
+from intervaltree import IntervalTree
+from collections import namedtuple
+from itertools import islice
+import logging
+
+FunctionInfo = namedtuple('FunctionInfo', 'name subprogram low_pc high_pc')
+LineInfo = namedtuple('LineInfo', 'cu filename dirname line')
+SymbolInfo = namedtuple('SymbolInfo', 'name address size type')
+
+class ElfSymbolDecoder(object):
+    def __init__(self, elf):
+        assert isinstance(elf, ELFFile)
+        self.elffile = elf
+
+        self.symtab = self.elffile.get_section_by_name('.symtab')
+        self.symcount = self.symtab.num_symbols()
+        self.symbol_dict = {}
+        self.symbol_tree = None
+
+        # Build indices.
+        self._build_symbol_search_tree()
+        self._process_arm_type_symbols()
+
+    def get_elf(self):
+        return self.elffile
+
+    def get_symbol_for_address(self, addr):
+        try:
+            return sorted(self.symbol_tree[addr])[0].data
+        except IndexError:
+            return None
+    
+    def get_symbol_for_name(self, name):
+        try:
+            return self.symbol_dict[name]
+        except KeyError:
+            return None
+
+    def _build_symbol_search_tree(self):
+        self.symbol_tree = IntervalTree()
+        symbols = self.symtab.iter_symbols()
+        for symbol in symbols:
+            # Only look for functions and objects.
+            sym_type = symbol.entry['st_info']['type']
+            if sym_type not in ['STT_FUNC', 'STT_OBJECT']:
+                continue
+
+            sym_value = symbol.entry['st_value']
+            sym_size = symbol.entry['st_size']
+
+            # Cannot put an empty interval into the tree, so ensure symbols have
+            # at least a size of 1.
+            real_sym_size = sym_size
+            if sym_size == 0:
+                sym_size = 1
+
+            syminfo = SymbolInfo(name=symbol.name, address=sym_value, size=real_sym_size, type=sym_type)
+
+            # Add to symbol dict.
+            self.symbol_dict[symbol.name] = syminfo
+            
+            # Add to symbol tree.
+            self.symbol_tree.addi(sym_value, sym_value+sym_size, syminfo)
+
+    def _process_arm_type_symbols(self):
+        type_symbols = self._get_arm_type_symbol_iter()
+#         map(print, imap(lambda x:"%s : 0x%x" % (x.name, x['st_value']), type_symbols))
+
+    def _get_arm_type_symbol_iter(self):
+        # Scan until we find $m symbol.
+        i = 1
+        while i < self.symcount:
+            symbol = self.symtab.get_symbol(i)
+            if symbol.name == '$m':
+                break
+            i += 1
+        if i >= self.symcount:
+            return
+        n = symbol['st_value']
+        return islice(self.symtab.iter_symbols(), i, n)
+
+
+class DwarfAddressDecoder(object):
+    def __init__(self, elf):
+        assert isinstance(elf, ELFFile)
+        self.elffile = elf
+
+        if not self.elffile.has_dwarf_info():
+            raise Exception("No DWARF debug info available")
+
+        self.dwarfinfo = self.elffile.get_dwarf_info()
+
+        self.subprograms = None
+        self.function_tree = None
+        self.line_tree = None
+
+        # Build indices.
+        self._get_subprograms()
+        self._build_function_search_tree()
+        self._build_line_search_tree()
+
+    def get_function_for_address(self, addr):
+        try:
+            return sorted(self.function_tree[addr])[0].data
+        except IndexError:
+            return None
+
+    def get_line_for_address(self, addr):
+        try:
+            return sorted(self.line_tree[addr])[0].data
+        except IndexError:
+            return None
+
+    def _get_subprograms(self):
+        self.subprograms = []
+        for CU in self.dwarfinfo.iter_CUs():
+            self.subprograms.extend([d for d in CU.iter_DIEs() if d.tag == 'DW_TAG_subprogram'])
+
+    def _build_function_search_tree(self):
+        self.function_tree = IntervalTree()
+        for prog in self.subprograms:
+            try:
+                name = prog.attributes['DW_AT_name'].value
+                low_pc = prog.attributes['DW_AT_low_pc'].value
+                high_pc = prog.attributes['DW_AT_high_pc'].value
+
+                # Skip subprograms excluded from the link.
+                if low_pc == 0:
+                    continue
+
+                # If high_pc is not explicitly an address, then it's an offset from the
+                # low_pc value.
+                if prog.attributes['DW_AT_high_pc'].form != 'DW_FORM_addr':
+                    high_pc = low_pc + high_pc
+
+                fninfo = FunctionInfo(name=name, subprogram=prog, low_pc=low_pc, high_pc=high_pc)
+
+                self.function_tree.addi(low_pc, high_pc, fninfo)
+            except KeyError:
+                pass
+
+    def _build_line_search_tree(self):
+        self.line_tree = IntervalTree()
+        for cu in self.dwarfinfo.iter_CUs():
+            lineprog = self.dwarfinfo.line_program_for_CU(cu)
+            prevstate = None
+            skipThisSequence = False
+            for entry in lineprog.get_entries():
+                # Look for a DW_LNE_set_address command with a 0 address. This indicates
+                # code that is not actually included in the link.
+                #
+                # TODO: find a better way to determine the code is really not present and
+                #       doesn't have a real address of 0
+                if entry.is_extended and entry.command == DW_LNE_set_address \
+                        and len(entry.args) == 1 and entry.args[0] == 0:
+                    skipThisSequence = True
+
+                # We're interested in those entries where a new state is assigned
+                if entry.state is None:
+                    continue
+
+                # Looking for a range of addresses in two consecutive states.
+                if prevstate and not skipThisSequence:
+                    fileinfo = lineprog['file_entry'][prevstate.file - 1]
+                    filename = fileinfo.name
+                    dirname = lineprog['include_directory'][fileinfo.dir_index - 1]
+                    info = LineInfo(cu=cu, filename=filename, dirname=dirname, line=prevstate.line)
+                    fromAddr = prevstate.address
+                    toAddr = entry.state.address
+                    try:
+                        if fromAddr != 0 and toAddr != 0:
+                            if fromAddr == toAddr:
+                                toAddr += 1
+                            self.line_tree.addi(fromAddr, toAddr, info)
+                    except:
+                        logging.debug("Problematic lineprog:")
+                        self._dump_lineprog(lineprog)
+                        raise
+
+                if entry.state.end_sequence:
+                    prevstate = None
+                    skipThisSequence = False
+                else:
+                    prevstate = entry.state
+
+    def _dump_lineprog(self, lineprog):
+        for i, e in enumerate(lineprog.get_entries()):
+            s = e.state
+            if s is None:
+                logging.debug("%d: cmd=%d ext=%d args=%s", i, e.command, int(e.is_extended), repr(e.args))
+            else:
+                logging.debug("%d: %06x %4d stmt=%1d block=%1d end=%d file=[%d]%s", i, s.address, s.line, s.is_stmt, int(s.basic_block), int(s.end_sequence), s.file, lineprog['file_entry'][s.file-1].name)
+
+    def dump_subprograms(self):
+        for prog in self.subprograms:
+            name = prog.attributes['DW_AT_name'].value
+            try:
+                low_pc = prog.attributes['DW_AT_low_pc'].value
+            except KeyError:
+                low_pc = 0
+            try:
+                high_pc = prog.attributes['DW_AT_high_pc'].value
+            except KeyError:
+                high_pc = 0xffffffff
+            filename = os.path.basename(prog._parent.attributes['DW_AT_name'].value.replace('\\', '/'))
+            logging.debug("%s%s%08x %08x %s", name, (' ' * (50-len(name))), low_pc, high_pc, filename)
+
+

--- a/pyOCD/debug/elf/elf.py
+++ b/pyOCD/debug/elf/elf.py
@@ -1,0 +1,214 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2017 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+from __future__ import print_function
+from ...core.memory_map import (MemoryRange, MemoryMap)
+from .decoder import (ElfSymbolDecoder, DwarfAddressDecoder)
+from elftools.elf.elffile import ELFFile
+from elftools.elf.constants import SH_FLAGS
+import logging
+import six
+
+##
+# @brief Memory range for a section of an ELF file.
+#
+# Objects of this class represent sections of an ELF file. See the ELFBinaryFile class documentation
+# for details of how sections are selected and how to get instances of this class.
+#
+# If a region in the target's memory map can be found that contains the section, it will be
+# accessible via the instance's _region_ attribute. Otherwise _region_ will be `None`. A maximum of
+# one associated memory region is supported, even if the section spans multiple regions.
+#
+# The contents of the ELF section can be read via the `data` property as a `bytearray`. The data is
+# read from the file only once and cached.
+class ELFSection(MemoryRange):
+    def __init__(self, elf, sect):
+        self._elf = elf
+        self._section = sect
+        self._name = self._section.name
+        self._data = None
+
+        # Look up the corresponding memory region.
+        start = self._section['sh_addr']
+        length = self._section['sh_size']
+        regions = self._elf._memory_map.getIntersectingRegions(start=start, length=length)
+        region = regions[0] if len(regions) else None
+
+        super(ELFSection, self).__init__(start=start, length=length, region=region)
+
+    @property
+    def name(self):
+        return self._name
+        
+    @property
+    def type(self):
+        return self._section['sh_type']
+
+    @property
+    def flags(self):
+        return self._section['sh_flags']
+
+    @property
+    def data(self):
+        if self._data is None:
+            self._data = bytearray(self._section.data())
+        return self._data
+
+    @property
+    def flags_description(self):
+        flags = self.flags
+        flagsDesc = ""
+        if flags & SH_FLAGS.SHF_WRITE:
+            flagsDesc += "WRITE|"
+        if flags & SH_FLAGS.SHF_ALLOC:
+            flagsDesc += "ALLOC|"
+        if flags & SH_FLAGS.SHF_EXECINSTR:
+            flagsDesc += "EXECINSTR"
+        if flagsDesc[-1] == '|':
+            flagsDesc = flagsDesc[:-1]
+        return flagsDesc
+
+    def __repr__(self):
+        return "<ELFSection@0x{0:x} {1} {2} {3} {4} {5}>".format(
+            id(self), self.name, self.type, self.flags_description, hex(self.start), hex(self.length))
+
+##
+# @brief An ELF binary executable file.
+#
+# Examines the ELF and provides several lists of useful data: section objects, and both used
+# and unused ranges of memory.
+#
+# An ELFSection object is created for each of the sections of the file that are loadable code or
+# data, or otherwise occupy memory. These are normally the .text, .rodata, .data, and .bss
+# sections. More specifically, the list of sections contains any section with a type of
+# `SHT_PROGBITS` or `SHT_NOBITS`. Also, at least one of the `SHF_WRITE`, `SHF_ALLOC`, or
+# `SHF_EXECINSTR` flags must be set.
+#
+# The set of sections is compared with the target's memory map to produce a lists of the used
+# (occupied) and unused (unoccupied) ranges of memory. Note that if the executable uses ranges
+# of memory not mapped with a section of the ELF file, those ranges will not be considered in
+# the used/unused lists. Also, only ranges completely contained within a region of the memory
+# map are considered.
+class ELFBinaryFile(object):
+    def __init__(self, elf, memory_map):
+        if isinstance(elf, six.string_types):
+            self._file = open(elf, 'rb')
+            self._owns_file = True
+        else:
+            self._file = elf
+            self._owns_file = False
+        self._elf = ELFFile(self._file)
+        self._memory_map = memory_map or MemoryMap()
+
+        self._symbol_decoder = None
+        self._address_decoder = None
+
+        self._extract_sections()
+        self._compute_regions()
+
+    ## @brief Close the ELF file if it is owned by this instance.
+    def __del__(self):
+        if self._owns_file:
+            self.close()
+
+    def _extract_sections(self):
+        # Get list of interesting sections.
+        self._sections = []
+        sections = self._elf.iter_sections()
+        for s in sections:
+            # Skip sections not of these types.
+            if s['sh_type'] not in ('SHT_PROGBITS', 'SHT_NOBITS'):
+                continue
+
+            # Skip sections that don't have one of these flags set.
+            if s['sh_flags'] & (SH_FLAGS.SHF_WRITE | SH_FLAGS.SHF_ALLOC | SH_FLAGS.SHF_EXECINSTR) == 0:
+                continue
+
+            self._sections.append(ELFSection(self, s))
+        self._sections.sort(key=lambda x: x.start)
+
+    def _dump_sections(self):
+        for s in self._sections:
+            print("{0:<20} {1:<25} {2:<10} {3:<10}".format(
+                s.name, s.flags_description, hex(s.start), hex(s.length)))
+
+    def _compute_regions(self):
+        used = []
+        unused = []
+        for region in self._memory_map:
+            current = region.start
+            for sect in self._sections:
+                start = sect.start
+                length = sect.length
+
+                # Skip if this section isn't within this memory region.
+                if not region.containsRange(start, length=length):
+                    continue
+
+                # Add this section as used.
+                used.append(MemoryRange(start=start, length=length, region=region))
+
+                # Add unused segment.
+                if start > current:
+                    unused.append(MemoryRange(start=current, length=(start - current), region=region))
+
+                current = start + length
+
+            # Add a final unused segment of the region.
+            if region.end > current:
+                unused.append(MemoryRange(start=current, end=region.end, region=region))
+        self._used = used
+        self._unused = unused
+
+    def close(self):
+        self._file.close()
+        self._owns_file = False
+
+    ##
+    # @brief Access the list of sections in the ELF file.
+    # @return A list of ELFSection objects sorted by start address.
+    @property
+    def sections(self):
+        return self._sections
+
+    ##
+    # @brief Access the list of used ranges of memory in the ELF file.
+    # @return A list of MemoryRange objects sorted by start address.
+    @property
+    def used_ranges(self):
+        return self._used
+
+    ##
+    # @brief Access the list of unused ranges of memory in the ELF file.
+    # @return A list of MemoryRange objects sorted by start address.
+    @property
+    def unused_ranges(self):
+        return self._unused
+
+    @property
+    def symbol_decoder(self):
+        if self._symbol_decoder is None:
+            self._symbol_decoder = ElfSymbolDecoder(self._elf)
+        return self._symbol_decoder
+
+    @property
+    def address_decoder(self):
+        if self._address_decoder is None:
+            self._address_decoder = DwarfAddressDecoder(self._elf)
+        return self._address_decoder
+
+
+

--- a/pyOCD/debug/elf/flash_reader.py
+++ b/pyOCD/debug/elf/flash_reader.py
@@ -1,0 +1,90 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2016 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from ..context import DebugContext
+from ...utility import conversion
+import logging
+from intervaltree import (Interval, IntervalTree)
+
+## @brief Reads flash memory regions from an ELF file instead of the target.
+class FlashReaderContext(DebugContext):
+    def __init__(self, parentContext, elf):
+        super(FlashReaderContext, self).__init__(parentContext.core)
+        self._parent = parentContext
+        self._elf = elf
+        self._log = logging.getLogger('flashreadercontext')
+
+        self._build_regions()
+
+    def _build_regions(self):
+        self._tree = IntervalTree()
+        for sect in [s for s in self._elf.sections if (s.region and s.region.isFlash)]:
+            start = sect.start
+            length = sect.length
+            sect.data # Go ahead and read the data from the file.
+            self._tree.addi(start, start + length, sect)
+            self._log.debug("created flash section [%x:%x] for section %s", start, start + length, sect.name)
+
+    def readMemory(self, addr, transfer_size=32, now=True):
+        length = transfer_size // 8
+        matches = self._tree.search(addr, addr + length)
+        # Must match only one interval (ELF section).
+        if len(matches) != 1:
+            return self._parent.readMemory(addr, transfer_size, now)
+        section = matches.pop().data
+        addr -= section.start
+
+        def cb():
+            self._log.debug("read flash data [%x:%x] from section %s", section.start + addr, section.start + addr  + length, section.name)
+            data = section.data[addr:addr + length]
+            if transfer_size == 8:
+                return data[0]
+            elif transfer_size == 16:
+                return conversion.byteListToU16leList(data)[0]
+            elif transfer_size == 32:
+                return conversion.byteListToU32leList(data)[0]
+            else:
+                raise ValueError("invalid transfer_size (%d)" % transfer_size)
+
+        if now:
+            return cb()
+        else:
+            return cb
+
+    def readBlockMemoryUnaligned8(self, addr, size):
+        matches = self._tree.search(addr, addr + size)
+        # Must match only one interval (ELF section).
+        if len(matches) != 1:
+            return self._parent.readBlockMemoryUnaligned8(addr, size)
+        section = matches.pop().data
+        addr -= section.start
+        data = section.data[addr:addr + size]
+        self._log.debug("read flash data [%x:%x]", section.start + addr, section.start + addr  + size)
+        return list(data)
+
+    def readBlockMemoryAligned32(self, addr, size):
+        return conversion.byteListToU32leList(self.readBlockMemoryUnaligned8(addr, size))
+
+    def writeMemory(self, addr, value, transfer_size=32):
+        return self._parent.writeMemory(addr, value, transfer_size)
+
+    def writeBlockMemoryUnaligned8(self, addr, value):
+        return self._parent.writeBlockMemoryUnaligned8(addr, value)
+
+    def writeBlockMemoryAligned32(self, addr, data):
+        return self._parent.writeBlockMemoryAligned32(addr, data)
+

--- a/pyOCD/debug/elf/symbols.py
+++ b/pyOCD/debug/elf/symbols.py
@@ -1,0 +1,31 @@
+"""
+ mbed CMSIS-DAP debugger
+ Copyright (c) 2017 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from ..symbols import SymbolProvider
+
+## @brief Get symbol information from an ELF file.
+class ELFSymbolProvider(SymbolProvider):
+    def __init__(self, elf):
+        self._symbols = elf.symbol_decoder
+
+    def get_symbol_value(self, name):
+        sym = self._symbols.get_symbol_for_name(name)
+        if sym is not None:
+            return sym.address
+        else:
+            return None
+

--- a/pyOCD/flash/flash.py
+++ b/pyOCD/flash/flash.py
@@ -63,13 +63,21 @@ class PageInfo(object):
         self.erase_weight = None        # Time it takes to erase a page
         self.program_weight = None      # Time it takes to program a page (Not including data transfer time)
         self.size = None                # Size of page
-        self.crc_supported = None       # Is the function computeCrcs supported?
+
+    def __repr__(self):
+        return "<PageInfo@0x%x base=0x%x size=0x%x erswt=%g prgwt=%g>" \
+            % (id(self), self.base_addr, self.size, self.erase_weight, self.program_weight)
 
 class FlashInfo(object):
 
     def __init__(self):
         self.rom_start = None           # Starting address of ROM
         self.erase_weight = None        # Time it takes to perform a chip erase
+        self.crc_supported = None       # Is the function computeCrcs supported?
+
+    def __repr__(self):
+        return "<FlashInfo@0x%x start=0x%x erswt=%g crc=%s>" \
+            % (id(self), self.rom_start, self._erase_weight, self.crc_supported)
 
 class Flash(object):
     """
@@ -81,6 +89,8 @@ class Flash(object):
         self.flash_algo = flash_algo
         self.flash_algo_debug = False
         if flash_algo is not None:
+            self.is_valid = True
+            self.use_analyzer = flash_algo['analyzer_supported']
             self.end_flash_algo = flash_algo['load_address'] + len(flash_algo) * 4
             self.begin_stack = flash_algo['begin_stack']
             self.begin_data = flash_algo['begin_data']
@@ -96,21 +106,27 @@ class Flash(object):
             self.double_buffer_supported = len(self.page_buffers) > 1
 
         else:
+            self.is_valid = False
+            self.use_analyzer = False
             self.end_flash_algo = None
             self.begin_stack = None
             self.begin_data = None
             self.static_base = None
+            self.min_program_length = 0
+            self.page_buffers = []
+            self.double_buffer_supported = False
 
     @property
     def minimumProgramLength(self):
         return self.min_program_length
 
-    def init(self):
+    def init(self, reset=True):
         """
         Download the flash algorithm in RAM
         """
         self.target.halt()
-        self.target.setTargetState("PROGRAM")
+        if reset:
+            self.target.setTargetState("PROGRAM")
 
         # update core register to execute the init subroutine
         result = self.callFunctionAndWait(self.flash_algo['pc_init'], init=True)
@@ -118,6 +134,9 @@ class Flash(object):
         # check the return code
         if result != 0:
             logging.error('init error: %i', result)
+
+    def cleanup(self):
+        pass
 
     def computeCrcs(self, sectors):
         data = []
@@ -273,7 +292,7 @@ class Flash(object):
         info = FlashInfo()
         info.rom_start = boot_region.start if boot_region else 0
         info.erase_weight = DEFAULT_CHIP_ERASE_WEIGHT
-        info.crc_supported = self.flash_algo['analyzer_supported']
+        info.crc_supported = self.use_analyzer
         return info
 
     def getFlashBuilder(self):
@@ -315,7 +334,7 @@ class Flash(object):
         if init:
             # download flash algo in RAM
             self.target.writeBlockMemoryAligned32(self.flash_algo['load_address'], self.flash_algo['instructions'])
-            if self.flash_algo['analyzer_supported']:
+            if self.use_analyzer:
                 self.target.writeBlockMemoryAligned32(self.flash_algo['analyzer_address'], analyzer)
 
         reg_list.append('pc')
@@ -351,23 +370,28 @@ class Flash(object):
             pass
 
         if self.flash_algo_debug:
-            analyzer_supported = self.flash_algo['analyzer_supported']
+            regs = self.target.readCoreRegistersRaw(range(19) + [20])
+            logging.debug("Registers after flash algo: [%s]", " ".join("%08x" % r for r in regs))
 
             expected_fp = self.flash_algo['static_base']
             expected_sp = self.flash_algo['begin_stack']
             expected_pc = self.flash_algo['load_address']
             expected_flash_algo = self.flash_algo['instructions']
-            if analyzer_supported:
+            if self.use_analyzer:
                 expected_analyzer = analyzer
+            final_ipsr = self.target.readCoreRegister('xpsr') & 0xff
             final_fp = self.target.readCoreRegister('r9')
             final_sp = self.target.readCoreRegister('sp')
             final_pc = self.target.readCoreRegister('pc')
             #TODO - uncomment if Read/write and zero init sections can be moved into a separate flash algo section
             #final_flash_algo = self.target.readBlockMemoryAligned32(self.flash_algo['load_address'], len(self.flash_algo['instructions']))
-            #if analyzer_supported:
+            #if self.use_analyzer:
             #    final_analyzer = self.target.readBlockMemoryAligned32(self.flash_algo['analyzer_address'], len(analyzer))
 
             error = False
+            if final_ipsr != 0:
+                logging.error("IPSR should be 0 but is 0x%02x", final_ipsr)
+                error = True
             if final_fp != expected_fp:
                 # Frame pointer should not change
                 logging.error("Frame pointer should be 0x%x but is 0x%x" % (expected_fp, final_fp))
@@ -384,7 +408,7 @@ class Flash(object):
             #if not _same(expected_flash_algo, final_flash_algo):
             #    logging.error("Flash algorithm overwritten!")
             #    error = True
-            #if analyzer_supported and not _same(expected_analyzer, final_analyzer):
+            #if self.use_analyzer and not _same(expected_analyzer, final_analyzer):
             #    logging.error("Analyzer overwritten!")
             #    error = True
             assert error == False

--- a/pyOCD/target/target_MKL28Z512xxx7.py
+++ b/pyOCD/target/target_MKL28Z512xxx7.py
@@ -128,26 +128,37 @@ flash_algo = {
 class Flash_kl28z(Flash_Kinetis):
     def __init__(self, target):
         super(Flash_kl28z, self).__init__(target, flash_algo)
+        self._saved_firccsr = 0
+        self._saved_rccr = 0
 
     ##
     # This function sets up target clocks to ensure that flash is clocked at the maximum
     # of 24MHz. Doing so gets the best flash programming performance. The FIRC clock source
     # is used so that there is no dependency on an external crystal frequency.
-    def init(self):
-        super(Flash_kl28z, self).init()
+    def init(self, reset=True):
+        super(Flash_kl28z, self).init(reset)
 
         # Enable FIRC.
         value = self.target.read32(SCG_FIRCCSR)
+        self._saved_firccsr = value
         value |= FIRCEN_MASK
         self.target.write32(SCG_FIRCCSR, value)
 
         # Switch system to FIRC, core=48MHz (/1), slow=24MHz (/2).
         # Flash and the bus are clocked from the slow clock, and its max is 24MHz,
         # so there is no benefit from raising the core clock further.
+        self._saved_rccr = self.target.read32(SCG_RCCR)
         self.target.write32(SCG_RCCR, (0x3 << SCS_SHIFT) | (1 << DIVSLOW_SHIFT))
 
         csr = self.target.read32(SCG_CSR)
         logging.debug("SCG_CSR = 0x%08x", csr)
+
+    ##
+    # Restore clock registers to original values.
+    def cleanup(self):
+        self.target.write32(SCG_FIRCCSR, self._saved_firccsr)
+        self.target.write32(SCG_RCCR, self._saved_rccr)
+
 
 class KL28x(Kinetis):
 

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -99,6 +99,7 @@ class GDBServerTool(object):
         parser.add_argument("-G", "--gdb-syscall", dest="semihost_use_syscalls", action="store_true", help="Use GDB syscalls for semihosting file I/O.")
         parser.add_argument("-c", "--command", dest="commands", metavar="CMD", action='append', nargs='+', help="Run command (OpenOCD compatibility).")
         parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
+        parser.add_argument("--elf", metavar="PATH", help="Optionally specify ELF file being debugged.")
         self.parser = parser
         return parser
 
@@ -298,6 +299,9 @@ class GDBServerTool(object):
                         print("No board selected")
                         return 1
                     with board_selected as board:
+                        # Set ELF if provided.
+                        if self.args.elf:
+                            board.target.elf = self.args.elf
                         baseTelnetPort = self.gdb_server_settings['telnet_port']
                         for core_number, core in board.target.cores.items():
                             self.gdb_server_settings['telnet_port'] = baseTelnetPort + core_number

--- a/pyOCD/utility/mask.py
+++ b/pyOCD/utility/mask.py
@@ -65,7 +65,7 @@ def bfx(value, msb, lsb):
 def bfi(value, msb, lsb, field):
     mask = bitmask((msb, lsb))
     value &= ~mask
-    value |= (field & mask) << lsb
+    value |= (field << lsb) & mask
     return value
 
 def _msb( n ):

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ install_requires = [
     'websocket-client',
     'intervaltree',
     'colorama',
+    'pyelftools',
     ]
 if sys.platform.startswith('linux'):
     install_requires.extend([
@@ -48,7 +49,7 @@ setup(
     },
     setup_requires=['setuptools_scm!=1.5.3,!=1.5.4', 'setuptools_scm_git_archive'],
     description="CMSIS-DAP debugger for Python",
-    long_description=open('README.rst', 'Ur').read(),
+    long_description=open('README.rst', 'r').read(),
     author="Chris Reed, Martin Kojtal, Russ Butler",
     author_email="chris.reed@arm.com, martin.kojtal@arm.com, russ.butler@arm.com",
     url='https://github.com/mbedmicro/pyOCD',


### PR DESCRIPTION
This PR brings in ELF file decoding and some related features. The new `pyOCD.debug.elf` package contains all of the new modules. ELF file parsing is handled by the pyelftools package, which is added to install dependencies. This ELF support forms the basis for many advanced features such as SWO-based profiling.

ELF decoding capabilities:
- Extract useful sections and their data.
- Determine ranges of memory that are occupied and unoccupied by section data.
- Look up symbols by address or name. (C++ demangling is not supported yet.)
- Get function address range and name by address (using DWARF data).
- Get source file and line for an address.

A new debug context called `FlashReaderContext` optimizes reads from flash memory regions by providing data from an ELF file instead of reading from the target's memory. pyocd-gdbserver accepts a `--elf` command line argument which sets the ELF file's path and enables this feature for the gdb server.

pyocd-flashtool can now write ELF files to target flash.

ELF support and a couple new commands were added to pyocd-tool. It also accepts a `--elf` command line argument now. You can now use symbol names in the arguments to other commands. For example. `r32 g_myCounter` to read the word at the address of a global variable.

The new commands are:
- `where` to print symbol name, file, and line number for an address or current PC.
- `symbol` to print the address of a named symbol.

This PR also includes some minor cleanup of the `Flash` class, and a fix to the `bfi()` utility function.