### PR TITLE
STLink enhancements

### DIFF
--- a/docs/SESSION_OPTIONS.md
+++ b/docs/SESSION_OPTIONS.md
@@ -1,32 +1,52 @@
 Session Options
 ===============
 
-This guide documents the session options that are supported by pyOCD.
+This guide documents the session options that are supported by pyOCD and how to use them.
 
-Many of these options have dedicated command line arguments for the pyOCD tools. Any option can
-be set with the `-Ooption=value` argument.
+Many of these options have dedicated command line arguments. Arbitrary options can be set
+individually with the `-Ooption=value` command line argument. You may also use a YAML config file to
+set multiple options. And if you are using the Python API, you may pass any session options directly
+to the `ConnectHelper` methods or `Session` constructor as keyword arguments.
+
+## Config file
+
+pyOCD supports a YAML configuration file that lets you provide session options that either apply to
+all probes or to a single probe, based on the probe's unique ID.
+
+The easiest way to use a config file is to use the `--config` command line option, for instance
+`--config=myconfig.yaml`. Alternatively, you can set the `config_file` session option.
+
+The top level of the YAML file is a dictionary. The keys in the top-level dictionary must be names
+of session options, or the key `probes`. Session options are set to the value corresponding to the
+dictionary entry. Unrecognized option names are ignored.
+
+If there is a top-level `probes` key, its value must be a dictionary with keys that match a
+substring of debug probe unique IDs. Usually you would just use the complete unique ID shown by
+listing connected boards (i.e., `pyocd-gdbserver --list`). The values for the unique ID entries are
+dictionaries containing session options, just like the top level of the YAML file. Of course, these
+session options are only applied when connecting with the given probe. If the probe unique ID
+substring listed in the config file matches more than one probe, the corresponding session options
+will be applied to all matching probes.
+
+Example board config file:
+````yaml
+probes:
+  066EFF555051897267233656: # Probe's unique ID.
+    target_override:  stm32l475xg
+    test_binary:      stm32l475vg_iot01a.bin
+
+# Global options
+auto_unlock: false
+frequency: 8000000 # Set 8 MHz SWD default for all probes
+````
+
+## Options list
 
 - `auto_unlock`: (bool) If the target is locked, it will by default be automatically mass erased in
     order to gain debug access. Set this option to False to disable auto unlock.
 
-- `config_file`: (str) Path to a YAML file that lets you specify session options either globally
-    or per probe, based on the probe's unique ID. No default.
-
-    Any keys in the top-level dictionary are set as session options. If there is a top-level
-    `probes` key, its value must be a dictionary with keys uniquely matching a substring of
-    debug probe unique IDs. The values of the unique ID keys are dictionaries containing session
-    options.
-
-    Example board config file:
-    ````yaml
-    probes:
-      066EFF555051897267233656:
-        board_id:         0764
-        target_override:  stm32l475xg
-        test_binary:      stm32l475vg_iot01a.bin
-    auto_unlock: false
-    frequency: 8000000 # 8 MHz default for all probes
-    ````
+- `config_file`: (str) Relative path to a YAML config file that lets you specify session options
+    either globally or per probe. No default. The format of the file is documented above.
 
 - `frequency`: (int) SWD/JTAG frequency in Hertz. Default is 1 MHz.
 
@@ -36,7 +56,8 @@ be set with the `-Ooption=value` argument.
 
 - `target_override`: (str) Target type name to use instead of default board target or default `cortex_m`.
 
-- `test_binary`: (str) Specify the test binary file name. The binary must be in the `binaries/`
-    directory. This option is most useful when set in a board config file for running the functional
-    tests on boards that cannot be automatically detected.
+- `test_binary`: (str) Specify the test binary file name used by the functional test suite (in the
+    `test/` directory). The binary must be in the `binaries/` directory. This option is most useful
+    when set in a board config file for running the functional tests on boards that cannot be
+    automatically detected.
 

--- a/docs/SESSION_OPTIONS.md
+++ b/docs/SESSION_OPTIONS.md
@@ -8,22 +8,34 @@ be set with the `-Ooption=value` argument.
 
 - `auto_unlock`: (bool) If the target is locked, it will by default be automatically mass erased in
     order to gain debug access. Set this option to False to disable auto unlock.
-- `board_config_file`: (str) Path to a JSON file that lets you set options per probe, based on the
-    probe's unique ID. No default.
+
+- `config_file`: (str) Path to a YAML file that lets you specify session options either globally
+    or per probe, based on the probe's unique ID. No default.
+
+    Any keys in the top-level dictionary are set as session options. If there is a top-level
+    `probes` key, its value must be a dictionary with keys uniquely matching a substring of
+    debug probe unique IDs. The values of the unique ID keys are dictionaries containing session
+    options.
 
     Example board config file:
-    ````json
-    {
-        "066EFF555051897267233656" : {
-            "target_override" : "stm32l475xg",
-            "test_binary" :     "stm32l475vg_iot01a.bin"
-        },
-    }
+    ````yaml
+    probes:
+      066EFF555051897267233656:
+        board_id:         0764
+        target_override:  stm32l475xg
+        test_binary:      stm32l475vg_iot01a.bin
+    auto_unlock: false
+    frequency: 8000000 # 8 MHz default for all probes
     ````
