### PR TITLE
Updated to intervaltree 3.x

### DIFF
--- a/pyocd/debug/cache.py
+++ b/pyocd/debug/cache.py
@@ -252,7 +252,7 @@ class MemoryCache(object):
     #   of the cached subranges. The second element is a set of Interval objects for each of the
     #   non-cached subranges.
     def _get_ranges(self, addr, count):
-        cached = self._cache.search(addr, addr + count)
+        cached = self._cache.overlap(addr, addr + count)
         uncached = {Interval(addr, addr + count)}
         for cachedIv in cached:
             newUncachedSet = set()
@@ -465,7 +465,7 @@ class MemoryCache(object):
         if cacheable:
             size = len(value)
             end = addr + size
-            cached = sorted(self._cache.search(addr, end), key=lambda x:x.begin)
+            cached = sorted(self._cache.overlap(addr, end), key=lambda x:x.begin)
             self._metrics.writes += size
 
             if len(cached):

--- a/pyocd/test/test_memcache.py
+++ b/pyocd/test/test_memcache.py
@@ -108,27 +108,27 @@ class TestMemoryCache:
     def test_16_no_mem_region(self, mockcore, memcache):
         assert memcache.read_memory_block8(0x30000000, 4) == [0x55] * 4
         # Make sure we didn't cache anything.
-        assert memcache._cache.search(0x30000000, 0x30000004) == set()
+        assert memcache._cache.overlap(0x30000000, 0x30000004) == set()
 
     def test_17_noncacheable_region_read(self, mockcore, memcache):
         mockcore.write_memory_block8(0x20000410, [90, 91, 92, 93])
         assert memcache.read_memory_block8(0x20000410, 4) == [90, 91, 92, 93]
         # Make sure we didn't cache anything.
-        assert memcache._cache.search(0x20000410, 0x20000414) == set()
+        assert memcache._cache.overlap(0x20000410, 0x20000414) == set()
 
     def test_18_noncacheable_region_write(self, mockcore, memcache):
         memcache.write_memory_block8(0x20000410, [1, 2, 3, 4])
         mockcore.write_memory_block8(0x20000410, [90, 91, 92, 93])
         assert memcache.read_memory_block8(0x20000410, 4) == [90, 91, 92, 93]
         # Make sure we didn't cache anything.
-        assert memcache._cache.search(0x20000410, 0x20000414) == set()
+        assert memcache._cache.overlap(0x20000410, 0x20000414) == set()
 
     def test_19_write_into_cached(self, mockcore, memcache):
         mockcore.write_memory_block8(4, [1, 2, 3, 4, 5, 6, 7, 8])
         assert memcache.read_memory_block8(4, 8) == [1, 2, 3, 4, 5, 6, 7, 8]
         memcache.write_memory_block8(6, [128, 129, 130, 131])
         assert memcache.read_memory_block8(4, 8) == [1, 2, 128, 129, 130, 131, 7, 8]
-        assert len(list(memcache._cache.search(4, 12))[0].data) == 8
+        assert len(list(memcache._cache.overlap(4, 12))[0].data) == 8
 
     def test_20_empty_read(self, memcache):
         assert memcache.read_memory_block8(128, 0) == []

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'enum34;python_version<"3.4"',
         'future',
         'websocket-client',
-        'intervaltree<3.0',
+        'intervaltree>=3.0.2,<4.0',
         'colorama',
         'pyelftools',
         'pyusb>=1.0.0b2',


### PR DESCRIPTION
Updated intervaltree minimum version to 3.0.2 and fixed compatibility problems. Version 3.x fixes several issues, including warnings produced by using a deprecated API in Python 3. However, the new version introduced breaking API changes. In particular, the `search()` method used by the memory cache was replaced with more refined search methods.