### PR TITLE
STLinkV2 debug probe support

### DIFF
--- a/pyOCD/board/mbed_board.py
+++ b/pyOCD/board/mbed_board.py
@@ -40,9 +40,9 @@ class MbedBoard(Board):
             self.native_target = board_info.target
             self._test_binary = board_info.binary
         except KeyError:
+            board_info = None
             self._name = "Unknown Board"
             self.native_target = None
-            self._test_binary = None
 
         # Unless overridden use the native target
         if target is None:
@@ -54,12 +54,9 @@ class MbedBoard(Board):
 
         super(MbedBoard, self).__init__(session, target)
 
-    @property
-    def test_binary(self):
-        """
-        Return name of test binary file
-        """
-        return self._test_binary
+        # Set test binary if not already set.
+        if (board_info is not None) and (self._test_binary is None):
+            self._test_binary = board_info.binary
 
     @property
     def name(self):

--- a/pyOCD/core/memory_interface.py
+++ b/pyOCD/core/memory_interface.py
@@ -1,0 +1,163 @@
+# pyOCD debugger
+# Copyright (c) 2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..utility import conversion
+
+## @brief Interface for memory access.
+class MemoryInterface(object):
+
+    ## @brief Write a single memory location.
+    #
+    # By default the transfer size is a word.
+    def write_memory(self, addr, data, transfer_size=32):
+        raise NotImplementedError()
+        
+    ## @brief Read a memory location.
+    #
+    # By default, a word will be read.
+    def read_memory(self, addr, transfer_size=32, now=True):
+        raise NotImplementedError()
+
+    ## @brief Write an aligned block of 32-bit words.
+    def write_memory_block32(self, addr, data):
+        raise NotImplementedError()
+
+    ## @brief Read an aligned block of 32-bit words.
+    def read_memory_block32(self, addr, size):
+        raise NotImplementedError()
+  
+    # @brief Shorthand to write a 32-bit word.
+    def write32(self, addr, value):
+        self.write_memory(addr, value, 32)
+
+    # @brief Shorthand to write a 16-bit halfword.
+    def write16(self, addr, value):
+        self.write_memory(addr, value, 16)
+
+    # @brief Shorthand to write a byte.
+    def write8(self, addr, value):
+        self.write_memory(addr, value, 8)
+
+    # @brief Shorthand to read a 32-bit word.
+    def read32(self, addr, now=True):
+        return self.read_memory(addr, 32, now)
+
+    # @brief Shorthand to read a 16-bit halfword.
+    def read16(self, addr, now=True):
+        return self.read_memory(addr, 16, now)
+
+    # @brief Shorthand to read a byte.
+    def read8(self, addr, now=True):
+        return self.read_memory(addr, 8, now)
+
+    ## @brief Read a block of unaligned bytes in memory.
+    # @return an array of byte values
+    def read_memory_block8(self, addr, size):
+        res = []
+
+        # try to read 8bits data
+        if (size > 0) and (addr & 0x01):
+            mem = self.read8(addr)
+            res.append(mem)
+            size -= 1
+            addr += 1
+
+        # try to read 16bits data
+        if (size > 1) and (addr & 0x02):
+            mem = self.read16(addr)
+            res.append(mem & 0xff)
+            res.append((mem >> 8) & 0xff)
+            size -= 2
+            addr += 2
+
+        # try to read aligned block of 32bits
+        if (size >= 4):
+            mem = self.read_memory_block32(addr, size // 4)
+            res += conversion.u32leListToByteList(mem)
+            size -= 4*len(mem)
+            addr += 4*len(mem)
+
+        if (size > 1):
+            mem = self.read16(addr)
+            res.append(mem & 0xff)
+            res.append((mem >> 8) & 0xff)
+            size -= 2
+            addr += 2
+
+        if (size > 0):
+            mem = self.read8(addr)
+            res.append(mem)
+
+        return res
+
+    ## @brief Write a block of unaligned bytes in memory.
+    def write_memory_block8(self, addr, data):
+        size = len(data)
+        idx = 0
+
+        #try to write 8 bits data
+        if (size > 0) and (addr & 0x01):
+            self.write8(addr, data[idx])
+            size -= 1
+            addr += 1
+            idx += 1
+
+        # try to write 16 bits data
+        if (size > 1) and (addr & 0x02):
+            self.write16(addr, data[idx] | (data[idx+1] << 8))
+            size -= 2
+            addr += 2
+            idx += 2
+
+        # write aligned block of 32 bits
+        if (size >= 4):
+            data32 = conversion.byteListToU32leList(data[idx:idx + (size & ~0x03)])
+            self.write_memory_block32(addr, data32)
+            addr += size & ~0x03
+            idx += size & ~0x03
+            size -= size & ~0x03
+
+        # try to write 16 bits data
+        if (size > 1):
+            self.write16(addr, data[idx] | (data[idx+1] << 8))
+            size -= 2
+            addr += 2
+            idx += 2
+
+        #try to write 8 bits data
+        if (size > 0):
+            self.write8(addr, data[idx])
+
+    # Deprecated names.
+
+    def writeMemory(self, addr, data, transfer_size=32):
+        self.write_memory(addr, data, transfer_size)
+        
+    def readMemory(self, addr, transfer_size=32, now=True):
+        return self.read_memory(addr, transfer_size, now)
+    
+    def writeBlockMemoryAligned32(self, addr, data):
+        self.write_memory_block32(addr, data)
+
+    def readBlockMemoryAligned32(self, addr, size):
+        return self.read_memory_block32(addr, size)
+        
+    def writeBlockMemoryUnaligned8(self, addr, data):
+        self.write_memory_block8(addr, data)
+
+    def readBlockMemoryUnaligned8(self, addr, size):
+        return self.read_memory_block8(addr, size)
+

--- a/pyOCD/probe/aggregator.py
+++ b/pyOCD/probe/aggregator.py
@@ -15,9 +15,11 @@
 # limitations under the License.
 
 from .cmsis_dap_probe import CMSISDAPProbe
+from .stlink_probe import StlinkProbe
 
 PROBE_CLASSES = [
     CMSISDAPProbe,
+    StlinkProbe,
     ]
 
 ## @brief Simple class to enable collecting probes of all supported probe types.

--- a/pyOCD/probe/debug_probe.py
+++ b/pyOCD/probe/debug_probe.py
@@ -137,5 +137,8 @@ class DebugProbe(object):
 
     def write_ap_multiple(self, addr, values):
         raise NotImplementedError()
+    
+    def get_memory_interface_for_ap(self, apsel):
+        return None
   
 

--- a/pyOCD/probe/stlink/__init__.py
+++ b/pyOCD/probe/stlink/__init__.py
@@ -1,0 +1,21 @@
+# pyOCD debugger
+# Copyright (c) 2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class STLinkException(RuntimeError):
+    pass
+
+

--- a/pyOCD/probe/stlink/stlink.py
+++ b/pyOCD/probe/stlink/stlink.py
@@ -1,0 +1,439 @@
+# pyOCD debugger
+# Copyright (c) 2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import STLinkException
+from ...core import exceptions
+import logging
+import struct
+import six
+from enum import Enum
+
+log = logging.getLogger('stlink')
+
+## @brief STLink V2 and V3 command interface.
+class STLink(object):
+    class Protocol(Enum):
+        SWD = 1
+        JTAG = 2
+    
+    # Common commands.
+    GET_VERSION = 0xf1
+    JTAG_COMMAND = 0xf2
+    DFU_COMMAND = 0xf3
+    SWIM_COMMAND = 0xf4
+    GET_CURRENT_MODE = 0xf5
+    GET_TARGET_VOLTAGE = 0xf7
+    GET_VERSION_EXT = 0xfb
+
+    # Modes returned by GET_CURRENT_MODE.
+    DEV_DFU_MODE = 0x00
+    DEV_MASS_MODE = 0x01
+    DEV_JTAG_MODE = 0x02
+    DEV_SWIM_MODE = 0x03
+
+    # Commands to exit other modes.
+    DFU_EXIT = 0x07
+    SWIM_EXIT = 0x01
+
+    # JTAG commands.
+    JTAG_READMEM_32BIT = 0x07
+    JTAG_WRITEMEM_32BIT = 0x08
+    JTAG_READMEM_8BIT = 0x0c
+    JTAG_WRITEMEM_8BIT = 0x0d
+    JTAG_EXIT = 0x21
+    JTAG_ENTER2 = 0x30
+    JTAG_GETLASTRWSTATUS2 = 0x3e # From V2J15
+    JTAG_DRIVE_NRST = 0x3c
+    SWV_START_TRACE_RECEPTION = 0x40
+    SWV_STOP_TRACE_RECEPTION = 0x41
+    SWV_GET_TRACE_NEW_RECORD_NB = 0x42
+    SWD_SET_FREQ = 0x43 # From V2J20
+    JTAG_SET_FREQ = 0x44 # From V2J24
+    JTAG_READ_DAP_REG = 0x45 # From V2J24
+    JTAG_WRITE_DAP_REG = 0x46 # From V2J24
+    JTAG_READMEM_16BIT = 0x47 # From V2J26
+    JTAG_WRITEMEM_16BIT = 0x48 # From V2J26
+    JTAG_INIT_AP = 0x4b # From V2J28
+    JTAG_CLOSE_AP_DBG = 0x4c # From V2J28
+    SET_COM_FREQ = 0x61 # V3 only, replaces SWD/JTAG_SET_FREQ
+    GET_COM_FREQ = 0x62 # V3 only
+    
+    # Parameters for JTAG_ENTER2.
+    JTAG_ENTER_SWD = 0xa3
+    JTAG_ENTER_JTAG_NO_CORE_RESET = 0xa3
+
+    # Parameters for JTAG_DRIVE_NRST.
+    JTAG_DRIVE_NRST_LOW = 0x00
+    JTAG_DRIVE_NRST_HIGH = 0x01
+    JTAG_DRIVE_NRST_PULSE = 0x02
+    
+    # Parameters for JTAG_INIT_AP and JTAG_CLOSE_AP_DBG.
+    JTAG_AP_NO_CORE = 0x00
+    JTAG_AP_CORTEXM_CORE = 0x01
+    
+    # Parameters for SET_COM_FREQ and GET_COM_FREQ.
+    JTAG_STLINK_SWD_COM = 0x00
+    JTAG_STLINK_JTAG_COM = 0x01
+    
+    # Status codes.
+    JTAG_OK = 0x80
+    JTAG_UNKNOWN_ERROR = 0x01
+    JTAG_SPI_ERROR = 0x02
+    JTAG_DMA_ERROR = 0x03
+    JTAG_UNKNOWN_JTAG_CHAIN = 0x04
+    JTAG_NO_DEVICE_CONNECTED = 0x05
+    JTAG_INTERNAL_ERROR = 0x06
+    JTAG_CMD_WAIT = 0x07
+    JTAG_CMD_ERROR = 0x08
+    JTAG_GET_IDCODE_ERROR = 0x09
+    JTAG_ALIGNMENT_ERROR = 0x0a
+    JTAG_DBG_POWER_ERROR = 0x0b
+    JTAG_WRITE_ERROR = 0x0c
+    JTAG_WRITE_VERIF_ERROR = 0x0d
+    JTAG_ALREADY_OPENED_IN_OTHER_MODE = 0x0e
+    SWD_AP_WAIT = 0x10
+    SWD_AP_FAULT = 0x11
+    SWD_AP_ERROR = 0x12
+    SWD_AP_PARITY_ERROR = 0x13
+    SWD_DP_WAIT = 0x14
+    SWD_DP_FAULT = 0x15
+    SWD_DP_ERROR = 0x16
+    SWD_DP_PARITY_ERROR = 0x17
+    SWD_AP_WDATA_ERROR = 0x18
+    SWD_AP_STICKY_ERROR = 0x19
+    SWD_AP_STICKYORUN_ERROR = 0x1a
+    SWV_NOT_AVAILABLE = 0x20
+    JTAG_FREQ_NOT_SUPPORTED = 0x41
+    JTAG_UNKNOWN_CMD = 0x42
+    
+    STATUS_MESSAGES = {
+        JTAG_UNKNOWN_ERROR : "Unknown error",
+        JTAG_SPI_ERROR : "SPI error",
+        JTAG_DMA_ERROR : "DMA error",
+        JTAG_UNKNOWN_JTAG_CHAIN : "Unknown JTAG chain",
+        JTAG_NO_DEVICE_CONNECTED : "No device connected",
+        JTAG_INTERNAL_ERROR : "Internal error",
+        JTAG_CMD_WAIT : "Command wait",
+        JTAG_CMD_ERROR : "Command error",
+        JTAG_GET_IDCODE_ERROR : "Get IDCODE error",
+        JTAG_ALIGNMENT_ERROR : "Alignment error",
+        JTAG_DBG_POWER_ERROR : "Debug power error",
+        JTAG_WRITE_ERROR : "Write error",
+        JTAG_WRITE_VERIF_ERROR : "Write verification error",
+        JTAG_ALREADY_OPENED_IN_OTHER_MODE : "Already opened in another mode",
+        SWD_AP_WAIT : "AP wait",
+        SWD_AP_FAULT : "AP fault",
+        SWD_AP_ERROR : "AP error",
+        SWD_AP_PARITY_ERROR : "AP parity error",
+        SWD_DP_WAIT : "DP wait",
+        SWD_DP_FAULT : "DP fault",
+        SWD_DP_ERROR : "DP error",
+        SWD_DP_PARITY_ERROR : "DP parity error",
+        SWD_AP_WDATA_ERROR : "AP WDATA error",
+        SWD_AP_STICKY_ERROR : "AP sticky error",
+        SWD_AP_STICKYORUN_ERROR : "AP sticky overrun error",
+        SWV_NOT_AVAILABLE : "SWV not available",
+        JTAG_FREQ_NOT_SUPPORTED : "Frequency not supported",
+        JTAG_UNKNOWN_CMD : "Unknown command",
+    }
+
+    SWD_FREQ_MAP = {
+        4600000 :   0,
+        1800000 :   1, # Default
+        1200000 :   2,
+        950000 :    3,
+        650000 :    5,
+        480000 :    7,
+        400000 :    9,
+        360000 :    10,
+        240000 :    15,
+        150000 :    25,
+        125000 :    31,
+        100000 :    40,
+    }
+    
+    JTAG_FREQ_MAP = {
+        18000000 :  2,
+        9000000 :   4,
+        4500000 :   8,
+        2250000 :   16,
+        1120000 :   32, # Default
+        560000 :    64,
+        280000 :    128,
+        140000 :    256,
+    }
+
+    MAXIMUM_TRANSFER_SIZE = 1024
+    
+    MIN_JTAG_VERSION = 24
+    
+    # Port number to use to indicate DP registers.
+    DP_PORT = 0xffff
+
+    def __init__(self, device):
+        self._device = device
+        self._hw_version = 0
+        self._jtag_version = 0
+        self._version_str = None
+        self._target_voltage = 0
+    
+    def open(self):
+        self._device.open()
+        self.get_version()
+        self.get_target_voltage()
+
+    def close(self):
+        self.enter_idle()
+        self._device.close()
+
+    def get_version(self):
+        # GET_VERSION response structure:
+        #   Byte 0-1:
+        #     [15:12] Major/HW version
+        #     [11:6]  JTAG/SWD version
+        #     [5:0]   SWIM or MSC version
+        #   Byte 2-3: ST_VID
+        #   Byte 4-5: STLINK_PID
+        response = self._device.transfer([self.GET_VERSION], readSize=6)
+        ver, = struct.unpack('>H', response[:2])
+        dev_ver = self._device.version_name
+        # TODO create version bitfield constants
+        self._hw_version = (ver >> 12) & 0xf
+        self._jtag_version = (ver >> 6) & 0x3f
+        self._version_str = "%s v%dJ%d" % (dev_ver, self._hw_version, self._jtag_version)
+        
+        # For STLinkV3 we must use the extended get version command.
+        if self._hw_version >= 3:
+            # GET_VERSION_EXT response structure (byte offsets):
+            #   0: HW version
+            #   1: SWIM version
+            #   2: JTAG/SWD version
+            #   3: MSC/VCP version
+            #   4: Bridge version
+            #   5-7: reserved
+            #   8-9: ST_VID
+            #   10-11: STLINK_PID
+            response = self._device.transfer([self.GET_VERSION_EXT], readSize=12)
+            hw_vers, _, self._jtag_version = struct.unpack('<3B', response[0:3])
+
+        # Check versions.
+        if self._jtag_version == 0:
+            raise STLinkException("%s firmware does not support JTAG/SWD. Please update"
+                "to a firmware version that supports JTAG/SWD" % (self._version_str))
+        if self._jtag_version < self.MIN_JTAG_VERSION:
+            raise STLinkException("STLink %s is using an unsupported, older firmware version. "
+                "Please update to the latest STLink firmware. Current version is %s, must be at least version v2J%d.)" 
+                % (self.serial_number, self._version_str, self.MIN_JTAG_VERSION))
+
+    @property
+    def vendor_name(self):
+        return self._device.vendor_name
+
+    @property
+    def product_name(self):
+        return self._device.product_name + self._device.version_name
+
+    @property
+    def serial_number(self):
+        return self._device.serial_number
+
+    @property
+    def hw_version(self):
+        return self._hw_version
+
+    @property
+    def jtag_version(self):
+        return self._jtag_version
+
+    @property
+    def version_str(self):
+        return self._version_str
+
+    @property
+    def target_voltage(self):
+        return self._target_voltage
+
+    def get_target_voltage(self):
+        response = self._device.transfer([self.GET_TARGET_VOLTAGE], readSize=8)
+        a0, a1 = struct.unpack('<II', response[:8])
+        self._target_voltage = 2 * a1 * 1.2 / a0 if a0 != 0 else None
+
+    def enter_idle(self):
+        response = self._device.transfer([self.GET_CURRENT_MODE], readSize=2)
+        if response[0] == self.DEV_DFU_MODE:
+            self._device.transfer([self.DFU_COMMAND, self.DFU_EXIT])
+        elif response[0] == self.DEV_JTAG_MODE:
+            self._device.transfer([self.JTAG_COMMAND, self.JTAG_EXIT])
+        elif response[0] == self.DEV_SWIM_MODE:
+            self._device.transfer([self.SWIM_COMMAND, self.SWIM_EXIT])
+
+    def set_swd_frequency(self, freq=1800000):
+        if self._jtag_version < 20:
+            return
+        for f, d in self.SWD_FREQ_MAP.items():
+            if freq >= f:
+                response = self._device.transfer([self.JTAG_COMMAND, self.SWD_SET_FREQ, d], readSize=2)
+                self._check_status(response)
+                return
+        raise STLinkException("Selected SWD frequency is too low")
+
+    def set_jtag_frequency(self, freq=1120000):
+        if self._jtag_version < 24:
+            return
+        for f, d in self.JTAG_FREQ_MAP.items():
+            if freq >= f:
+                response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_SET_FREQ, d], readSize=2)
+                self._check_status(response)
+                return
+        raise STLinkException("Selected JTAG frequency is too low")
+
+    def enter_debug(self, protocol):
+        self.enter_idle()
+        
+        if protocol == self.Protocol.SWD:
+            protocolParam = self.JTAG_ENTER_SWD
+        elif protocol == self.Protocol.JTAG:
+            protocolParam = self.JTAG_ENTER_JTAG_NO_CORE_RESET
+        response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_ENTER2, protocolParam, 0], readSize=2)
+        self._check_status(response)
+    
+    def open_ap(self, apsel):
+        if self._jtag_version < 28:
+            return
+        cmd = [self.JTAG_COMMAND, self.JTAG_INIT_AP, apsel, self.JTAG_AP_NO_CORE]
+        response = self._device.transfer(cmd, readSize=2)
+        self._check_status(response)
+    
+    def close_ap(self, apsel):
+        if self._jtag_version < 28:
+            return
+        cmd = [self.JTAG_COMMAND, self.JTAG_CLOSE_AP_DBG, apsel]
+        response = self._device.transfer(cmd, readSize=2)
+        self._check_status(response)
+
+    def target_reset(self):
+        response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_DRIVE_NRST, JTAG_DRIVE_NRST_PULSE], readSize=2)
+        self._check_status(response)
+    
+    def drive_nreset(self, isAsserted):
+        value = self.JTAG_DRIVE_NRST_LOW if isAsserted else self.JTAG_DRIVE_NRST_HIGH
+        response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_DRIVE_NRST, value], readSize=2)
+        self._check_status(response)
+    
+    def _check_status(self, response):
+        status, = struct.unpack('<H', response)
+        if status != self.JTAG_OK:
+            raise STLinkException("STLink error (%d): " % status + self.STATUS_MESSAGES.get(status, "Unknown error"))
+
+    def _read_mem(self, addr, size, memcmd, max):
+        result = []
+        while size:
+            thisTransferSize = min(size, max)
+            
+            cmd = [self.JTAG_COMMAND, memcmd]
+            cmd.extend(six.iterbytes(struct.pack('<IHB', addr, thisTransferSize)))
+            result += self._device.transfer(cmd, readSize=thisTransferSize)
+            
+            addr += thisTransferSize
+            size -= thisTransferSize
+            
+            # Check status of this read.
+            response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_GETLASTRWSTATUS2], readSize=12)
+            status, _, faultAddr = struct.unpack('<HHI', response[0:8])
+            if status in (self.JTAG_UNKNOWN_ERROR, self.SWD_AP_FAULT, self.SWD_DP_FAULT):
+                exc = exceptions.TransferFaultError()
+                exc.fault_address = faultAddr
+                exc.fault_length = thisTransferSize - (faultAddr - addr)
+                raise exc
+            elif status != self.JTAG_OK:
+                raise STLinkException("STLink error: " + self.STATUS_MESSAGES.get(status, "Unknown error"))
+        return result
+
+    def _write_mem(self, addr, data, memcmd, max):
+        while len(data):
+            thisTransferSize = min(len(data), max)
+            thisTransferData = data[:thisTransferSize]
+            
+            cmd = [self.JTAG_COMMAND, memcmd]
+            cmd.extend(six.iterbytes(struct.pack('<IHB', addr, thisTransferSize)))
+            self._device.transfer(cmd, writeData=thisTransferData)
+            
+            addr += thisTransferSize
+            data = data[thisTransferSize:]
+            
+            # Check status of this write.
+            response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_GETLASTRWSTATUS2], readSize=12)
+            status, _, faultAddr = struct.unpack('<HHI', response[0:8])
+            if status in (self.JTAG_UNKNOWN_ERROR, self.SWD_AP_FAULT, self.SWD_DP_FAULT):
+                exc = exceptions.TransferFaultError()
+                exc.fault_address = faultAddr
+                exc.fault_length = thisTransferSize - (faultAddr - addr)
+                raise exc
+            elif status != self.JTAG_OK:
+                raise STLinkException("STLink error (%x): " % status + self.STATUS_MESSAGES.get(status, "Unknown error"))
+
+    def read_mem32(self, addr, size):
+        assert (addr & 0x3) == 0 and (size & 0x3) == 0, "address and size must be word aligned"
+        return self._read_mem(addr, size, self.JTAG_READMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE)
+
+    def write_mem32(self, addr, data):
+        assert (addr & 0x3) == 0 and (len(data) & 3) == 0, "address and size must be word aligned"
+        self._write_mem(addr, data, self.JTAG_WRITEMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE)
+
+    def read_mem16(self, addr, size):
+        assert (addr & 0x1) == 0 and (size & 0x1) == 0, "address and size must be half-word aligned"
+
+        if self._jtag_version < 26:
+            # 16-bit r/w is only available from J26, so revert to 8-bit accesses.
+            return self.read_mem8(addr, size)
+        
+        return self._read_mem(addr, size, self.JTAG_READMEM_16BIT, self.MAXIMUM_TRANSFER_SIZE)
+
+    def write_mem16(self, addr, data):
+        assert (addr & 0x1) == 0 and (len(data) & 1) == 0, "address and size must be half-word aligned"
+
+        if self._jtag_version < 26:
+            # 16-bit r/w is only available from J26, so revert to 8-bit accesses.
+            self.write_mem8(addr, data)
+            return
+        
+        self._write_mem(addr, data, self.JTAG_WRITEMEM_16BIT, self.MAXIMUM_TRANSFER_SIZE)
+
+    def read_mem8(self, addr, size):
+        return self._read_mem(addr, size, self.JTAG_READMEM_8BIT, self._device.max_packet_size)
+
+    def write_mem8(self, addr, data):
+        self._write_mem(addr, data, self.JTAG_WRITEMEM_8BIT, self._device.max_packet_size)
+    
+    def read_dap_register(self, port, addr):
+        assert ((addr & 0xf0) == 0) or (port != self.DP_PORT), "banks are not allowed for DP registers"
+        assert (addr >> 16) == 0, "register address must be 16-bit"
+        
+        cmd = [self.JTAG_COMMAND, self.JTAG_READ_DAP_REG]
+        cmd.extend(six.iterbytes(struct.pack('<HH', port, addr)))
+        response = self._device.transfer(cmd, readSize=8)
+        self._check_status(response[:2])
+        value, = struct.unpack('<I', response[4:8])
+        return value
+    
+    def write_dap_register(self, port, addr, value):
+        assert ((addr & 0xf0) == 0) or (port != self.DP_PORT), "banks are not allowed for DP registers"
+        assert (addr >> 16) == 0, "register address must be 16-bit"
+        cmd = [self.JTAG_COMMAND, self.JTAG_WRITE_DAP_REG]
+        cmd.extend(six.iterbytes(struct.pack('<HHI', port, addr, value)))
+        response = self._device.transfer(cmd, readSize=2)
+        self._check_status(response)
+