+
 - `frequency`: (int) SWD/JTAG frequency in Hertz. Default is 1 MHz.
+
 - `halt_on_connect`: (bool) Whether to halt the target immediately upon connecting. Default is True.
+
 - `resume_on_disconnect`: (bool) Whether to resume a halted target when disconnecting. Default is True.
+
 - `target_override`: (str) Target type name to use instead of default board target or default `cortex_m`.
+
 - `test_binary`: (str) Specify the test binary file name. The binary must be in the `binaries/`
     directory. This option is most useful when set in a board config file for running the functional
     tests on boards that cannot be automatically detected.

--- a/pyocd/board/mbed_board.py
+++ b/pyocd/board/mbed_board.py
@@ -38,7 +38,6 @@ class MbedBoard(Board):
             board_info = BOARD_ID_TO_INFO[board_id]
             self._name = board_info.name
             self.native_target = board_info.target
-            self._test_binary = board_info.binary
         except KeyError:
             board_info = None
             self._name = "Unknown Board"

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -98,8 +98,8 @@ class Session(object):
     
     def _get_config(self):
         # Load config file if one was provided via options.
-        if 'config_file' in self._options:
-            configPath = self._options['config_file']
+        configPath = self._options.get('config_file', None)
+        if isinstance(configPath, six.string_types):
             try:
                 with open(configPath, 'r') as configFile:
                     return yaml.safe_load(configFile)

