### PR TITLE
Using session options for gdb server options

### DIFF
--- a/docs/SESSION_OPTIONS.md
+++ b/docs/SESSION_OPTIONS.md
@@ -28,6 +28,8 @@ session options are only applied when connecting with the given probe. If the pr
 substring listed in the config file matches more than one probe, the corresponding session options
 will be applied to all matching probes.
 
+Options set in the config file will override any options set via the command line.
+
 Example board config file:
 ````yaml
 probes:
@@ -40,20 +42,18 @@ auto_unlock: false
 frequency: 8000000 # Set 8 MHz SWD default for all probes
 ````
 
+
 ## Options list
 
 - `auto_unlock`: (bool) If the target is locked, it will by default be automatically mass erased in
-    order to gain debug access. Set this option to False to disable auto unlock.
+    order to gain debug access. Set this option to False to disable auto unlock. Default is True.
 
 - `config_file`: (str) Relative path to a YAML config file that lets you specify session options
-    either globally or per probe. No default. The format of the file is documented above.
+    either globally or per probe. No default. The format of the file is documented above. No default.
 
 - `frequency`: (int) SWD/JTAG frequency in Hertz. Default is 1 MHz.
 
 - `halt_on_connect`: (bool) Whether to halt the target immediately upon connecting. Default is True.
-
-- `report_core_number`: (bool) Whether gdb server should report core number as part of the
-    per-thread information. Default is False.
 
 - `resume_on_disconnect`: (bool) Whether to resume a halted target when disconnecting. Default is True.
 
@@ -64,3 +64,65 @@ frequency: 8000000 # Set 8 MHz SWD default for all probes
     when set in a board config file for running the functional tests on boards that cannot be
     automatically detected.
 
+
+## GDB server options list
+
+These session options are currently only applied when running the GDB server.
+
+- `chip_erase`: (bool) Whether to perform a chip erase or sector erases when programming
+    flash. If not set, pyOCD will use the fastest erase method.
+
+- `enable_semihosting`: (bool) Set to True to handle semihosting requests. Also see the
+    `semihost_console_type` option. Default is False.
+
+- `fast_program`: (bool) Setting this option to True will use CRC checks of existing flash sector
+    contents to determine whether pages need to be programmed. Default is False.
+
+- `gdbserver_port`: (int) Base TCP port for the gdbserver. The core number, which is 0 for the
+    primary core, will be added to this value. Default is 3333.
+
+- `hide_programming_progress`: (bool) Disables flash programming progress bar when True. Default is
+    False.
+
+- `persist`: (bool) If True, the GDB server will not exit after GDB disconnects. Default is False.
+
+- `report_core_number`: (bool) Whether gdb server should report core number as part of the
+    per-thread information. Default is False.
+
+- `semihost_console_type`: (str) If set to "telnet" then the semihosting telnet server will be
+    started, otherwise semihosting will print to the console. Default is "telnet".
+
+- `semihost_use_syscalls`: (bool) Whether to use GDB syscalls for semihosting file access operations,
+    or to have pyOCD perform the operations. This is most useful if GDB is running on a remote
+    system. Default is False.
+
+- `serve_local_only`: (bool) When this option is True, the GDB server and semihosting telnet ports
+    are only served on localhost, making them inaccessible across the network. If False, you can
+    connect to these ports from any machine that is on the same network. Default is True.
+
+- `soft_bkpt_as_hard`: (bool) Whether to force all breakpoints to be hardware breakpoints. Default
+    is False.
+
+- `step_into_interrupt`: (bool) Set this option to True to enable interrupts when performing step
+    operations. Otherwise interrupts will be disabled and step operations cannot be interrupted.
+    Default is False.
+
+- `telnet_port`: (int) Base TCP port number for the semihosting telnet server. The core number,
+    which will be 0 for the primary core, is added to this value. Default is 4444.
+
+- `vector_catch`: (str) Enable vector catch sources, one letter per enabled source in any order, or
+    `all` or `none`.
+
+    The source letters are:
+    - `h`=hard fault
+    - `b`=bus fault
+    - `m`=mem fault
+    - `i`=irq err
+    - `s`=state err
+    - `c`=check err
+    - `p`=nocp
+    - `r`=reset
+    - `a`=all
+    - `n`=none
+
+    Default is only hard fault enabled.

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -195,7 +195,7 @@ class GDBServerPacketIOThread(threading.Thread):
             self._buffer = self._buffer[1:]
             if LOG_ACK:
                 self.log.debug('got ack: %s', c)
-            if c == '-':
+            if c == b'-':
                 # Handle nack from gdb
                 self._write_packet(self._last_packet)
                 return


### PR DESCRIPTION
Instead of passing the `options` parameter to `GDBServer`, it now uses session options. The gdb server session options are documented in SESSION_OPTIONS.md.

Included a single-character Python 3 fix in the gdb server. It would only have caused a problem if gdb nack'd a packet.