### PR TITLE
enum34 is only needed for Python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import sys
 install_requires = [
     'intelhex',
     'six',
-    'enum34',
+    "enum34;python_version<'3.4'",
     'future',
     'websocket-client',
     'intervaltree',


### PR DESCRIPTION
When building for Python3, omit the dependency
on support backported to Python2 from Python3.4

Signed-off-by: Neil Williams <codehelp@debian.org>