--- a/pyocd/probe/stlink/constants.py
+++ b/pyocd/probe/stlink/constants.py
@@ -1,0 +1,181 @@
+# pyOCD debugger
+# Copyright (c) 2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import STLinkException
+from ...core import exceptions
+import logging
+import struct
+import six
+
+class Commands:    
+    """!
+    @brief STLink V2 and V3 commands.
+    """
+    
+    # Common commands.
+    GET_VERSION = 0xf1
+    JTAG_COMMAND = 0xf2
+    DFU_COMMAND = 0xf3
+    SWIM_COMMAND = 0xf4
+    GET_CURRENT_MODE = 0xf5
+    GET_TARGET_VOLTAGE = 0xf7
+    GET_VERSION_EXT = 0xfb
+
+    # Modes returned by GET_CURRENT_MODE.
+    DEV_DFU_MODE = 0x00
+    DEV_MASS_MODE = 0x01
+    DEV_JTAG_MODE = 0x02
+    DEV_SWIM_MODE = 0x03
+
+    # Commands to exit other modes.
+    DFU_EXIT = 0x07
+    SWIM_EXIT = 0x01
+
+    # JTAG commands.
+    JTAG_READMEM_32BIT = 0x07
+    JTAG_WRITEMEM_32BIT = 0x08
+    JTAG_READMEM_8BIT = 0x0c
+    JTAG_WRITEMEM_8BIT = 0x0d
+    JTAG_EXIT = 0x21
+    JTAG_ENTER2 = 0x30
+    JTAG_GETLASTRWSTATUS2 = 0x3e # From V2J15
+    JTAG_DRIVE_NRST = 0x3c
+    SWV_START_TRACE_RECEPTION = 0x40
+    SWV_STOP_TRACE_RECEPTION = 0x41
+    SWV_GET_TRACE_NEW_RECORD_NB = 0x42
+    SWD_SET_FREQ = 0x43 # From V2J20
+    JTAG_SET_FREQ = 0x44 # From V2J24
+    JTAG_READ_DAP_REG = 0x45 # From V2J24
+    JTAG_WRITE_DAP_REG = 0x46 # From V2J24
+    JTAG_READMEM_16BIT = 0x47 # From V2J26
+    JTAG_WRITEMEM_16BIT = 0x48 # From V2J26
+    JTAG_INIT_AP = 0x4b # From V2J28
+    JTAG_CLOSE_AP_DBG = 0x4c # From V2J28
+    SET_COM_FREQ = 0x61 # V3 only, replaces SWD/JTAG_SET_FREQ
+    GET_COM_FREQ = 0x62 # V3 only
+    
+    # Parameters for JTAG_ENTER2.
+    JTAG_ENTER_SWD = 0xa3
+    JTAG_ENTER_JTAG_NO_CORE_RESET = 0xa3
+
+    # Parameters for JTAG_DRIVE_NRST.
+    JTAG_DRIVE_NRST_LOW = 0x00
+    JTAG_DRIVE_NRST_HIGH = 0x01
+    JTAG_DRIVE_NRST_PULSE = 0x02
+    
+    # Parameters for JTAG_INIT_AP and JTAG_CLOSE_AP_DBG.
+    JTAG_AP_NO_CORE = 0x00
+    JTAG_AP_CORTEXM_CORE = 0x01
+    
+    # Parameters for SET_COM_FREQ and GET_COM_FREQ.
+    JTAG_STLINK_SWD_COM = 0x00
+    JTAG_STLINK_JTAG_COM = 0x01
+    
+class Status:
+    """!
+    @brief STLink status codes and messages.
+    """
+    # Status codes.
+    JTAG_OK = 0x80
+    JTAG_UNKNOWN_ERROR = 0x01
+    JTAG_SPI_ERROR = 0x02
+    JTAG_DMA_ERROR = 0x03
+    JTAG_UNKNOWN_JTAG_CHAIN = 0x04
+    JTAG_NO_DEVICE_CONNECTED = 0x05
+    JTAG_INTERNAL_ERROR = 0x06
+    JTAG_CMD_WAIT = 0x07
+    JTAG_CMD_ERROR = 0x08
+    JTAG_GET_IDCODE_ERROR = 0x09
+    JTAG_ALIGNMENT_ERROR = 0x0a
+    JTAG_DBG_POWER_ERROR = 0x0b
+    JTAG_WRITE_ERROR = 0x0c
+    JTAG_WRITE_VERIF_ERROR = 0x0d
+    JTAG_ALREADY_OPENED_IN_OTHER_MODE = 0x0e
+    SWD_AP_WAIT = 0x10
+    SWD_AP_FAULT = 0x11
+    SWD_AP_ERROR = 0x12
+    SWD_AP_PARITY_ERROR = 0x13
+    SWD_DP_WAIT = 0x14
+    SWD_DP_FAULT = 0x15
+    SWD_DP_ERROR = 0x16
+    SWD_DP_PARITY_ERROR = 0x17
+    SWD_AP_WDATA_ERROR = 0x18
+    SWD_AP_STICKY_ERROR = 0x19
+    SWD_AP_STICKYORUN_ERROR = 0x1a
+    SWV_NOT_AVAILABLE = 0x20
+    JTAG_FREQ_NOT_SUPPORTED = 0x41
+    JTAG_UNKNOWN_CMD = 0x42
+    
+    ## Map from status code to error message.
+    MESSAGES = {
+        JTAG_UNKNOWN_ERROR : "Unknown error",
+        JTAG_SPI_ERROR : "SPI error",
+        JTAG_DMA_ERROR : "DMA error",
+        JTAG_UNKNOWN_JTAG_CHAIN : "Unknown JTAG chain",
+        JTAG_NO_DEVICE_CONNECTED : "No device connected",
+        JTAG_INTERNAL_ERROR : "Internal error",
+        JTAG_CMD_WAIT : "Command wait",
+        JTAG_CMD_ERROR : "Command error",
+        JTAG_GET_IDCODE_ERROR : "Get IDCODE error",
+        JTAG_ALIGNMENT_ERROR : "Alignment error",
+        JTAG_DBG_POWER_ERROR : "Debug power error",
+        JTAG_WRITE_ERROR : "Write error",
+        JTAG_WRITE_VERIF_ERROR : "Write verification error",
+        JTAG_ALREADY_OPENED_IN_OTHER_MODE : "Already opened in another mode",
+        SWD_AP_WAIT : "AP wait",
+        SWD_AP_FAULT : "AP fault",
+        SWD_AP_ERROR : "AP error",
+        SWD_AP_PARITY_ERROR : "AP parity error",
+        SWD_DP_WAIT : "DP wait",
+        SWD_DP_FAULT : "DP fault",
+        SWD_DP_ERROR : "DP error",
+        SWD_DP_PARITY_ERROR : "DP parity error",
+        SWD_AP_WDATA_ERROR : "AP WDATA error",
+        SWD_AP_STICKY_ERROR : "AP sticky error",
+        SWD_AP_STICKYORUN_ERROR : "AP sticky overrun error",
+        SWV_NOT_AVAILABLE : "SWV not available",
+        JTAG_FREQ_NOT_SUPPORTED : "Frequency not supported",
+        JTAG_UNKNOWN_CMD : "Unknown command",
+    }
+
+## Map from SWD frequency in Hertz to delay loop count.
+SWD_FREQ_MAP = {
+    4600000 :   0,
+    1800000 :   1, # Default
+    1200000 :   2,
+    950000 :    3,
+    650000 :    5,
+    480000 :    7,
+    400000 :    9,
+    360000 :    10,
+    240000 :    15,
+    150000 :    25,
+    125000 :    31,
+    100000 :    40,
+}
+
+## Map from JTAG frequency in Hertz to frequency divider.
+JTAG_FREQ_MAP = {
+    18000000 :  2,
+    9000000 :   4,
+    4500000 :   8,
+    2250000 :   16,
+    1120000 :   32, # Default
+    560000 :    64,
+    280000 :    128,
+    140000 :    256,
+}
+

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from . import STLinkException
+from .constants import (Commands, Status, SWD_FREQ_MAP, JTAG_FREQ_MAP)
 from ...core import exceptions
 import logging
 import struct
@@ -23,164 +24,32 @@ from enum import Enum
 
 log = logging.getLogger('stlink')
 
-## @brief STLink V2 and V3 command interface.
 class STLink(object):
+    """!
+    @brief STLink V2 and V3 command-level interface.
+    """
     class Protocol(Enum):
+        """!
+        @brief Protocol options to pass to STLink.enter_debug() method.
+        """
         SWD = 1
         JTAG = 2
     