--- a/pyOCD/probe/stlink/usb.py
+++ b/pyOCD/probe/stlink/usb.py
@@ -1,0 +1,217 @@
+# pyOCD debugger
+# Copyright (c) 2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from . import STLinkException
+import usb.core
+import usb.util
+import logging
+import six
+import threading
+from collections import namedtuple
+
+# Set to True to enable debug logs of USB data transfers.
+LOG_USB_DATA = False
+
+log = logging.getLogger('stlink.usb')
+
+STLinkInfo = namedtuple('STLinkInfo', 'version_name out_ep in_ep swv_ep')
+
+##
+# @brief Provides low-level USB enumeration and transfers for STLinkV2/3 devices.
+class STLinkUSBInterface(object):
+    # Command packet size.
+    CMD_SIZE = 16
+    
+    # ST's USB vendor ID
+    USB_VID = 0x0483
+
+    # Map of USB PID to firmware version name and device endpoints.
+    USB_PID_EP_MAP = {
+        # PID              Version  OUT     IN      SWV
+        0x3748: STLinkInfo('V2',    0x02,   0x81,   0x83),
+        0x374b: STLinkInfo('V2-1',  0x01,   0x81,   0x82),
+        0x374a: STLinkInfo('V2-1',  0x01,   0x81,   0x82),  # Audio
+        0x3742: STLinkInfo('V2-1',  0x01,   0x81,   0x82),  # No MSD
+        0x374e: STLinkInfo('V3',    0x01,   0x81,   0x82),
+        0x374f: STLinkInfo('V3',    0x01,   0x81,   0x82),  # Bridge
+        0x3753: STLinkInfo('V3',    0x01,   0x81,   0x82),  # 2VCP
+        }
+    
+    DEBUG_INTERFACE_NUMBER = 0
+
+    @classmethod
+    def _usb_match(cls, dev):
+        try:
+            # Check VID/PID.
+            isSTLink = (dev.idVendor == cls.USB_VID) and (dev.idProduct in cls.USB_PID_EP_MAP)
+            
+            # Try accessing the product name, which will cause a permission error on Linux. Better
+            # to error out here than later when building the device description.
+            if isSTLink:
+                dummy = dev.product
+            
+            return isSTLink
+        except ValueError as error:
+            # Permission denied error gets reported as ValueError (The device has no langid).
+            log.debug(("ValueError \"{}\" while trying to access STLink USB device fields "
+                           "for idVendor=0x{:04x} idProduct=0x{:04x}. "
+                           "This is probably a permission issue.").format(error, dev.idVendor, dev.idProduct))
+            return False
+        except usb.core.USBError as error:
+            log.warning("Exception getting device info: %s", error)
+            return False
+        except IndexError as error:
+            log.warning("Internal pyusb error: %s", error)
+            return False
+
+    @classmethod
+    def get_all_connected_devices(cls):
+        devices = usb.core.find(find_all=True, custom_match=cls._usb_match)
+        
+        intfList = []
+        for dev in devices:
+            intf = cls(dev)
+            intfList.append(intf)
+        
+        return intfList
+
+    def __init__(self, dev):
+        self._dev = dev
+        assert dev.idVendor == self.USB_VID
+        self._info = self.USB_PID_EP_MAP[dev.idProduct]
+        self._ep_out = None
+        self._ep_in = None
+        self._ep_swv = None
+        self._max_packet_size = 64
+        self._closed = True
+    
+    def open(self):
+        assert self._closed
+        
+        self._dev.set_configuration()
+        config = self._dev.get_active_configuration()
+        
+        # Debug interface is always interface 0, alt setting 0.
+        interface = config[(self.DEBUG_INTERFACE_NUMBER, 0)]
+        
+        # Look up endpoint objects.
+        for endpoint in interface:
+            if endpoint.bEndpointAddress == self._info.out_ep:
+                self._ep_out = endpoint
+            elif endpoint.bEndpointAddress == self._info.in_ep:
+                self._ep_in = endpoint
+            elif endpoint.bEndpointAddress == self._info.swv_ep:
+                self._ep_swv = endpoint
+        
+        if not self._ep_out:
+            raise STLinkException("Unable to find OUT endpoint")
+        if not self._ep_in:
+            raise STLinkException("Unable to find IN endpoint")
+
+        self._max_packet_size = self._ep_in.wMaxPacketSize
+        
+        # Claim this interface to prevent other processes from accessing it.
+        usb.util.claim_interface(self._dev, 0)
+        
+        self._flush_rx()
+        self._closed = False
+    
+    def close(self):
+        assert not self._closed
+        self._closed = True
+        usb.util.release_interface(self._dev, self.DEBUG_INTERFACE_NUMBER)
+        usb.util.dispose_resources(self._dev)
+        self._ep_out = None
+        self._ep_in = None
+
+    @property
+    def serial_number(self):
+        return self._dev.serial_number
+
+    @property
+    def vendor_name(self):
+        return self._dev.manufacturer
+
+    @property
+    def product_name(self):
+        return self._dev.product
+
+    @property
+    def version_name(self):
+        return self._info.version_name
+
+    @property
+    def max_packet_size(self):
+        return self._max_packet_size
+
+    def _flush_rx(self):
+        # Flush the RX buffers by reading until timeout exception
+        try:
+            while True:
+                self._ep_in.read(self._max_packet_size, 1)
+        except usb.core.USBError:
+            # USB timeout expected
+            pass
+
+    def _read(self, size, timeout=1000):
+        # Round up reads to the maximum packet size.
+        read_size = max(size, self._max_packet_size)
+#         if read_size % 4:
+#             read_size += 4 - (read_size & 0x3)
+#         return bytearray(self._ep_in.read(read_size, timeout))
+        return self._ep_in.read(read_size, timeout)
+
+    def transfer(self, cmd, writeData=None, readSize=None, timeout=1000):
+        # Pad command to required 16 bytes.
+        assert len(cmd) <= self.CMD_SIZE
+        paddedCmd = bytearray(self.CMD_SIZE)
+        paddedCmd[0:len(cmd)] = cmd
+        
+        try:
+            # Command phase.
+            if LOG_USB_DATA:
+                log.debug("  USB CMD> %s" % ' '.join(['%02x' % i for i in paddedCmd]))
+            count = self._ep_out.write(paddedCmd, timeout)
+            assert count == len(paddedCmd)
+            
+            # Optional data out phase.
+            if writeData is not None:
+                if LOG_USB_DATA:
+                    log.debug("  USB OUT> %s" % ' '.join(['%02x' % i for i in writeData]))
+                count = self._ep_out.write(writeData, timeout)
+                assert count == len(writeData)
+            
+            # Optional data in phase.
+            if readSize is not None:
+                if LOG_USB_DATA:
+                    log.debug("  USB IN < (%d bytes)" % readSize)
+                data = self._read(readSize)
+                if LOG_USB_DATA:
+                    log.debug("  USB IN < %s" % ' '.join(['%02x' % i for i in data]))
+                return data
+        except usb.core.USBError as exc:
+            six.raise_from(STLinkException("USB Error: %s" % exc), exc)
+        return None
+
+    def read_swv(self, size, timeout=1000):
+        return self._ep_swv.read(size, timeout)
+    
+    def __repr__(self):
+        return "<{} @ {:#x} vid={:#06x} pid={:#06x} sn={} version={}>".format(
+            self.__class__.__name__, id(self),
+            self._dev.idVendor, self._dev.idProduct, self.serial_number,
+            self.version)

