### PR TITLE
Fix core register access APIs

### DIFF
--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -227,14 +227,14 @@ class CoreSightTarget(Target):
     def write_core_register(self, id, data):
         return self.selected_core.write_core_register(id, data)
 
-    def read_core_register(self, reg):
-        return self.selected_core.read_core_register(reg)
+    def read_core_register_raw(self, reg):
+        return self.selected_core.read_core_register_raw(reg)
 
     def read_core_registers_raw(self, reg_list):
         return self.selected_core.read_core_registers_raw(reg_list)
 
-    def write_core_register(self, reg, data):
-        self.selected_core.write_core_register(reg, data)
+    def write_core_register_raw(self, reg, data):
+        self.selected_core.write_core_register_raw(reg, data)
 
     def write_core_registers_raw(self, reg_list, data_list):
         self.selected_core.write_core_registers_raw(reg_list, data_list)

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -125,13 +125,13 @@ class Target(MemoryInterface, Notifier):
     def write_core_register(self, id, data):
         raise NotImplementedError()
 
-    def read_core_register(self, reg):
+    def read_core_register_raw(self, reg):
         raise NotImplementedError()
 
     def read_core_registers_raw(self, reg_list):
         raise NotImplementedError()
 
-    def write_core_register(self, reg, data):
+    def write_core_register_raw(self, reg, data):
         raise NotImplementedError()
 
     def write_core_registers_raw(self, reg_list, data_list):

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -764,7 +764,7 @@ class CortexM(Target, CoreSightComponent):
         Unpack floating point register values
         """
         regIndex = register_name_to_index(reg)
-        regValue = self.read_core_register(regIndex)
+        regValue = self.read_core_register_raw(regIndex)
         # Convert int to float.
         if is_float_register(regIndex):
             regValue = conversion.u32_to_float32(regValue)
@@ -772,7 +772,7 @@ class CortexM(Target, CoreSightComponent):
             regValue = conversion.u64_to_float64(regValue)
         return regValue
 
-    def read_core_register(self, reg):
+    def read_core_register_raw(self, reg):
         """
         read a core register (r0 .. r16).
         If reg is a string, find the number associated to this register
@@ -883,7 +883,7 @@ class CortexM(Target, CoreSightComponent):
             data = conversion.float64_to_u64(data)
         self.write_core_register_raw(regIndex, data)
 
-    def write_core_register(self, reg, data):
+    def write_core_register_raw(self, reg, data):
         """
         write a core register (r0 .. r16)
         If reg is a string, find the number associated to this register
@@ -925,9 +925,9 @@ class CortexM(Target, CoreSightComponent):
                 singleHigh = (data >> 32) & 0xffffffff
                 reg_data_list += [(-reg, singleLow), (-reg + 1, singleHigh)]
             elif is_cfbp_subregister(reg) and cfbpValue is None:
-                cfbpValue = self.read_core_register(CORE_REGISTER['cfbp'])
+                cfbpValue = self.read_core_register_raw(CORE_REGISTER['cfbp'])
             elif is_psr_subregister(reg) and xpsrValue is None:
-                xpsrValue = self.read_core_register(CORE_REGISTER['xpsr'])
+                xpsrValue = self.read_core_register_raw(CORE_REGISTER['xpsr'])
             else:
                 # Other register, just copy directly.
                 reg_data_list.append((reg, data))

--- a/pyocd/debug/context.py
+++ b/pyocd/debug/context.py
@@ -61,13 +61,13 @@ class DebugContext(MemoryInterface):
         Unpack floating point register values
         """
         regIndex = register_name_to_index(reg)
-        regValue = self.read_core_register(regIndex)
+        regValue = self.read_core_register_raw(regIndex)
         # Convert int to float.
         if is_float_register(regIndex):
             regValue = conversion.u32_to_float32(regValue)
         return regValue
 
-    def read_core_register(self, reg):
+    def read_core_register_raw(self, reg):
         """
         read a core register (r0 .. r16).
         If reg is a string, find the number associated to this register
@@ -86,11 +86,11 @@ class DebugContext(MemoryInterface):
         """
         regIndex = register_name_to_index(reg)
         # Convert float to int.
-        if is_float_register(regIndex):
+        if is_float_register(regIndex) and type(data) is float:
             data = conversion.float32_to_u32(data)
-        self.write_core_register(regIndex, data)
+        self.write_core_register_raw(regIndex, data)
 
-    def write_core_register(self, reg, data):
+    def write_core_register_raw(self, reg, data):
         """
         write a core register (r0 .. r16)
         If reg is a string, find the number associated to this register

--- a/pyocd/debug/context.py
+++ b/pyocd/debug/context.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2016 ARM Limited
+ Copyright (c) 2016-2019 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 """
 
 from ..core.memory_interface import MemoryInterface