-    # Common commands.
-    GET_VERSION = 0xf1
-    JTAG_COMMAND = 0xf2
-    DFU_COMMAND = 0xf3
-    SWIM_COMMAND = 0xf4
-    GET_CURRENT_MODE = 0xf5
-    GET_TARGET_VOLTAGE = 0xf7
-    GET_VERSION_EXT = 0xfb
-
-    # Modes returned by GET_CURRENT_MODE.
-    DEV_DFU_MODE = 0x00
-    DEV_MASS_MODE = 0x01
-    DEV_JTAG_MODE = 0x02
-    DEV_SWIM_MODE = 0x03
-
-    # Commands to exit other modes.
-    DFU_EXIT = 0x07
-    SWIM_EXIT = 0x01
-
-    # JTAG commands.
-    JTAG_READMEM_32BIT = 0x07
-    JTAG_WRITEMEM_32BIT = 0x08
-    JTAG_READMEM_8BIT = 0x0c
-    JTAG_WRITEMEM_8BIT = 0x0d
-    JTAG_EXIT = 0x21
-    JTAG_ENTER2 = 0x30
-    JTAG_GETLASTRWSTATUS2 = 0x3e # From V2J15
-    JTAG_DRIVE_NRST = 0x3c
-    SWV_START_TRACE_RECEPTION = 0x40
-    SWV_STOP_TRACE_RECEPTION = 0x41
-    SWV_GET_TRACE_NEW_RECORD_NB = 0x42
-    SWD_SET_FREQ = 0x43 # From V2J20
-    JTAG_SET_FREQ = 0x44 # From V2J24
-    JTAG_READ_DAP_REG = 0x45 # From V2J24
-    JTAG_WRITE_DAP_REG = 0x46 # From V2J24
-    JTAG_READMEM_16BIT = 0x47 # From V2J26
-    JTAG_WRITEMEM_16BIT = 0x48 # From V2J26
-    JTAG_INIT_AP = 0x4b # From V2J28
-    JTAG_CLOSE_AP_DBG = 0x4c # From V2J28
-    SET_COM_FREQ = 0x61 # V3 only, replaces SWD/JTAG_SET_FREQ
-    GET_COM_FREQ = 0x62 # V3 only
-    
-    # Parameters for JTAG_ENTER2.
-    JTAG_ENTER_SWD = 0xa3
-    JTAG_ENTER_JTAG_NO_CORE_RESET = 0xa3
-
-    # Parameters for JTAG_DRIVE_NRST.
-    JTAG_DRIVE_NRST_LOW = 0x00
-    JTAG_DRIVE_NRST_HIGH = 0x01
-    JTAG_DRIVE_NRST_PULSE = 0x02
-    
-    # Parameters for JTAG_INIT_AP and JTAG_CLOSE_AP_DBG.
-    JTAG_AP_NO_CORE = 0x00
-    JTAG_AP_CORTEXM_CORE = 0x01
-    
-    # Parameters for SET_COM_FREQ and GET_COM_FREQ.
-    JTAG_STLINK_SWD_COM = 0x00
-    JTAG_STLINK_JTAG_COM = 0x01
-    
-    # Status codes.
-    JTAG_OK = 0x80
-    JTAG_UNKNOWN_ERROR = 0x01
-    JTAG_SPI_ERROR = 0x02
-    JTAG_DMA_ERROR = 0x03
-    JTAG_UNKNOWN_JTAG_CHAIN = 0x04
-    JTAG_NO_DEVICE_CONNECTED = 0x05
-    JTAG_INTERNAL_ERROR = 0x06
-    JTAG_CMD_WAIT = 0x07
-    JTAG_CMD_ERROR = 0x08
-    JTAG_GET_IDCODE_ERROR = 0x09
-    JTAG_ALIGNMENT_ERROR = 0x0a
-    JTAG_DBG_POWER_ERROR = 0x0b
-    JTAG_WRITE_ERROR = 0x0c
-    JTAG_WRITE_VERIF_ERROR = 0x0d
-    JTAG_ALREADY_OPENED_IN_OTHER_MODE = 0x0e
-    SWD_AP_WAIT = 0x10
-    SWD_AP_FAULT = 0x11
-    SWD_AP_ERROR = 0x12
-    SWD_AP_PARITY_ERROR = 0x13
-    SWD_DP_WAIT = 0x14
-    SWD_DP_FAULT = 0x15
-    SWD_DP_ERROR = 0x16
-    SWD_DP_PARITY_ERROR = 0x17
-    SWD_AP_WDATA_ERROR = 0x18
-    SWD_AP_STICKY_ERROR = 0x19
-    SWD_AP_STICKYORUN_ERROR = 0x1a
-    SWV_NOT_AVAILABLE = 0x20
-    JTAG_FREQ_NOT_SUPPORTED = 0x41
-    JTAG_UNKNOWN_CMD = 0x42
-    
-    STATUS_MESSAGES = {
-        JTAG_UNKNOWN_ERROR : "Unknown error",
-        JTAG_SPI_ERROR : "SPI error",
-        JTAG_DMA_ERROR : "DMA error",
-        JTAG_UNKNOWN_JTAG_CHAIN : "Unknown JTAG chain",
-        JTAG_NO_DEVICE_CONNECTED : "No device connected",
-        JTAG_INTERNAL_ERROR : "Internal error",
-        JTAG_CMD_WAIT : "Command wait",
-        JTAG_CMD_ERROR : "Command error",
-        JTAG_GET_IDCODE_ERROR : "Get IDCODE error",
-        JTAG_ALIGNMENT_ERROR : "Alignment error",
-        JTAG_DBG_POWER_ERROR : "Debug power error",
-        JTAG_WRITE_ERROR : "Write error",
-        JTAG_WRITE_VERIF_ERROR : "Write verification error",
-        JTAG_ALREADY_OPENED_IN_OTHER_MODE : "Already opened in another mode",
-        SWD_AP_WAIT : "AP wait",
-        SWD_AP_FAULT : "AP fault",
-        SWD_AP_ERROR : "AP error",
-        SWD_AP_PARITY_ERROR : "AP parity error",
-        SWD_DP_WAIT : "DP wait",
-        SWD_DP_FAULT : "DP fault",
-        SWD_DP_ERROR : "DP error",
-        SWD_DP_PARITY_ERROR : "DP parity error",
-        SWD_AP_WDATA_ERROR : "AP WDATA error",
-        SWD_AP_STICKY_ERROR : "AP sticky error",
-        SWD_AP_STICKYORUN_ERROR : "AP sticky overrun error",
-        SWV_NOT_AVAILABLE : "SWV not available",
-        JTAG_FREQ_NOT_SUPPORTED : "Frequency not supported",
-        JTAG_UNKNOWN_CMD : "Unknown command",
-    }
-
-    SWD_FREQ_MAP = {
-        4600000 :   0,
-        1800000 :   1, # Default
-        1200000 :   2,
-        950000 :    3,
-        650000 :    5,
-        480000 :    7,
-        400000 :    9,
-        360000 :    10,
-        240000 :    15,
-        150000 :    25,
-        125000 :    31,
-        100000 :    40,
-    }
-    
-    JTAG_FREQ_MAP = {
-        18000000 :  2,
-        9000000 :   4,
-        4500000 :   8,
-        2250000 :   16,
-        1120000 :   32, # Default
-        560000 :    64,
-        280000 :    128,
-        140000 :    256,
-    }
-
+    ## Maximum number of bytes to send or receive for 32- and 16- bit transfers.
+    #
+    # 8-bit transfers have a maximum size of the maximum USB packet size (64 bytes for full speed).
     MAXIMUM_TRANSFER_SIZE = 1024
     
