### PR TITLE
Fixed TI CC3220SF regression with dp attribute

### DIFF
--- a/pyOCD/target/target_CC3220SF.py
+++ b/pyOCD/target/target_CC3220SF.py
@@ -147,6 +147,6 @@ class CortexM_CC3220SF(CortexM):
             try:
                 self.writeMemory(CortexM.NVIC_AIRCR, CortexM.NVIC_AIRCR_VECTKEY | CortexM.NVIC_AIRCR_VECTRESET)
                 # Without a flush a transfer error can occur
-                self.dp.flush()
+                self.flush()
             except exceptions.TransferError:
-                self.dp.flush()
+                self.flush()


### PR DESCRIPTION
The `CortexM_CC3220SF` class was using `self.dp` to perform a transport flush. CortexM objects no longer have a `dp` attribute, and the proper way to flush changed to calling `self.flush()`.