--- a/pyOCD/probe/stlink/usb.py
+++ b/pyOCD/probe/stlink/usb.py
@@ -62,7 +62,7 @@ class STLinkUSBInterface(object):
             # Try accessing the product name, which will cause a permission error on Linux. Better
             # to error out here than later when building the device description.
             if isSTLink:
-                dummy = dev.product
+                dev.product
             
             return isSTLink
         except ValueError as error:
@@ -80,7 +80,12 @@ class STLinkUSBInterface(object):
 
     @classmethod
     def get_all_connected_devices(cls):
-        devices = usb.core.find(find_all=True, custom_match=cls._usb_match)
+        try:
+            devices = usb.core.find(find_all=True, custom_match=cls._usb_match)
+        except usb.core.NoBackendError:
+            # Print a warning if pyusb cannot find a backend, and return no probes.
+            log.warning("STLink probes are not supported because no libusb library was found.")
+            return []
         
         intfList = []
         for dev in devices:

--- a/pyOCD/probe/stlink_probe.py
+++ b/pyOCD/probe/stlink_probe.py
@@ -1,0 +1,208 @@
+# pyOCD debugger
+# Copyright (c) 2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .debug_probe import DebugProbe
+from ..core import exceptions
+from .stlink import (STLinkException, usb, stlink)
+from ..utility import conversion
+import six
+
+## @brief Wraps an StLink as a DebugProbe.
+class StlinkProbe(DebugProbe):
+        
+    APSEL = 0xff000000
+    APSEL_SHIFT = 24
+    
+    @classmethod
+    def get_all_connected_probes(cls):
+        try:
+            return [cls(dev) for dev in usb.STLinkUSBInterface.get_all_connected_devices()]
+        except STLinkException as exc:
+            six.raise_from(cls._convert_exception(exc), exc)
+    
+    @classmethod
+    def get_probe_with_id(cls, unique_id):
+        try:
+            for dev in usb.STLinkUSBInterface.get_all_connected_devices():
+                if dev.serial_number == unique_id:
+                    return cls(usb.STLinkUSBInterface(unique_id))
+            else:
+                return None
+        except STLinkException as exc:
+            six.raise_from(cls._convert_exception(exc), exc)
+
+    def __init__(self, device):
+        self._link = stlink.STLink(device)
+        self._is_open = False
+        self._nreset_state = False
+        
+    @property
+    def description(self):
+        return self.product_name
+    
+    @property
+    def vendor_name(self):
+        return self._link.vendor_name
+    
+    @property
+    def product_name(self):
+        return self._link.product_name
+
+    ## @brief Only valid after opening.
+    @property
+    def supported_wire_protocols(self):
+        return [DebugProbe.Protocol.DEFAULT, DebugProbe.Protocol.SWD, DebugProbe.Protocol.JTAG]
+
+    @property
+    def unique_id(self):
+        return self._link.serial_number
+
+    @property
+    def wire_protocol(self):
+        return DebugProbe.Protocol.SWD if self._is_connected else None
+    
+    @property
+    def is_open(self):
+        return self._is_open
+    
+    def open(self):
+        try:
+            self._link.open()
+            self._is_open = True
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+    
+    def close(self):
+        try:
+            self._link.close()
+            self._is_open = False
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    # ------------------------------------------- #
+    #          Target control functions
+    # ------------------------------------------- #
+    def connect(self, protocol=None):
+        """Initialize DAP IO pins for JTAG or SWD"""
+        try:
+            self._link.enter_debug(stlink.STLink.Protocol.SWD)
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    # TODO remove
+    def swj_sequence(self):
+        """Send sequence to activate JTAG or SWD on the target"""
+        pass
+
+    def disconnect(self):
+        """Deinitialize the DAP I/O pins"""
+        try:
+            self._link.enter_idle()
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def set_clock(self, frequency):
+        """Set the frequency for JTAG and SWD in Hz
+
+        This function is safe to call before connect is called.
+        """
+        try:
+            self._link.set_swd_frequency(frequency)
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def reset(self):
+        """Reset the target"""
+        try:
+            self._link.target_reset()
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def assert_reset(self, asserted):
+        """Assert or de-assert target reset line"""
+        try:
+            self._link.drive_nreset(asserted)
+            self._nreset_state = asserted
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+    
+    def is_reset_asserted(self):
+        """Returns True if the target reset line is asserted or False if de-asserted"""
+        return self._nreset_state
+
+    def flush(self):
+        """Write out all unsent commands"""
+        pass
+
+    # ------------------------------------------- #
+    #          DAP Access functions
+    # ------------------------------------------- #
+    
+    def read_dp(self, addr, now=True):
+        try:
+            result = self._link.read_dap_register(stlink.STLink.DP_PORT, addr)
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+        
+        def read_dp_result_callback():
+            return result
+        
+        return result if now else read_dp_result_callback
+
+    def write_dp(self, addr, data):
+        try:
+            result = self._link.write_dap_register(stlink.STLink.DP_PORT, addr, data)
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def read_ap(self, addr, now=True):
+        try:
+            apsel = (addr & self.APSEL) >> self.APSEL_SHIFT
+            result = self._link.read_dap_register(apsel, addr & 0xffff)
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+        
+        def read_ap_result_callback():
+            return result
+        
+        return result if now else read_ap_result_callback
+
+    def write_ap(self, addr, data):
+        try:
+            apsel = (addr & self.APSEL) >> self.APSEL_SHIFT
+            result = self._link.write_dap_register(apsel, addr & 0xffff, data)
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def read_ap_multiple(self, addr, count=1, now=True):
+        results = [self.read_ap(addr, now=True) for n in range(count)]
+        
+        def read_ap_multiple_result_callback():
+            return result
+        
+        return results if now else read_ap_multiple_result_callback
+
+    def write_ap_multiple(self, addr, values):
+        for v in values:
+            self.write_ap(addr, v)
+
+    @staticmethod
+    def _convert_exception(exc):
+        if isinstance(exc, STLinkException):
+            return exceptions.ProbeError(str(exc))
+        else:
+            return exc
+