+    ## Minimum required STLink firmware version.
     MIN_JTAG_VERSION = 24
     
-    # Port number to use to indicate DP registers.
+    ## Firmware version that adds 16-bit transfers.
+    MIN_JTAG_VERSION_16BIT_XFER = 26
+    
+    ## Firmware version that adds multiple AP support.
+    MIN_JTAG_VERSION_MULTI_AP = 28
+    
+    ## Port number to use to indicate DP registers.
     DP_PORT = 0xffff
 
     def __init__(self, device):
@@ -207,7 +76,7 @@ class STLink(object):
         #     [5:0]   SWIM or MSC version
         #   Byte 2-3: ST_VID
         #   Byte 4-5: STLINK_PID
-        response = self._device.transfer([self.GET_VERSION], readSize=6)
+        response = self._device.transfer([Commands.GET_VERSION], readSize=6)
         ver, = struct.unpack('>H', response[:2])
         dev_ver = self._device.version_name
         # TODO create version bitfield constants
@@ -226,7 +95,7 @@ class STLink(object):
             #   5-7: reserved
             #   8-9: ST_VID
             #   10-11: STLINK_PID
-            response = self._device.transfer([self.GET_VERSION_EXT], readSize=12)
+            response = self._device.transfer([Commands.GET_VERSION_EXT], readSize=12)
             hw_vers, _, self._jtag_version = struct.unpack('<3B', response[0:3])
 
         # Check versions.
@@ -267,35 +136,31 @@ class STLink(object):
         return self._target_voltage
 
     def get_target_voltage(self):
-        response = self._device.transfer([self.GET_TARGET_VOLTAGE], readSize=8)
+        response = self._device.transfer([Commands.GET_TARGET_VOLTAGE], readSize=8)
         a0, a1 = struct.unpack('<II', response[:8])
         self._target_voltage = 2 * a1 * 1.2 / a0 if a0 != 0 else None
 
     def enter_idle(self):
-        response = self._device.transfer([self.GET_CURRENT_MODE], readSize=2)
-        if response[0] == self.DEV_DFU_MODE:
-            self._device.transfer([self.DFU_COMMAND, self.DFU_EXIT])
-        elif response[0] == self.DEV_JTAG_MODE:
-            self._device.transfer([self.JTAG_COMMAND, self.JTAG_EXIT])
-        elif response[0] == self.DEV_SWIM_MODE:
-            self._device.transfer([self.SWIM_COMMAND, self.SWIM_EXIT])
+        response = self._device.transfer([Commands.GET_CURRENT_MODE], readSize=2)
+        if response[0] == Commands.DEV_DFU_MODE:
+            self._device.transfer([Commands.DFU_COMMAND, Commands.DFU_EXIT])
+        elif response[0] == Commands.DEV_JTAG_MODE:
+            self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_EXIT])
+        elif response[0] == Commands.DEV_SWIM_MODE:
+            self._device.transfer([Commands.SWIM_COMMAND, Commands.SWIM_EXIT])
 
     def set_swd_frequency(self, freq=1800000):
