### PR TITLE
Update to beta release of pyyaml for 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.version_info[0] > 2:
     # Python 3.x version requires explicitly setting the encoding.
     # Python 2.x version of open() doesn't support the encoding parameter.
     open_args['encoding'] = 'utf-8'
-    
+
 with open('README.md', **open_args) as f:
     readme = f.read()
 
@@ -59,7 +59,7 @@ setup(
         'pyusb>=1.0.0b2,<2.0',
         'pywinusb>=0.4.0;platform_system=="Windows"',
         'hidapi;platform_system=="Darwin"',
-        'pyyaml>=3.0,<4.0',
+        'pyyaml>=4.2b1,<5.0',
         ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
[CVE-2017-18342](https://nvd.nist.gov/vuln/detail/CVE-2017-18342) has been issued. Mbed OS also now pins this dependency: https://github.com/ARMmbed/mbed-os/blob/master/requirements.txt#L7. This is causing some issues in their CI, so I'm proposing this change here. Happy to discuss alternatives if you feel any are appropriate!