### PR TITLE
Fix reference to self in pyocd-flashtool

### DIFF
--- a/pyocd/tools/flash_tool.py
+++ b/pyocd/tools/flash_tool.py
@@ -139,7 +139,7 @@ def main():
         ConnectHelper.list_connected_probes()
     else:
         session = ConnectHelper.session_with_chosen_probe(
-                            config_file=self.args.config,
+                            config_file=args.config,
                             board_id=args.board_id,
                             target_override=args.target_override,
                             frequency=args.frequency,


### PR DESCRIPTION
Fixes a copy and paste issue introduced in 0.13.0 with the config file support.