-        if self._jtag_version < 20:
-            return
-        for f, d in self.SWD_FREQ_MAP.items():
+        for f, d in SWD_FREQ_MAP.items():
             if freq >= f:
-                response = self._device.transfer([self.JTAG_COMMAND, self.SWD_SET_FREQ, d], readSize=2)
+                response = self._device.transfer([Commands.JTAG_COMMAND, Commands.SWD_SET_FREQ, d], readSize=2)
                 self._check_status(response)
                 return
         raise STLinkException("Selected SWD frequency is too low")
 
     def set_jtag_frequency(self, freq=1120000):
-        if self._jtag_version < 24:
-            return
-        for f, d in self.JTAG_FREQ_MAP.items():
+        for f, d in JTAG_FREQ_MAP.items():
             if freq >= f:
-                response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_SET_FREQ, d], readSize=2)
+                response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_SET_FREQ, d], readSize=2)
                 self._check_status(response)
                 return
         raise STLinkException("Selected JTAG frequency is too low")
@@ -304,46 +169,46 @@ class STLink(object):
         self.enter_idle()
         
         if protocol == self.Protocol.SWD:
-            protocolParam = self.JTAG_ENTER_SWD
+            protocolParam = Commands.JTAG_ENTER_SWD
         elif protocol == self.Protocol.JTAG:
-            protocolParam = self.JTAG_ENTER_JTAG_NO_CORE_RESET
-        response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_ENTER2, protocolParam, 0], readSize=2)
+            protocolParam = Commands.JTAG_ENTER_JTAG_NO_CORE_RESET
+        response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_ENTER2, protocolParam, 0], readSize=2)
         self._check_status(response)
     
     def open_ap(self, apsel):
-        if self._jtag_version < 28:
+        if self._jtag_version < self.MIN_JTAG_VERSION_MULTI_AP:
             return
-        cmd = [self.JTAG_COMMAND, self.JTAG_INIT_AP, apsel, self.JTAG_AP_NO_CORE]
+        cmd = [Commands.JTAG_COMMAND, Commands.JTAG_INIT_AP, apsel, Commands.JTAG_AP_NO_CORE]
         response = self._device.transfer(cmd, readSize=2)
         self._check_status(response)
     
     def close_ap(self, apsel):
-        if self._jtag_version < 28:
+        if self._jtag_version < self.MIN_JTAG_VERSION_MULTI_AP:
             return
-        cmd = [self.JTAG_COMMAND, self.JTAG_CLOSE_AP_DBG, apsel]
+        cmd = [Commands.JTAG_COMMAND, Commands.JTAG_CLOSE_AP_DBG, apsel]
         response = self._device.transfer(cmd, readSize=2)
         self._check_status(response)
 
     def target_reset(self):
-        response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_DRIVE_NRST, JTAG_DRIVE_NRST_PULSE], readSize=2)
+        response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_DRIVE_NRST, Commands.JTAG_DRIVE_NRST_PULSE], readSize=2)
         self._check_status(response)
     
     def drive_nreset(self, isAsserted):
-        value = self.JTAG_DRIVE_NRST_LOW if isAsserted else self.JTAG_DRIVE_NRST_HIGH
-        response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_DRIVE_NRST, value], readSize=2)
+        value = Commands.JTAG_DRIVE_NRST_LOW if isAsserted else Commands.JTAG_DRIVE_NRST_HIGH
+        response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_DRIVE_NRST, value], readSize=2)
         self._check_status(response)
     
     def _check_status(self, response):
         status, = struct.unpack('<H', response)
-        if status != self.JTAG_OK:
-            raise STLinkException("STLink error (%d): " % status + self.STATUS_MESSAGES.get(status, "Unknown error"))
+        if status != Status.JTAG_OK:
+            raise STLinkException("STLink error (%d): " % status + Status.MESSAGES.get(status, "Unknown error"))
 
     def _read_mem(self, addr, size, memcmd, max, apsel):
         result = []
         while size:
             thisTransferSize = min(size, max)
             
-            cmd = [self.JTAG_COMMAND, memcmd]
+            cmd = [Commands.JTAG_COMMAND, memcmd]
             cmd.extend(six.iterbytes(struct.pack('<IHB', addr, thisTransferSize, apsel)))
             result += self._device.transfer(cmd, readSize=thisTransferSize)
             
@@ -351,15 +216,15 @@ class STLink(object):
             size -= thisTransferSize
             
             # Check status of this read.
-            response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_GETLASTRWSTATUS2], readSize=12)
+            response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_GETLASTRWSTATUS2], readSize=12)
             status, _, faultAddr = struct.unpack('<HHI', response[0:8])
-            if status in (self.JTAG_UNKNOWN_ERROR, self.SWD_AP_FAULT, self.SWD_DP_FAULT):
+            if status in (Status.JTAG_UNKNOWN_ERROR, Status.SWD_AP_FAULT, Status.SWD_DP_FAULT):
                 exc = exceptions.TransferFaultError()
                 exc.fault_address = faultAddr
                 exc.fault_length = thisTransferSize - (faultAddr - addr)
                 raise exc
