### PR TITLE
flash/loader: fix python3 compatibility issue with hex files

### DIFF
--- a/pyocd/flash/loader.py
+++ b/pyocd/flash/loader.py
@@ -122,7 +122,11 @@ class FileProgrammer(object):
         try:
             # Open the file if a path was provided.
             if isPath:
-                file_obj = open(file_or_path, "rb")
+                mode = 'rb'
+                if format == 'hex':
+                    # hex file must be read as plain text file
+                    mode = 'r'
+                file_obj = open(file_or_path, mode)
             else:
                 file_obj = file_or_path
 


### PR DESCRIPTION
This PR is fixing a compatibility issue with Python3 when trying to load an hex file.

I had this issue using Python 3.6 while trying to load a micro:bit firmware in hex format.
Tested with Python 2 and 3 and now it works as before.

Since this is my first PR on the project, I apologize if I'm not correctly following any development guideline. If a non regression test is needed, I'll be happy to write one but would need a bit of help.

Related to https://github.com/RIOT-OS/RIOT/pull/9847