### PR TITLE
Fixed MEM_AP memory transfers for non-zero APSEL

### DIFF
--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -326,7 +326,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         self.write_reg(MEM_AP_CSW, CSW_VALUE | CSW_SIZE32)
         self.write_reg(MEM_AP_TAR, addr)
         try:
-            self.link.write_ap_multiple(MEM_AP_DRW, data)
+            self.link.write_ap_multiple((self.ap_num << APSEL_SHIFT) | MEM_AP_DRW, data)
         except exceptions.TransferFaultError as error:
             # Annotate error with target address.
             self._handle_error(error, num)
@@ -351,7 +351,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         self.write_reg(MEM_AP_CSW, CSW_VALUE | CSW_SIZE32)
         self.write_reg(MEM_AP_TAR, addr)
         try:
-            resp = self.link.read_ap_multiple(MEM_AP_DRW, size)
+            resp = self.link.read_ap_multiple((self.ap_num << APSEL_SHIFT) | MEM_AP_DRW, size)
         except exceptions.TransferFaultError as error:
             # Annotate error with target address.
             self._handle_error(error, num)


### PR DESCRIPTION
The `_write_block32()` and `_read_block32`() methods of `MEM_AP` were not setting the APSEL on the address when calling into the probe. This bug would only affect multicore platforms.