-            elif status != self.JTAG_OK:
-                raise STLinkException("STLink error: " + self.STATUS_MESSAGES.get(status, "Unknown error"))
+            elif status != Status.JTAG_OK:
+                raise STLinkException("STLink error: " + Status.MESSAGES.get(status, "Unknown error"))
         return result
 
     def _write_mem(self, addr, data, memcmd, max, apsel):
@@ -367,7 +232,7 @@ class STLink(object):
             thisTransferSize = min(len(data), max)
             thisTransferData = data[:thisTransferSize]
             
-            cmd = [self.JTAG_COMMAND, memcmd]
+            cmd = [Commands.JTAG_COMMAND, memcmd]
             cmd.extend(six.iterbytes(struct.pack('<IHB', addr, thisTransferSize, apsel)))
             self._device.transfer(cmd, writeData=thisTransferData)
             
@@ -375,54 +240,54 @@ class STLink(object):
             data = data[thisTransferSize:]
             
             # Check status of this write.
-            response = self._device.transfer([self.JTAG_COMMAND, self.JTAG_GETLASTRWSTATUS2], readSize=12)
+            response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_GETLASTRWSTATUS2], readSize=12)
             status, _, faultAddr = struct.unpack('<HHI', response[0:8])
-            if status in (self.JTAG_UNKNOWN_ERROR, self.SWD_AP_FAULT, self.SWD_DP_FAULT):
+            if status in (Status.JTAG_UNKNOWN_ERROR, Status.SWD_AP_FAULT, Status.SWD_DP_FAULT):
                 exc = exceptions.TransferFaultError()
                 exc.fault_address = faultAddr
                 exc.fault_length = thisTransferSize - (faultAddr - addr)
                 raise exc
-            elif status != self.JTAG_OK:
-                raise STLinkException("STLink error (%x): " % status + self.STATUS_MESSAGES.get(status, "Unknown error"))
+            elif status != Status.JTAG_OK:
+                raise STLinkException("STLink error (%x): " % status + Status.MESSAGES.get(status, "Unknown error"))
 
     def read_mem32(self, addr, size, apsel):
         assert (addr & 0x3) == 0 and (size & 0x3) == 0, "address and size must be word aligned"
