### PR TITLE
Fix for installing from GitHub release archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+*.py        text
+*.c         text
+*.cpp       text
+*.h         text
+*.s         text
+*.S         text
+*.ld        text
+*.txt       text
+*.xml       text
+*.yml       text
+*.yaml      text
+*.md        text
+*.rst       text
+*.json      text
+*.ini       text
+Makefile    text
+*.bat       text eol=crlf
+*.map       text
+*.elf       binary
+*.bin       binary
+.git_archival.txt   export-subst


### PR DESCRIPTION
Added missing `.git_archival.txt` and `.gitattributes` files to make the [setuptools_scm_git_archive](https://github.com/Changaco/setuptools_scm_git_archive) plugin work.
