### PR TITLE
Fixed gdb server not being accessible via localhost

### DIFF
--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -267,7 +267,7 @@ class GDBServer(threading.Thread):
         self.flash = self.board.flash
         self.abstract_socket = None
         port_urlWSS = session.options.get('gdbserver_port', 3333)
-        if isinstance(port_urlWSS, str) == True:
+        if isinstance(port_urlWSS, str) is True:
             self.port = 0
             self.wss_server = port_urlWSS
         else:
@@ -310,7 +310,7 @@ class GDBServer(threading.Thread):
         self.did_init_thread_providers = False
         self.current_thread_id = 0
         self.first_run_after_reset_or_flash = True
-        if self.wss_server == None:
+        if self.wss_server is None:
             self.abstract_socket = GDBSocket(self.port, self.packet_size)
             if self.serve_local_only:
                 self.abstract_socket.host = 'localhost'
@@ -584,7 +584,7 @@ class GDBServer(threading.Thread):
         # handle hardware breakpoint Z1/z1
         if data[1:2] == b'1' or (self.soft_bkpt_as_hard and data[1:2] == b'0'):
             if data[0:1] == b'Z':
-                if self.target.set_breakpoint(addr, Target.BREAKPOINT_HW) == False:
+                if self.target.set_breakpoint(addr, Target.BREAKPOINT_HW) is False:
                     return self.create_rsp_packet(b'E01') #EPERM
             else:
                 self.target.remove_breakpoint(addr)
@@ -605,7 +605,7 @@ class GDBServer(threading.Thread):
 
         size = int(split[2], 16)
         if data[0:1] == b'Z':
-            if self.target.set_watchpoint(addr, size, watchpoint_type) == False:
+            if self.target.set_watchpoint(addr, size, watchpoint_type) is False:
                 return self.create_rsp_packet(b'E01') #EPERM
         else:
             self.target.remove_watchpoint(addr, size, watchpoint_type)

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -312,11 +312,11 @@ class GDBServer(threading.Thread):
         self.first_run_after_reset_or_flash = True
         if self.wss_server == None:
             self.abstract_socket = GDBSocket(self.port, self.packet_size)
+            if self.serve_local_only:
+                self.abstract_socket.host = 'localhost'
             self.abstract_socket.init()
             # Read back bound port in case auto-assigned (port 0)
             self.port = self.abstract_socket.port
-            if self.serve_local_only:
-                self.abstract_socket.host = 'localhost'
         else:
             self.abstract_socket = GDBWebSocket(self.wss_server)
 


### PR DESCRIPTION
When `--allow-remote` was not set, `GDBServer` was setting the socket's host to "localhost" only after it was inited. This bug was introduced in #455. Aside from being a problem for users, this caused `gdb_test.py` to fail. (Not sure why #455 still passed in CI.)