-        return self._read_mem(addr, size, self.JTAG_READMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
+        return self._read_mem(addr, size, Commands.JTAG_READMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
 
     def write_mem32(self, addr, data, apsel):
         assert (addr & 0x3) == 0 and (len(data) & 3) == 0, "address and size must be word aligned"
-        self._write_mem(addr, data, self.JTAG_WRITEMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
+        self._write_mem(addr, data, Commands.JTAG_WRITEMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
 
     def read_mem16(self, addr, size, apsel):
         assert (addr & 0x1) == 0 and (size & 0x1) == 0, "address and size must be half-word aligned"
 
-        if self._jtag_version < 26:
+        if self._jtag_version < self.MIN_JTAG_VERSION_16BIT_XFER:
             # 16-bit r/w is only available from J26, so revert to 8-bit accesses.
             return self.read_mem8(addr, size, apsel)
         
-        return self._read_mem(addr, size, self.JTAG_READMEM_16BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
+        return self._read_mem(addr, size, Commands.JTAG_READMEM_16BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
 
     def write_mem16(self, addr, data, apsel):
         assert (addr & 0x1) == 0 and (len(data) & 1) == 0, "address and size must be half-word aligned"
 
-        if self._jtag_version < 26:
+        if self._jtag_version < self.MIN_JTAG_VERSION_16BIT_XFER:
             # 16-bit r/w is only available from J26, so revert to 8-bit accesses.
             self.write_mem8(addr, data, apsel)
             return
         
-        self._write_mem(addr, data, self.JTAG_WRITEMEM_16BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
+        self._write_mem(addr, data, Commands.JTAG_WRITEMEM_16BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
 
     def read_mem8(self, addr, size, apsel):
-        return self._read_mem(addr, size, self.JTAG_READMEM_8BIT, self._device.max_packet_size, apsel)
+        return self._read_mem(addr, size, Commands.JTAG_READMEM_8BIT, self._device.max_packet_size, apsel)
 
     def write_mem8(self, addr, data, apsel):
-        self._write_mem(addr, data, self.JTAG_WRITEMEM_8BIT, self._device.max_packet_size, apsel)
+        self._write_mem(addr, data, Commands.JTAG_WRITEMEM_8BIT, self._device.max_packet_size, apsel)
     
     def read_dap_register(self, port, addr):
         assert ((addr & 0xf0) == 0) or (port != self.DP_PORT), "banks are not allowed for DP registers"
         assert (addr >> 16) == 0, "register address must be 16-bit"
         
-        cmd = [self.JTAG_COMMAND, self.JTAG_READ_DAP_REG]
+        cmd = [Commands.JTAG_COMMAND, Commands.JTAG_READ_DAP_REG]
         cmd.extend(six.iterbytes(struct.pack('<HH', port, addr)))
         response = self._device.transfer(cmd, readSize=8)
         self._check_status(response[:2])
@@ -432,7 +297,7 @@ class STLink(object):
     def write_dap_register(self, port, addr, value):
         assert ((addr & 0xf0) == 0) or (port != self.DP_PORT), "banks are not allowed for DP registers"
         assert (addr >> 16) == 0, "register address must be 16-bit"
-        cmd = [self.JTAG_COMMAND, self.JTAG_WRITE_DAP_REG]
+        cmd = [Commands.JTAG_COMMAND, Commands.JTAG_WRITE_DAP_REG]
         cmd.extend(six.iterbytes(struct.pack('<HHI', port, addr, value)))
         response = self._device.transfer(cmd, readSize=2)
         self._check_status(response)

--- a/pyocd/tools/flash_tool.py
+++ b/pyocd/tools/flash_tool.py
@@ -73,6 +73,7 @@ parser.add_argument("format", nargs='?', choices=supported_formats, default=None
 parser.add_argument('--version', action='version', version=__version__)
 # reserved: "-p", "--port"
 # reserved: "-c", "--cmd-port"
+parser.add_argument('--config', metavar="PATH", default=None, help="Use a YAML config file.")
 parser.add_argument("-b", "--board", dest="board_id", default=None,
                     help="Connect to board by board ID. Use -l to list all connected boards. Only a unique part of the board ID needs to be provided.")
 parser.add_argument("-l", "--list", action="store_true", dest="list_all", default=False,
@@ -138,6 +139,7 @@ def main():
         ConnectHelper.list_connected_probes()
     else:
         session = ConnectHelper.session_with_chosen_probe(
+                            config_file=self.args.config,
                             board_id=args.board_id,
                             target_override=args.target_override,
                             frequency=args.frequency,

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -73,6 +73,7 @@ class GDBServerTool(object):
         # Keep args in snyc with flash_tool.py when possible
         parser = argparse.ArgumentParser(description='PyOCD GDB Server', epilog=epilog)
         parser.add_argument('--version', action='version', version=__version__)
+        parser.add_argument('--config', metavar="PATH", default=None, help="Use a YAML config file.")
         parser.add_argument("-p", "--port", dest="port_number", type=int, default=3333, help="Set the port number that GDB server will open (default 3333).")
         parser.add_argument("-sc", "--semihost-console", dest="semihost_console_type", default="telnet", choices=('telnet', 'stdx'), help="Console for semihosting.")
         parser.add_argument("-T", "--telnet-port", dest="telnet_port", type=int, default=4444, help="Specify the telnet port for semihosting (default 4444).")
@@ -289,6 +290,7 @@ class GDBServerTool(object):
             else:
                 try:
                     session = ConnectHelper.session_with_chosen_probe(
+                        config_file=self.args.config,
                         board_id=self.args.board_id,
                         target_override=self.args.target_override,
                         frequency=self.args.frequency,

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -555,6 +555,7 @@ class PyOCDTool(object):
 
         parser = argparse.ArgumentParser(description='Target inspection utility', epilog=epi)
         parser.add_argument('--version', action='version', version=__version__)
+        parser.add_argument('--config', metavar="PATH", default=None, help="Use a YAML config file.")
         parser.add_argument("-H", "--halt", action="store_true", help="Halt core upon connect.")
         parser.add_argument("-N", "--no-init", action="store_true", help="Do not init debug system.")
         parser.add_argument('-k', "--clock", metavar='KHZ', default=DEFAULT_CLOCK_FREQ_KHZ, type=int, help="Set SWD speed in kHz. (Default 1 MHz.)")
@@ -602,6 +603,7 @@ class PyOCDTool(object):
 
             # Connect to board.
             self.session = ConnectHelper.session_with_chosen_probe(
+                            config_file=self.args.config,
                             board_id=self.args.board,
                             target_override=self.args.target,
                             init_board=False,

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(
         'pyelftools',
         'pyusb>=1.0.0b2',
         'pywinusb>=0.4.0;platform_system=="Windows"',
-        'hidapi;platform_system=="Darwin"'
+        'hidapi;platform_system=="Darwin"',
+        'pyyaml',
         ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -5,6 +5,6 @@ test_results*.txt
 automated_test_results*.txt
 automated_test_summary.txt
 test_results.xml
-test_boards.json
+test_boards.yaml
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -28,7 +28,7 @@ isPy2 = (sys.version_info[0] == 2)
 # Returns common option values passed in when creating test sessions.
 def get_session_options():
     return {
-        'board_config_file' : 'test_boards.json',
+        'config_file' : 'test_boards.yaml',
         'frequency' : 1000000, # 1 MHz
         }
 


### PR DESCRIPTION
- A couple STLink USB related fixes.
- Fixed recovery from invalid memory accesses. The `cortex_test.py` functional test now passes when using STLink.
- Reorganized STLink probe code by moving command and status constants to a new `pyocd.probe.stlink.constants` module.

Also included in the PR is a change to turn the board config file (added in a recent PR) into a general pyOCD configuration file. It still serves the purpose of board-specific config that is required to run the functional tests on targets via STLink. The documentation for config files is in the `docs/SESSION_OPTIONS.md` file under the `config_file` option.