### PR TITLE
Multiple fixes related to gdbserver and ST boards

### DIFF
--- a/pyOCD/board/board.py
+++ b/pyOCD/board/board.py
@@ -37,7 +37,7 @@ class Board(object):
         boardConfig = self._load_board_config()
         for uid, settings in boardConfig.items():
             if uid.lower() in self.unique_id.lower():
-                log.info("Using board config settings for board %s: %s" % (session.probe.unique_id, settings))
+                log.info("Using board config settings for board %s" % (session.probe.unique_id))
                 if 'target_type' in settings:
                     self._target_type = settings['target_type']
                 if 'test_binary' in settings:
@@ -45,6 +45,7 @@ class Board(object):
 
         # Create Target and Flash instances.
         try:
+            log.info("Target type is %s", self._target_type)
             self.target = TARGET[self._target_type](session)
             self.flash = FLASH[self._target_type](self.target)
         except KeyError as exc:

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -1287,7 +1287,7 @@ class GDBServer(threading.Thread):
             threads = self.thread_provider.get_threads()
             for thread in threads:
                 hexId = "%x" % thread.unique_id
-                t = SubElement(root, 'thread', id=hexId, core="0")
+                t = SubElement(root, 'thread', id=hexId, core="0", name=thread.name, handle=hexId)
 
                 desc = thread.description
                 if desc:

--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -840,7 +840,7 @@ class GDBServer(threading.Thread):
                 idx_begin += 1
 
             # Get flash builder if there isn't one already
-            if self.flashBuilder == None:
+            if self.flashBuilder is None:
                 self.flashBuilder = self.flash.getFlashBuilder()
 
             # Add data to flash builder
@@ -850,16 +850,18 @@ class GDBServer(threading.Thread):
 
         # we need to flash everything
         elif b'FlashDone' in ops :
-            if self.hide_programming_progress:
-                progress_cb = None
-            else:
-                progress_cb = print_progress()
+            # Only program if we received data.
+            if self.flashBuilder is not None:
+                if self.hide_programming_progress:
+                    progress_cb = None
+                else:
+                    progress_cb = print_progress()
 
-            self.flashBuilder.program(chip_erase=self.chip_erase, progress_cb=progress_cb, fast_verify=self.fast_program)
+                self.flashBuilder.program(chip_erase=self.chip_erase, progress_cb=progress_cb, fast_verify=self.fast_program)
 
-            # Set flash builder to None so that on the next flash command a new
-            # object is used.
-            self.flashBuilder = None
+                # Set flash builder to None so that on the next flash command a new
+                # object is used.
+                self.flashBuilder = None
 
             self.first_run_after_reset_or_flash = True
             if self.thread_provider is not None:

--- a/pyOCD/tools/flash_tool.py
+++ b/pyOCD/tools/flash_tool.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2015 ARM Limited
+ Copyright (c) 2006-2018 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ from .. import target
 from ..core.helpers import ConnectHelper
 from ..probe.pyDAPAccess import DAPAccess
 from ..utility.progress import print_progress
+from ..utility.cmdline import convert_session_options
 from ..debug.elf.elf import (ELFBinaryFile, SH_FLAGS)
 
 LEVELS = {
@@ -103,6 +104,7 @@ parser.add_argument("-fp", "--fast_program", action="store_true",
                     help="Use only the CRC of each page to determine if it already has the same data.")
 parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
 parser.add_argument("--mass-erase", action="store_true", help="Mass erase the target device.")
+parser.add_argument("-O", "--option", metavar="OPTION", action="append", help="Set session option of form 'OPTION=VALUE'.")
 
 # Notes
 # -Currently "--unlock" does nothing since kinetis parts will automatically get unlocked
@@ -137,7 +139,8 @@ def main():
                             board_id=args.board_id,
                             target_override=args.target_override,
                             frequency=args.frequency,
-                            blocking=False)
+                            blocking=False,
+                            **convert_session_options(args.option))
         if session is None:
             print("Error: There is no debug probe connected.")
             sys.exit(1)

--- a/pyOCD/tools/gdb_server.py
+++ b/pyOCD/tools/gdb_server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013 ARM Limited
+ Copyright (c) 2006-2018 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -31,7 +31,8 @@ from ..core.session import Session
 from ..core.helpers import ConnectHelper
 from ..debug.svd import isCmsisSvdAvailable
 from ..gdbserver import GDBServer
-from ..utility.cmdline import (split_command_line, VECTOR_CATCH_CHAR_MAP, convert_vector_catch)
+from ..utility.cmdline import (split_command_line, VECTOR_CATCH_CHAR_MAP, convert_vector_catch,
+                                convert_session_options)
 from ..probe.cmsis_dap_probe import CMSISDAPProbe
 from ..probe.pyDAPAccess import DAPAccess
 from ..core.session import Session
@@ -103,6 +104,7 @@ class GDBServerTool(object):
         parser.add_argument("-c", "--command", dest="commands", metavar="CMD", action='append', nargs='+', help="Run command (OpenOCD compatibility).")
         parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
         parser.add_argument("--elf", metavar="PATH", help="Optionally specify ELF file being debugged.")
+        parser.add_argument("-O", "--option", metavar="OPTION", action="append", help="Set session option of form 'OPTION=VALUE'.")
         self.parser = parser
         return parser
 
@@ -289,7 +291,8 @@ class GDBServerTool(object):
                     session = ConnectHelper.session_with_chosen_probe(
                         board_id=self.args.board_id,
                         target_override=self.args.target_override,
-                        frequency=self.args.frequency)
+                        frequency=self.args.frequency,
+                        **convert_session_options(self.args.option))
                     if session is None:
                         print("No board selected")
                         return 1

