### PR TITLE
Correct naming error in exception-showing

### DIFF
--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -977,7 +977,7 @@ class CortexM(Target, CoreSightComponent):
             if exc_num == 0 and not name_thread:
                 return None
             else:
-                return self.CORE_EXCEPTION[num]
+                return self.CORE_EXCEPTION[exc_num]
         else:
             irq_num = exc_num - len(self.CORE_EXCEPTION)
             name = None


### PR DESCRIPTION
Late edit to #437 missed a rename of `num` to `exc_num` - code was
showing external interrupts successfully, but trapped if faced with an
internal exception.