### PR TITLE
Correct flash algorithm call sequence

### DIFF
--- a/pyocd/core/exceptions.py
+++ b/pyocd/core/exceptions.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018 Arm Limited
+# Copyright (c) 2018-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,23 +15,23 @@
 # limitations under the License.
 
 class Error(RuntimeError):
-    """Parent of all errors pyOCD can raise"""
+    """! @brief Parent of all errors pyOCD can raise"""
     pass
 
 class ProbeError(Error):
-    """Error communicating with device"""
+    """! @brief Error communicating with device"""
     pass
 
 class TransferError(ProbeError):
-    """Error ocurred with a transfer over SWD or JTAG"""
+    """! @brief Error ocurred with a transfer over SWD or JTAG"""
     pass
 
 class TransferTimeoutError(TransferError):
-    """A SWD or JTAG timeout occurred"""
+    """! @brief An SWD or JTAG timeout occurred"""
     pass
 
 class TransferFaultError(TransferError):
-    """A SWD Fault occurred"""
+    """! @brief An SWD Fault occurred"""
     def __init__(self, faultAddress=None, length=None):
         super(TransferFaultError, self).__init__(faultAddress)
         self._address = faultAddress
@@ -65,5 +65,9 @@ class TransferFaultError(TransferError):
                 desc += "-0x%08x" % self.fault_end_address
         return desc
   
-  
+class FlashFailure(RuntimeError):
+    """! @brief Exception raised when flashing fails for some reason. """
+    pass
+
+
 

--- a/pyocd/target/family/flash_cortex_m.py
+++ b/pyocd/target/family/flash_cortex_m.py
@@ -22,7 +22,10 @@ class Flash_cortex_m(Flash):
     def __init__(self, target):
         super(Flash_cortex_m, self).__init__(target, None)
 
-    def init(self):
+    def init(self, operation, address=None, clock=0, reset=True):
+        raise Exception("Unsupported flash operation on generic cortex_m")
+
+    def uninit(self):
         raise Exception("Unsupported flash operation on generic cortex_m")
 
     def compute_crcs(self, sectors):

--- a/pyocd/target/target_LPC4330.py
+++ b/pyocd/target/target_LPC4330.py
@@ -355,7 +355,7 @@ class LPC4330(CoreSightTarget):
 
         # The LPC4330 flash init routine can be used to remount FLASH.
         self.ignoreReset = True
-        self.flash.init()
+        self.flash.init(Flash.Operation.VERIFY)
         self.ignoreReset = False
 
         # Set SP and PC based on interrupt vector in SPIFI_FLASH

--- a/pyocd/target/target_MKL28Z512xxx7.py
+++ b/pyocd/target/target_MKL28Z512xxx7.py
@@ -135,8 +135,8 @@ class Flash_kl28z(Flash_Kinetis):
     # This function sets up target clocks to ensure that flash is clocked at the maximum
     # of 24MHz. Doing so gets the best flash programming performance. The FIRC clock source
     # is used so that there is no dependency on an external crystal frequency.
-    def init(self, reset=True):
-        super(Flash_kl28z, self).init(reset)
+    def prepare_target(self, operation, address=None, clock=0, reset=True):
+        super(Flash_kl28z, self).init(operation, address, clock, reset)
 
         # Enable FIRC.
         value = self.target.read32(SCG_FIRCCSR)
@@ -155,7 +155,7 @@ class Flash_kl28z(Flash_Kinetis):
 
     ##
     # Restore clock registers to original values.
-    def cleanup(self):
+    def restore_target(self):
         self.target.write32(SCG_FIRCCSR, self._saved_firccsr)
         self.target.write32(SCG_RCCR, self._saved_rccr)
 

--- a/pyocd/tools/flash_tool.py
+++ b/pyocd/tools/flash_tool.py
@@ -179,7 +179,7 @@ def main():
                         return
                     
                     flash = region.flash
-                    flash.init()
+                    flash.init(flash.Operation.ERASE)
                     
                     for i in range(args.count):
                         page_info = flash.get_page_info(page_addr)
@@ -195,7 +195,7 @@ def main():
                         print("Erasing sector 0x%08x" % page_addr)
                         flash.erase_page(page_addr)
                         page_addr += page_info.size
-                    
+
                     flash.cleanup()
                 else:
                     print("No operation performed")

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -903,7 +903,7 @@ class PyOCDCommander(object):
             assert region.flash is not None
             
             # Program phrase to flash.
-            region.flash.init()
+            region.flash.init(region.flash.Operation.PROGRAM)
             region.flash.program_phrase(addr, data)
             region.flash.cleanup()
         else:

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -193,7 +193,6 @@ def basic_test(board_id, file):
         # Fill 3 pages with 0x55
         page_size = flash.get_page_info(addr_flash).size
         fill = [0x55] * page_size
-        flash.init()
         for i in range(0, 3):
             address = addr_flash + page_size * i
             # Test only supports a location with 3 aligned
@@ -201,14 +200,18 @@ def basic_test(board_id, file):
             current_page_size = flash.get_page_info(addr_flash).size
             assert page_size == current_page_size
             assert address % current_page_size == 0
-            print("Erasing page 0x%08x" % address)
+
+            flash.init(flash.Operation.ERASE)
             flash.erase_page(address)
-            print("Programming page 0x%08x" % address)
+            flash.uninit()
+
+            flash.init(flash.Operation.PROGRAM)
             flash.program_page(address, fill)
-        print("Erasing page 0x%08x" % (addr_flash + page_size))
+            flash.uninit()
         # Erase the middle page
+        flash.init(flash.Operation.ERASE)
         flash.erase_page(addr_flash + page_size)
-        print("Verifying")
+        flash.cleanup()
         # Verify the 1st and 3rd page were not erased, and that the 2nd page is fully erased
         data = target.read_memory_block8(addr_flash, page_size * 3)
         expected = fill + [0xFF] * page_size + fill

--- a/test/blank_test.py
+++ b/test/blank_test.py
@@ -36,8 +36,9 @@ for i in range(0, 10):
     with ConnectHelper.session_with_chosen_probe(**get_session_options()) as session:
         board = session.board
         # Erase and then reset - This locks Kinetis devices
-        board.flash.init()
+        board.flash.init(board.flash.Operation.ERASE)
         board.flash.erase_all()
+        board.flash.cleanup()
         board.target.reset()
 
 print("\n\n------ Testing Attaching to board ------")


### PR DESCRIPTION
This pull request corrects the function call sequence used for flash algorithms to match the documented API. Most importantly, this means calling `Init()` with the operation to be performed (erase or program) and calling `Uninit()` and `Init()` again prior to changing the operation. Most of the changes are in the `Flash` and `FlashBuilder` classes, though it also touched the classes in `pyocd.flash.loader` and a few other places.

In addition to changing the call sequence, the `Flash` class now handles flash algos that do not provide chip erase functionality. It also handles missing init and uninit functions.

**Note:** This change *does* noticeably impact flash programming performance when using page erase, as shown in the table below. This performance degradation will be addressed in a future pull request.

| Target |    Chip Erase |          Page Erase |          Page Erase (Same data) |
------|----|----|----|
| k64f before |      25.826 KB/s |         24.361 KB/s |         52.333 KB/s         |
| k64f after |      25.823 KB/s |        *20.458 KB/s* |         52.535 KB/s         |

Closes #486 
Closes #501 