-from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index, is_float_register)
+from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index, is_float_register,
+                                    is_double_float_register)
 from ..utility import conversion
 import logging
 
@@ -65,6 +66,8 @@ class DebugContext(MemoryInterface):
         # Convert int to float.
         if is_float_register(regIndex):
             regValue = conversion.u32_to_float32(regValue)
+        elif is_double_float_register(regIndex):
+            regValue = conversion.u64_to_float64(regValue)
         return regValue
 
     def read_core_register_raw(self, reg):
@@ -88,6 +91,8 @@ class DebugContext(MemoryInterface):
         # Convert float to int.
         if is_float_register(regIndex) and type(data) is float:
             data = conversion.float32_to_u32(data)
+        elif is_double_float_register(regIndex) and type(data) is float:
+            data = conversion.float64_to_u64(data)
         self.write_core_register_raw(regIndex, data)
 
     def write_core_register_raw(self, reg, data):

--- a/pyocd/gdbserver/context_facade.py
+++ b/pyocd/gdbserver/context_facade.py
@@ -99,13 +99,13 @@ class GDBDebugContextFacade(object):
             regName = self._register_list[reg].name
             value = conversion.hex8_to_u32be(data)
             logging.debug("GDB: write reg %s: 0x%X", regName, value)
-            self._context.write_core_register(regName, value)
+            self._context.write_core_register_raw(regName, value)
 
     def gdb_get_register(self, reg):
         resp = ''
         if reg < len(self._register_list):
             regName = self._register_list[reg].name
-            regValue = self._context.read_core_register(regName)
+            regValue = self._context.read_core_register_raw(regName)
             resp = six.b(conversion.u32_to_hex8le(regValue))
             logging.debug("GDB reg: %s = 0x%X", regName, regValue)
         return resp

--- a/pyocd/rtos/argon.py
+++ b/pyocd/rtos/argon.py
@@ -191,7 +191,7 @@ class ArgonThreadContext(DebugContext):
             # Look up offset for this register on the stack.
             spOffset = table.get(reg, None)
             if spOffset is None:
-                reg_vals.append(self._parent.read_core_register(reg))
+                reg_vals.append(self._parent.read_core_register_raw(reg))
                 continue
             if inException:
                 spOffset -= swStacked
@@ -201,7 +201,7 @@ class ArgonThreadContext(DebugContext):
                     reg_vals.append(self._parent.read32(sp + spOffset))
                 else:
                     # Not available - try live one
-                    reg_vals.append(self._parent.read_core_register(reg))
+                    reg_vals.append(self._parent.read_core_register_raw(reg))
             except exceptions.TransferError:
                 reg_vals.append(0)
 

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -216,7 +216,7 @@ class FreeRTOSThreadContext(DebugContext):
             # Look up offset for this register on the stack.
             spOffset = table.get(reg, None)
             if spOffset is None:
-                reg_vals.append(self._parent.read_core_register(reg))
+                reg_vals.append(self._parent.read_core_register_raw(reg))
                 continue
             if inException:
                 spOffset -= swStacked
@@ -226,7 +226,7 @@ class FreeRTOSThreadContext(DebugContext):
                     reg_vals.append(self._parent.read32(sp + spOffset))
                 else:
                     # Not available - try live one
-                    reg_vals.append(self._parent.read_core_register(reg))
+                    reg_vals.append(self._parent.read_core_register_raw(reg))
             except exceptions.TransferError:
                 reg_vals.append(0)
 

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -193,7 +193,7 @@ class RTXThreadContext(DebugContext):
             # Look up offset for this register on the stack.
             spOffset = table.get(reg, None)
             if spOffset is None:
-                reg_vals.append(self._parent.read_core_register(reg))
+                reg_vals.append(self._parent.read_core_register_raw(reg))
                 continue
             if inException:
                 spOffset -= swStacked
@@ -203,7 +203,7 @@ class RTXThreadContext(DebugContext):
                     reg_vals.append(self._parent.read32(sp + spOffset))
                 else:
                     # Not available - try live one
-                    reg_vals.append(self._parent.read_core_register(reg))
+                    reg_vals.append(self._parent.read_core_register_raw(reg))
             except exceptions.TransferError:
                 reg_vals.append(0)
 

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -133,7 +133,7 @@ class ZephyrThreadContext(DebugContext):
                 continue
 
             # If we get here, this is a register not in any of the dictionaries
-            val = self._parent.read_core_register(reg)
+            val = self._parent.read_core_register_raw(reg)
             log.debug("Reading live register %d = 0x%x", reg, val)
             reg_vals.append(val)
             continue


### PR DESCRIPTION
Commit ef63b40 accidentally renamed both `readCoreRegister` and `readCoreRegisterRaw` to `read_core_register`, and the same for `writeCoreRegister[Raw]`. This happened to not cause and tests or gdbserver usage to fail.

Added tests of the register access APIs to `cortex_test.py`.

Closes #490