### PR TITLE
RTOS fixes

### DIFF
--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -572,7 +572,7 @@ class CortexM(Target, CoreSightComponent):
         self.notify(Notification(event=Target.EVENT_POST_RUN, source=self, data=Target.RUN_TYPE_STEP))
 
     def clear_debug_cause_bits(self):
-        self.write_memory(CortexM.DFSR, CortexM.DFSR_DWTTRAP | CortexM.DFSR_BKPT | CortexM.DFSR_HALTED)
+        self.write_memory(CortexM.DFSR, CortexM.DFSR_VCATCH | CortexM.DFSR_DWTTRAP | CortexM.DFSR_BKPT | CortexM.DFSR_HALTED)
 
     def reset(self, software_reset=None):
         """
@@ -944,6 +944,10 @@ class CortexM(Target, CoreSightComponent):
 
     def is_debug_trap(self):
         debugEvents = self.read_memory(CortexM.DFSR) & (CortexM.DFSR_DWTTRAP | CortexM.DFSR_BKPT | CortexM.DFSR_HALTED)
+        return debugEvents != 0
+
+    def is_vector_catch(self):
+        debugEvents = self.read_memory(CortexM.DFSR) & CortexM.DFSR_VCATCH
         return debugEvents != 0
 
     def get_target_context(self, core=None):

--- a/pyocd/gdbserver/context_facade.py
+++ b/pyocd/gdbserver/context_facade.py
@@ -117,12 +117,16 @@ class GDBDebugContextFacade(object):
         if self._context.core.is_debug_trap():
             return signals.SIGTRAP
 
-        fault = self._context.read_core_register('ipsr')
-        try:
-            signal = FAULT[fault]
-        except:
-            # If not a fault then default to SIGSTOP
-            signal = signals.SIGSTOP
+        # If not a fault then default to SIGSTOP
+        signal = signals.SIGSTOP
+
+        if self._context.core.is_vector_catch():
+            fault = self._context.core.read_core_register('ipsr')
+            try:
+                signal = FAULT[fault]
+            except IndexError:
+                pass
+
         logging.debug("GDB lastSignal: %d", signal)
         return signal
 

--- a/pyocd/rtos/argon.py
+++ b/pyocd/rtos/argon.py
@@ -180,16 +180,12 @@ class ArgonThreadContext(DebugContext):
             swStacked = 0x60
 
         for reg in reg_list:
-            # Check for regs we can't access.
-            if inException:
-                if reg == 18 or reg == 13: # PSP
-                    log.debug("psp = 0x%08x", sp + hwStacked)
-                    reg_vals.append(sp + hwStacked)
-                    continue
-
             # Must handle stack pointer specially.
             if reg == 13:
-                reg_vals.append(sp + swStacked + hwStacked)
+                if inException:
+                    reg_vals.append(sp + hwStacked)
+                else:
+                    reg_vals.append(sp + swStacked + hwStacked)
                 continue
 
             # Look up offset for this register on the stack.

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -201,15 +201,12 @@ class FreeRTOSThreadContext(DebugContext):
                 log.debug("Transfer error while reading thread's saved LR")
 
         for reg in reg_list:
-            # Check for regs we can't access.
-            if inException:
-                if reg == 18 or reg == 13: # PSP
-                    reg_vals.append(sp + hwStacked)
-                    continue
-
             # Must handle stack pointer specially.
             if reg == 13:
-                reg_vals.append(sp + swStacked + hwStacked)
+                if inException:
+                    reg_vals.append(sp + hwStacked)
+                else:
+                    reg_vals.append(sp + swStacked + hwStacked)
                 continue
 
             # Look up offset for this register on the stack.

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -165,13 +165,17 @@ class FreeRTOSThreadContext(DebugContext):
         reg_list = [register_name_to_index(reg) for reg in reg_list]
         reg_vals = []
 
-        inException = self._parent.read_core_register('ipsr') > 0
         isCurrent = self._thread.is_current
+        inException = isCurrent and self._parent.read_core_register('ipsr') > 0
 
         # If this is the current thread and we're not in an exception, just read the live registers.
         if isCurrent and not inException:
             return self._parent.read_core_registers_raw(reg_list)
 
+        # Because of above tests, from now on, inException implies isCurrent;
+        # we are generating the thread view for the RTOS thread where the
+        # exception occurred; the actual Handler Mode thread view is produced
+        # by HandlerModeThread
         sp = self._thread.get_stack_pointer()
 
         # Determine which register offset table to use and the offsets past the saved state.
@@ -197,7 +201,7 @@ class FreeRTOSThreadContext(DebugContext):
 
         for reg in reg_list:
             # Check for regs we can't access.
-            if isCurrent and inException:
+            if inException:
                 if reg in self.EXCEPTION_UNAVAILABLE_REGS:
                     reg_vals.append(0)
                     continue
@@ -215,7 +219,7 @@ class FreeRTOSThreadContext(DebugContext):
             if spOffset is None:
                 reg_vals.append(self._parent.read_core_register(reg))
                 continue
-            if isCurrent and inException:
+            if inException:
                 spOffset -= swStacked
 
             try:

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -176,7 +176,11 @@ class FreeRTOSThreadContext(DebugContext):
         # we are generating the thread view for the RTOS thread where the
         # exception occurred; the actual Handler Mode thread view is produced
         # by HandlerModeThread
-        sp = self._thread.get_stack_pointer()
+        if inException:
+            # Reasonable to assume PSP is still valid
+            sp = self._parent.read_core_register('psp')
+        else:
+            sp = self._thread.get_stack_pointer()
 
         # Determine which register offset table to use and the offsets past the saved state.
         hwStacked = 0x20
@@ -263,16 +267,12 @@ class FreeRTOSThread(TargetThread):
             self._name = "Unnamed"
 
     def get_stack_pointer(self):
-        if self.is_current:
-            # Read live process stack.
-            sp = self._target_context.read_core_register('psp')
-        else:
-            # Get stack pointer saved in thread struct.
-            try:
-                sp = self._target_context.read32(self._base + THREAD_STACK_POINTER_OFFSET)
-            except exceptions.TransferError:
-                log.debug("Transfer error while reading thread's stack pointer @ 0x%08x", self._base + THREAD_STACK_POINTER_OFFSET)
-        return sp
+        # Get stack pointer saved in thread struct.
+        try:
+            return self._target_context.read32(self._base + THREAD_STACK_POINTER_OFFSET)
+        except exceptions.TransferError:
+            log.debug("Transfer error while reading thread's stack pointer @ 0x%08x", self._base + THREAD_STACK_POINTER_OFFSET)
+            return 0
 
     @property
     def state(self):

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -185,9 +185,13 @@ class FreeRTOSThreadContext(DebugContext):
         table = self.NOFPU_REGISTER_OFFSETS
         if self._has_fpu:
             try:
-                # Read stacked exception return LR.
-                offset = self.FPU_BASIC_REGISTER_OFFSETS[-1]
-                exceptionLR = self._parent.read32(sp + offset)
+                if inException and self._parent.core.is_vector_catch():
+                    # Vector catch has just occurred, take live LR
+                    exceptionLR = self._parent.read_core_register('lr')
+                else:
+                    # Read stacked exception return LR.
+                    offset = self.FPU_BASIC_REGISTER_OFFSETS[-1]
+                    exceptionLR = self._parent.read32(sp + offset)
 
                 # Check bit 4 of the saved exception LR to determine if FPU registers were stacked.
                 if (exceptionLR & (1 << 4)) != 0:

--- a/pyocd/rtos/provider.py
+++ b/pyocd/rtos/provider.py
@@ -111,6 +111,10 @@ class ThreadProvider(object):
     def is_valid_thread_id(self, threadId):
         raise NotImplementedError()
 
+    # From GDB's point of view, where Handler Mode is a thread
     def get_current_thread_id(self):
         raise NotImplementedError()
 
+    # From OS's point of view, so the current OS thread even in Handler Mode
+    def get_actual_current_thread_id(self):
+        raise NotImplementedError()

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -175,15 +175,13 @@ class RTXThreadContext(DebugContext):
                 log.debug("Transfer error while reading thread's saved LR")
 
         for reg in reg_list:
-            # Check for regs we can't access.
-            if inException:
-                if reg == 18 or reg == 13: # PSP
-                    reg_vals.append(sp + hwStacked)
-                    continue
 
             # Must handle stack pointer specially.
             if reg == 13:
-                reg_vals.append(sp + swStacked + hwStacked)
+                if inException:
+                    reg_vals.append(sp + hwStacked)
+                else:
+                    reg_vals.append(sp + swStacked + hwStacked)
                 continue
 
             # Look up offset for this register on the stack.

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -154,7 +154,11 @@ class RTXThreadContext(DebugContext):
         # we are generating the thread view for the RTOS thread where the
         # exception occurred; the actual Handler Mode thread view is produced
         # by HandlerModeThread
-        sp = self._thread.get_stack_pointer()
+        if inException:
+            # Reasonable to assume PSP is still valid
+            sp = self._parent.read_core_register('psp')
+        else:
+            sp = self._thread.get_stack_pointer()
 
         # Determine which register offset table to use and the offsets past the saved state.
         hwStacked = 0x20
@@ -278,16 +282,12 @@ class RTXTargetThread(TargetThread):
         return self._provider.get_actual_current_thread_id() == self._base
 
     def get_stack_pointer(self):
-        if self.is_current:
-            # Read live process stack.
-            sp = self._target_context.read_core_register('psp')
-        else:
-            # Get stack pointer saved in thread struct.
-            try:
-                sp = self._target_context.read32(self._base + RTXTargetThread.SP_OFFSET)
-            except exceptions.TransferError:
-                log.debug("Transfer error while reading thread's stack pointer @ 0x%08x", self._base + RTXTargetThread.SP_OFFSET)
-        return sp
+        # Get stack pointer saved in thread struct.
+        try:
+            return self._target_context.read32(self._base + RTXTargetThread.SP_OFFSET)
+        except exceptions.TransferError:
+            log.debug("Transfer error while reading thread's stack pointer @ 0x%08x", self._base + RTXTargetThread.SP_OFFSET)
+            return 0
 
     def get_stack_frame(self):
         return self._target_context.read8(self._base + RTXTargetThread.STACKFRAME_OFFSET)

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -143,13 +143,17 @@ class RTXThreadContext(DebugContext):
         reg_list = [register_name_to_index(reg) for reg in reg_list]
         reg_vals = []
 
-        inException = self._parent.read_core_register('ipsr') > 0
         isCurrent = self._thread.is_current
+        inException = isCurrent and self._parent.read_core_register('ipsr') > 0
 
         # If this is the current thread and we're not in an exception, just read the live registers.
         if isCurrent and not inException:
             return self._parent.read_core_registers_raw(reg_list)
 
+        # Because of above tests, from now on, inException implies isCurrent;
+        # we are generating the thread view for the RTOS thread where the
+        # exception occurred; the actual Handler Mode thread view is produced
+        # by HandlerModeThread
         sp = self._thread.get_stack_pointer()
 
         # Determine which register offset table to use and the offsets past the saved state.
@@ -171,7 +175,7 @@ class RTXThreadContext(DebugContext):
 
         for reg in reg_list:
             # Check for regs we can't access.
-            if isCurrent and inException:
+            if inException:
                 if reg in self.EXCEPTION_UNAVAILABLE_REGS:
                     reg_vals.append(0)
                     continue
@@ -189,7 +193,7 @@ class RTXThreadContext(DebugContext):
             if spOffset is None:
                 reg_vals.append(self._parent.read_core_register(reg))
                 continue
-            if isCurrent and inException:
+            if inException:
                 spOffset -= swStacked
 
             try:

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -286,7 +286,13 @@ class RTXTargetThread(TargetThread):
             return 0
 
     def get_stack_frame(self):
-        return self._target_context.read8(self._base + RTXTargetThread.STACKFRAME_OFFSET)
+        # Get "stack frame" (EXC_RETURN value from LR) saved in thread struct.
+        # Note that RTX5 only stores bottom byte - hide that by extending.
+        try:
+            return self._target_context.read8(self._base + RTXTargetThread.STACKFRAME_OFFSET) | 0xFFFFFF00
+        except exceptions.TransferError:
+            log.debug("Transfer error while reading thread's stack frame @ 0x%08x", self._base + RTXTargetThread.STACKFRAME_OFFSET)
+            return 0xFFFFFFFD
 
 ## @brief Thread provider for RTX5 RTOS.
 class RTX5ThreadProvider(ThreadProvider):

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -271,7 +271,7 @@ class RTXTargetThread(TargetThread):
 
     @property
     def is_current(self):
-        return self._provider.get_current_thread_id() == self._base
+        return self._provider.get_actual_current_thread_id() == self._base
 
     def get_stack_pointer(self):
         if self.is_current:
@@ -408,6 +408,11 @@ class RTX5ThreadProvider(ThreadProvider):
             return None
         if self._target_context.read_core_register('ipsr') > 0:
             return HandlerModeThread.UNIQUE_ID
+        return self.get_actual_current_thread_id()
+
+    def get_actual_current_thread_id(self):
+        if not self.is_enabled:
+            return None
         self.update_threads()
         return self._current_id
 

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -130,9 +130,6 @@ class RTXThreadContext(DebugContext):
                  # (reserved word: 196)
             }
 
-    # Registers that are not available on the stack for exceptions.
-    EXCEPTION_UNAVAILABLE_REGS = (4, 5, 6, 7, 8, 9, 10, 11)
-
     def __init__(self, parentContext, thread):
         super(RTXThreadContext, self).__init__(parentContext.core)
         self._parent = parentContext
@@ -180,9 +177,6 @@ class RTXThreadContext(DebugContext):
         for reg in reg_list:
             # Check for regs we can't access.
             if inException:
-                if reg in self.EXCEPTION_UNAVAILABLE_REGS:
-                    reg_vals.append(0)
-                    continue
                 if reg == 18 or reg == 13: # PSP
                     reg_vals.append(sp + hwStacked)
                     continue
@@ -201,7 +195,11 @@ class RTXThreadContext(DebugContext):
                 spOffset -= swStacked
 
             try:
-                reg_vals.append(self._parent.read32(sp + spOffset))
+                if spOffset >= 0:
+                    reg_vals.append(self._parent.read32(sp + spOffset))
+                else:
+                    # Not available - try live one
+                    reg_vals.append(self._parent.read_core_register(reg))
             except exceptions.TransferError:
                 reg_vals.append(0)
 

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -80,14 +80,18 @@ class ZephyrThreadContext(DebugContext):
         reg_list = [register_name_to_index(reg) for reg in reg_list]
         reg_vals = []
 
-        inException = self._parent.read_core_register('ipsr') > 0
         isCurrent = self._thread.is_current
+        inException = isCurrent and self._parent.read_core_register('ipsr') > 0
 
         # If this is the current thread and we're not in an exception, just read the live registers.
         if isCurrent and not inException:
             log.debug("Reading live registers")
             return self._parent.read_core_registers_raw(reg_list)
 
+        # Because of above tests, from now on, inException implies isCurrent;
+        # we are generating the thread view for the RTOS thread where the
+        # exception occurred; the actual Handler Mode thread view is produced
+        # by HandlerModeThread
         sp = self._thread.get_stack_pointer()
         exceptionFrame = 0x20
 

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -102,7 +102,7 @@ class ZephyrThreadContext(DebugContext):
         for reg in reg_list:
 
             # If this is a stack pointer register, add an offset to account for the exception stack frame
-            if reg == 13 or reg == 18:
+            if reg == 13:
                 val = sp + exceptionFrame
                 log.debug("Reading register %d = 0x%x", reg, val)
                 reg_vals.append(val)

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -92,7 +92,11 @@ class ZephyrThreadContext(DebugContext):
         # we are generating the thread view for the RTOS thread where the
         # exception occurred; the actual Handler Mode thread view is produced
         # by HandlerModeThread
-        sp = self._thread.get_stack_pointer()
+        if inException:
+            # Reasonable to assume PSP is still valid
+            sp = self._parent.read_core_register('psp')
+        else:
+            sp = self._thread.get_stack_pointer()
         exceptionFrame = 0x20
 
         for reg in reg_list:
@@ -176,17 +180,13 @@ class ZephyrThread(TargetThread):
             log.debug("Transfer error while reading thread info")
 
     def get_stack_pointer(self):
-        if self.is_current:
-            # Read live process stack.
-            sp = self._target_context.read_core_register('psp')
-        else:
-            # Get stack pointer saved in thread struct.
-            addr = self._base + self._offsets["t_stack_ptr"]
-            try:
-                sp = self._target_context.read32(addr)
-            except exceptions.TransferError:
-                log.debug("Transfer error while reading thread's stack pointer @ 0x%08x", addr)
-        return sp
+        # Get stack pointer saved in thread struct.
+        addr = self._base + self._offsets["t_stack_ptr"]
+        try:
+            return self._target_context.read32(addr)
+        except exceptions.TransferError:
+            log.debug("Transfer error while reading thread's stack pointer @ 0x%08x", addr)
+            return 0
 
     def update_info(self):
         try:


### PR DESCRIPTION
All the fairly-unarguable fixes from #430

* RTOS: Correct stack offset calcs 
* RTX5: Improve "current thread" logic
* RTOS: adjust `inException` flag
* RTOS: Simplify `XXXThread::get_stack_pointer()`
* RTOS: improve "exception unavailable" registers
* RTOS: Tidy SP read out and don't mess with PSP
* RTX5: Tighten Thread LR read - match SP code
* Add `CortexM::is_vector_catch`
* RTX5/FreeRTOS: Go for live LR on vector catch
* GDB: Only do SIGSEGV etc on vector catch