--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -673,6 +673,7 @@ class PyOCDTool(object):
             self.exitCode = 0
         except ValueError:
             print("Error: invalid argument")
+            traceback.print_exc()
         except exceptions.TransferError:
             print("Error: transfer failed")
             traceback.print_exc()

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 from setuptools import setup, find_packages
 import sys
 
+# Common dependencies.
 install_requires = [
     'intelhex',
     'six',
@@ -27,19 +28,21 @@ install_requires = [
     'intervaltree',
     'colorama',
     'pyelftools',
+    'pyusb>=1.0.0b2',
     ]
-if sys.platform.startswith('linux'):
-    install_requires.extend([
-        'pyusb>=1.0.0b2',
-    ])
-elif sys.platform.startswith('win'):
-    install_requires.extend([
+
+# Add OS-specific dependencies.
+os_install_requires = {
+    'linux' : [
+        ],
+    'win32' : [
         'pywinusb>=0.4.0',
-    ])
-elif sys.platform.startswith('darwin'):
-    install_requires.extend([
+        ],
+    'darwin' : [
         'hidapi',
-    ])
+        ],
+    }
+install_requires.extend(os_install_requires.get(sys.platform, []))
 
 setup(
     name="pyOCD",

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -5,4 +5,6 @@ test_results*.txt
 automated_test_results*.txt
 automated_test_summary.txt
 test_results.xml
+test_boards.json
+
 

--- a/test/automated_test.py
+++ b/test/automated_test.py
@@ -29,7 +29,7 @@ from pyOCD.utility.conversion import float32beToU32be
 from pyOCD.probe.aggregator import DebugProbeAggregator
 import logging
 from time import time
-from test_util import (TestResult, Test, IOTee, RecordingLogHandler)
+from test_util import (TestResult, Test, IOTee, RecordingLogHandler, get_session_options)
 import argparse
 from xml.etree import ElementTree
 import multiprocessing as mp
@@ -161,7 +161,7 @@ def print_board_header(outputFile, board, n, includeDividers=True, includeLeadin
 def test_board(board_id, n, loglevel, logToConsole, commonLogFile):
     probe = DebugProbeAggregator.get_probe_with_id(board_id)
     assert probe is not None
-    session = Session(probe)
+    session = Session(probe, **get_session_options())
     board = session.board
 
     originalStdout = sys.stdout

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -57,7 +57,7 @@ def basic_test(board_id, file):
         ram_region = ram_regions[0]
         rom_region = memory_map.getBootMemory()
 
-        addr = ram_region.start + 1
+        addr = ram_region.start
         size = 0x502
         addr_bin = rom_region.start
         addr_flash = rom_region.start + rom_region.length // 2

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -27,7 +27,7 @@ sys.path.insert(0, parentdir)
 import pyOCD
 from pyOCD.core.helpers import ConnectHelper
 from pyOCD.utility.conversion import float32beToU32be
-from test_util import Test
+from test_util import (Test, get_session_options)
 import logging
 
 class BasicTest(Test):
@@ -38,7 +38,7 @@ def run_basic_test(board_id):
     return basic_test(board_id, None)
 
 def basic_test(board_id, file):
-    with ConnectHelper.session_with_chosen_probe(unique_id=board_id) as session:
+    with ConnectHelper.session_with_chosen_probe(unique_id=board_id, **get_session_options()) as session:
         board = session.board
         addr = 0
         size = 0

--- a/test/blank_test.py
+++ b/test/blank_test.py
@@ -27,12 +27,13 @@ sys.path.insert(0, parentdir)
 import pyOCD
 from pyOCD.core.helpers import ConnectHelper
 import logging
+from test_util import get_session_options
 
 logging.basicConfig(level=logging.INFO)
 
 print("\n\n------ Test attaching to locked board ------")
 for i in range(0, 10):
-    with ConnectHelper.session_with_chosen_probe() as session:
+    with ConnectHelper.session_with_chosen_probe(**get_session_options()) as session:
         board = session.board
         # Erase and then reset - This locks Kinetis devices
         board.flash.init()
@@ -41,7 +42,7 @@ for i in range(0, 10):
 
 print("\n\n------ Testing Attaching to board ------")
 for i in range(0, 100):
-    with ConnectHelper.session_with_chosen_probe() as session:
+    with ConnectHelper.session_with_chosen_probe(**get_session_options()) as session:
         board = session.board
         board.target.halt()
         sleep(0.01)
@@ -49,14 +50,14 @@ for i in range(0, 100):
         sleep(0.01)
 
 print("\n\n------ Flashing new code ------")
-with ConnectHelper.session_with_chosen_probe() as session:
+with ConnectHelper.session_with_chosen_probe(**get_session_options()) as session:
     board = session.board
     binary_file = os.path.join(parentdir, 'binaries', board.test_binary)
     board.flash.flashBinary(binary_file)
 
 print("\n\n------ Testing Attaching to regular board ------")
 for i in range(0, 10):
-    with ConnectHelper.session_with_chosen_probe() as session:
+    with ConnectHelper.session_with_chosen_probe(**get_session_options()) as session:
         board = session.board
         board.target.resetStopOnReset()
         board.target.halt()

--- a/test/connect_test.py
+++ b/test/connect_test.py
@@ -27,7 +27,7 @@ sys.path.insert(0, parentdir)
 import pyOCD
 from pyOCD.core.helpers import ConnectHelper
 from pyOCD.core.target import Target
-from test_util import Test, TestResult
+from test_util import (Test, TestResult, get_session_options)
 import logging
 
 STATE_NAMES = {
@@ -81,7 +81,7 @@ def connect_test(board):
     result = ConnectTestResult()
 
     # Install binary.
-    live_session = ConnectHelper.session_with_chosen_probe(board_id=board_id, frequency=1000000)
+    live_session = ConnectHelper.session_with_chosen_probe(board_id=board_id, **get_session_options())
     live_board = live_session.board
     memory_map = board.target.getMemoryMap()
     rom_region = memory_map.getBootMemory()
@@ -91,10 +91,10 @@ def connect_test(board):
         print("Connecting with halt_on_connect=%s" % halt_on_connect)
         live_session = ConnectHelper.session_with_chosen_probe(
                         board_id=board_id,
-                        frequency=1000000, 
                         init_board=False,
                         halt_on_connect=halt_on_connect,
-                        resume_on_disconnect=resume)
+                        resume_on_disconnect=resume,
+                        **get_session_options())
         live_session.open()
         live_board = live_session.board
         print("Verifying target is", STATE_NAMES.get(expected_state, "unknown"))
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(level=level)
-    session = ConnectHelper.get_sessions_for_all_connected_probes()[0]
+    session = ConnectHelper.session_with_chosen_probe(open_session=False, **get_session_options())
     test = ConnectTest()
     result = [test.run(session.board)]
     test.print_perf_info(result)

--- a/test/cortex_test.py
+++ b/test/cortex_test.py
@@ -30,7 +30,7 @@ import pyOCD
 from pyOCD.core.helpers import ConnectHelper
 from pyOCD.utility.conversion import float32beToU32be
 from pyOCD.core import exceptions
-from test_util import Test, TestResult
+from test_util import (Test, TestResult, get_session_options)
 import logging
 from random import randrange
 
@@ -78,7 +78,7 @@ def test_function(session, function):
     return (stop - start) / float(TEST_COUNT)
 
 def cortex_test(board_id):
-    with ConnectHelper.session_with_chosen_probe(board_id=board_id, frequency=1000000) as session:
+    with ConnectHelper.session_with_chosen_probe(board_id=board_id, **get_session_options()) as session:
         board = session.board
         target_type = board.target_type
 

--- a/test/flash_test.py
+++ b/test/flash_test.py
@@ -34,7 +34,7 @@ from pyOCD.utility.conversion import float32beToU32be
 from pyOCD.flash.flash import Flash
 from pyOCD.flash.flash_builder import FlashBuilder
 from pyOCD.utility.progress import print_progress
-from test_util import Test, TestResult
+from test_util import (Test, TestResult, get_session_options)
 
 addr = 0
 size = 0
@@ -123,7 +123,7 @@ def same(d1, d2):
 
 
 def flash_test(board_id):
-    with ConnectHelper.session_with_chosen_probe(board_id=board_id, frequency=1000000) as session:
+    with ConnectHelper.session_with_chosen_probe(board_id=board_id, **get_session_options()) as session:
         board = session.board
         target_type = board.target_type
 
@@ -398,7 +398,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=level)
     DAPAccess.set_args(args.daparg)
     # Set to debug to print some of the decisions made while flashing
-    session = ConnectHelper.get_sessions_for_all_connected_probes()[0]
+    session = ConnectHelper.session_with_chosen_probe(open_session=False, **get_session_options())
     test = FlashTest()
     result = [test.run(session.board)]
     test.print_perf_info(result)

--- a/test/gdb_test.py
+++ b/test/gdb_test.py
@@ -36,7 +36,7 @@ import tempfile
 from pyOCD.tools.gdb_server import GDBServerTool
 from pyOCD.core.helpers import ConnectHelper
 from pyOCD.utility.py3_helpers import to_str_safe
-from test_util import Test, TestResult
+from test_util import (Test, TestResult, get_session_options)
 
 # TODO, c1728p9 - run script several times with
 #       with different command line parameters
@@ -87,7 +87,7 @@ TEST_RESULT_KEYS = [
 def test_gdb(board_id=None, n=0):
     temp_test_elf_name = None
     result = GdbTestResult()
-    with ConnectHelper.session_with_chosen_probe(board_id=board_id) as session:
+    with ConnectHelper.session_with_chosen_probe(board_id=board_id, **get_session_options()) as session:
         board = session.board
         memory_map = board.target.getMemoryMap()
         ram_regions = [region for region in memory_map if region.type == 'ram']

--- a/test/speed_test.py
+++ b/test/speed_test.py
@@ -28,7 +28,7 @@ sys.path.insert(0, parentdir)
 import pyOCD
 from pyOCD.core.helpers import ConnectHelper
 from pyOCD.probe.pyDAPAccess import DAPAccess
-from test_util import Test, TestResult
+from test_util import (Test, TestResult, get_session_options)
 import logging
 
 class SpeedTestResult(TestResult):
@@ -76,7 +76,7 @@ class SpeedTest(Test):
 
 
 def speed_test(board_id):
-    with ConnectHelper.session_with_chosen_probe(board_id=board_id, frequency=1000000) as session:
+    with ConnectHelper.session_with_chosen_probe(board_id=board_id, **get_session_options()) as session:
         board = session.board
         target_type = board.target_type
 
@@ -162,7 +162,7 @@ if __name__ == "__main__":
     level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(level=level)
     DAPAccess.set_args(args.daparg)
-    session = ConnectHelper.get_sessions_for_all_connected_probes()[0]
+    session = ConnectHelper.session_with_chosen_probe(open_session=False, **get_session_options())
     test = SpeedTest()
     result = [test.run(session.board)]
     test.print_perf_info(result)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -24,6 +24,13 @@ import six
 
 isPy2 = (sys.version_info[0] == 2)
 
+# Returns common option values passed in when creating test sessions.
+def get_session_options():
+    return {
+        'board_config_file' : 'test_boards.json',
+        'frequency' : 1000000, # 1 MHz
+        }
+
 class IOTee(object):
     def __init__(self, *args):
         self.outputs = list(args)


### PR DESCRIPTION
This patch adds support for connecting to STLinkV2 and V2-1 debug probes. The minimum STLink firmware version is V2J24. V3 is not fully supported yet.

STLinkV2 probes will show up and can be used just like CMSIS-DAP probes. The main difference is that you currently need to manually specify the target type using the `--target` option on command line tools (see the first known issue below).

Here is example output from `pyocd-tool list` showing both a DAPLink and STLinkV2 probe:
```
## => Board Name | Unique ID
-- -- ----------------------
 0 => FRDM-K64F [k64f] | 0240000029164e4500440012706e0007f301000097969900
 1 => STM32 STLinkV2-1 | 066EFF555051897267233656
```

Known issues:
- Currently, the board type cannot be automatically detected like it can with the DAPLink firmware. This will change when mbed-ls functionality is integrated to read board ID from the HTML file on the STLinkV2-1 USB MSC volume.
- Timeouts have been reported while debugging.
- `cortex_test.py` memory accesses fail for an unknown reason.
- `flash_test.py` fails for some ST devices. It's unclear whether this is related to STLink or the target support.
- (There are probably more issues.)

The purpose of this PR is to make the STLinkV2 support available as soon as feasible so the community can test and provide feedback. Existing functionality with CMSIS-DAP probes should not be affected in any way.

pyusb is now a dependency on all operating systems. However, libusb does not get installed automatically via pip dependency management. How to install libusb depends on your OS:
- Linux: should already be installed.
- macOS: use Homebrew: `brew install libusb`
- Windows: download libusb from [libusb.info](http://libusb.info) and place the DLL in your Python installation folder next to python.exe.