### PR TITLE
Ignore HEX sections which don't belong to Flash regions

### DIFF
--- a/pyocd/flash/loader.py
+++ b/pyocd/flash/loader.py
@@ -401,7 +401,8 @@ class FlashLoader(object):
             # Look up flash region.
             region = self._map.get_region_for_address(address)
             if region is None:
-                raise ValueError("no memory region defined for address 0x%08x" % address)
+                logging.warning("no memory region defined for address 0x%08x" % address)
+                return self
             if not region.is_flash:
                 raise ValueError("memory region at address 0x%08x is not flash" % address)
         


### PR DESCRIPTION
Display warning message instead of throwing an exception. 
Resolves #499