--- a/pyOCD/tools/pyocd.py
+++ b/pyOCD/tools/pyocd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2015 ARM Limited
+ Copyright (c) 2015-2018 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ from ..probe.pyDAPAccess import DAPAccess
 from ..probe.debug_probe import DebugProbe
 from ..core.target import Target
 from ..utility import mask
+from ..utility.cmdline import convert_session_options
 
 # Make disasm optional.
 try:
@@ -564,6 +565,7 @@ class PyOCDTool(object):
         parser.add_argument("cmd", nargs='?', default=None, help="Command")
         parser.add_argument("args", nargs='*', help="Arguments for the command.")
         parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
+        parser.add_argument("-O", "--option", metavar="OPTION", action="append", help="Set session option of form 'OPTION=VALUE'.")
         return parser.parse_args()
 
     def configure_logging(self):
@@ -606,7 +608,8 @@ class PyOCDTool(object):
                             auto_unlock=False,
                             halt_on_connect=self.args.halt,
                             resume_on_disconnect=False,
-                            frequency=(self.args.clock * 1000))
+                            frequency=(self.args.clock * 1000),
+                            **convert_session_options(self.args.option))
             if self.session is None:
                 return 1
             self.board = self.session.board

--- a/pyOCD/utility/cmdline.py
+++ b/pyOCD/utility/cmdline.py
@@ -87,3 +87,24 @@ def convert_vector_catch(value):
         # Reraise an error with a more helpful message.
         raise ValueError("invalid vector catch option '{}'".format(e.args[0]))
 
+## @brief Convert a list of session option settings to a dictionary.
+#
+#
+def convert_session_options(option_list):
+    options = {}
+    if option_list is not None:
+        for o in option_list:
+            if '=' in o:
+                name, value = o.split('=')
+                name = name.strip().lower()
+                value = value.strip()
+            else:
+                name = o.strip().lower()
+                if name.startswith('no-'):
+                    name = name[3:]
+                    value = False
+                else:
+                    value = True
+            options[name] = value
+    return options
+

--- a/pyOCD/utility/progress.py
+++ b/pyOCD/utility/progress.py
@@ -34,8 +34,11 @@ class ProgressReport(object):
     
     def __call__(self, progress):
         assert progress >= 0.0
-        assert progress <= 1.0
+#         assert progress <= 1.0 # TODO restore this assert when the progress > 1 bug is fixed
         assert (progress == 0 and self.prev_progress == 1.0) or (progress >= self.prev_progress)
+        
+        if progress > 1.0:
+            log.debug("progress out of bounds: %.3f", progress)
 
         # Reset state on 0.0
         if progress == 0.0:

--- a/test/gdb_script.py
+++ b/test/gdb_script.py
@@ -213,6 +213,9 @@ def run_test():
 
         # Connect to server
         gdb_execute("target remote localhost:%d" % test_port)
+        
+        # Show memory regions, useful for debug and verification.
+        gdb_execute("info mem")
 
         # Possibly useful other commands for reference:
         # info breakpoints

--- a/test/gdb_test.py
+++ b/test/gdb_test.py
@@ -119,8 +119,11 @@ def test_gdb(board_id=None, n=0):
 
     # Generate an elf from the binary test file.
     temp_test_elf_name = tempfile.mktemp('.elf')
-    objcopyOutput = check_output([OBJCOPY, "-v", "-I", "binary", "-O", "elf32-littlearm", "-B", "arm", "-S",
-        "--set-start", "0x%x" % rom_region.start, binary_file, temp_test_elf_name], stderr=STDOUT)
+    objcopyOutput = check_output([OBJCOPY,
+        "-v", "-I", "binary", "-O", "elf32-littlearm", "-B", "arm", "-S",
+        "--set-start", "0x%x" % rom_region.start,
+        "--change-addresses", "0x%x" % rom_region.start,
+        binary_file, temp_test_elf_name], stderr=STDOUT)
     print(to_str_safe(objcopyOutput))
     # Need to escape backslashes on Windows.
     if sys.platform.startswith('win'):
@@ -148,7 +151,8 @@ def test_gdb(board_id=None, n=0):
     output_filename = "output_%s_%d.txt" % (board.target_type, n)
     with open(output_filename, "w") as f:
         program = Popen(gdb, stdin=PIPE, stdout=f, stderr=STDOUT)
-        args = ['-p=%i' % test_port, "-f=%i" % test_clock, "-b=%s" % board_id, "-T=%i" % telnet_port]
+        args = ['-p=%i' % test_port, "-f=%i" % test_clock, "-b=%s" % board_id, "-T=%i" % telnet_port,
+                '-Oboard_config_file=test_boards.json']
         server = GDBServerTool()
         server.run(args)
         program.wait()


### PR DESCRIPTION
- If gdb sends a vFlashDone command without having sent a vFlashWrite, pyOCD will no longer raise an exception.
- Added `-O` command line option to all three pyOCD tools, which allows passing arbitrary session options.
- The `Board` class logs the selected target type, in particular to help users identify when pyOCD is using a generic cortex_m target for ST boards.
- `gdb_test.py` functional test fixes.
  - Corrected option passed to `arm-none-eabi-objcopy` to set LMA. This fixes testing with devices that have internal flash at an address other than 0.
  - Passing `-Oboard_config_file=test_boards.json` to gdbserver to let it pick up local board config settings, which is required to test ST boards for the time being.
  - The gdb test script executes "info mem" to display the memory regions.
- Settings `name` and `handle` attributes in the gdbserver threads XML report. These attributes are supported in gdb 7.10 and later, and are ignored in earlier versions.
- Worked around an intermittent assertion caused by flash programming progress being greater than 1.0. Insert of asserting, it now logs a debug message.
