### PR TITLE
Lock intervaltree version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'enum34;python_version<"3.4"',
         'future',
         'websocket-client',
-        'intervaltree',
+        'intervaltree<3.0',
         'colorama',
         'pyelftools',
         'pyusb>=1.0.0b2',


### PR DESCRIPTION
intervaltree version 3.0 (pypi released 4h ago) has backwards incompatible changes: https://github.com/chaimleib/intervaltree/tree/dev