### PR TITLE
Support nonstandard erased flash value

### DIFF
--- a/pyocd/core/memory_map.py
+++ b/pyocd/core/memory_map.py
@@ -122,6 +122,7 @@ class MemoryRegion(MemoryRangeBase):
         'access': 'rwx',
         'alias': None,
         'blocksize': 0,
+        'erased_byte_value': 0,
         'is_boot_memory': False,
         'is_powered_on_boot': True,
         'is_cacheable': True,
@@ -230,6 +231,7 @@ class FlashRegion(MemoryRegion):
         from ..flash.flash import Flash
 
         attrs['access'] = attrs.get('access', 'rx') # By default flash is not writable.
+        attrs['erased_byte_value'] = attrs.get('erased_byte_value', 0xff)
         super(FlashRegion, self).__init__(type=MemoryType.FLASH, start=start, end=end, length=length, **attrs)
         self._algo = attrs.get('algo', None)
         self._flash = None
@@ -255,6 +257,20 @@ class FlashRegion(MemoryRegion):
     @flash.setter
     def flash(self, flashInstance):
         self._flash = flashInstance
+        
+    def is_erased(self, d):
+        """! @brief Helper method to check if a block of data is erased.
+        @param self
+        @param d List of data or bytearray.
+        @retval True The contents of d all match the erased byte value for this flash region.
+        @retval False At least one byte in d did not match the erased byte value.
+        """
+        erasedByte = self.erased_byte_value
+        for b in d:
+            if b != erasedByte:
+                return False
+        return True
+
 
 ## @brief Contiguous region of external memory.
 class ExternalRegion(MemoryRegion):

--- a/pyocd/flash/flash.py
+++ b/pyocd/flash/flash.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2015 ARM Limited
+ Copyright (c) 2013-2019 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 from ..core.target import Target
 from ..core.exceptions import FlashFailure
+from ..utility.mask import msb
 import logging
 from struct import unpack
 from time import time
@@ -44,21 +45,6 @@ analyzer = (
     0x405a0a12, 0xd1f542bc, 0xc00443d2, 0xd1e74281, 0xbdf02000, 0xe7f82200, 0x000000b2, 0xedb88320,
     0x00000042, 
     )
-
-def _msb(n):
-    ndx = 0
-    while (1 < n):
-        n = (n >> 1)
-        ndx += 1
-    return ndx
-
-def _same(d1, d2):
-    if len(d1) != len(d2):
-        return False
-    for i in range(len(d1)):
-        if d1[i] != d2[i]:
-            return False
-    return True
 
 class PageInfo(object):
 
@@ -239,7 +225,7 @@ class Flash(object):
         # Convert address, size pairs into commands
         # for the crc computation algorithm to preform
         for addr, size in sectors:
-            size_val = _msb(size)
+            size_val = msb(size)
             addr_val = addr // size
             # Size must be a power of 2
             assert (1 << size_val) == size

--- a/pyocd/flash/flash_builder.py
+++ b/pyocd/flash/flash_builder.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2015 ARM Limited
+ Copyright (c) 2015-2019 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 from ..core.target import Target
 from ..core.exceptions import FlashFailure
 from ..utility.notification import Notification
+from ..utility.mask import same
 import logging
 from struct import unpack
 from time import time
@@ -39,13 +40,6 @@ class ProgrammingInfo(object):
         self.program_byte_count = 0
         self.page_count = 0
         self.same_page_count = 0
-
-def _same(d1, d2):
-    assert len(d1) == len(d2)
-    for i in range(len(d1)):
-        if d1[i] != d2[i]:
-            return False
-    return True
 
 def _stub_progress(percent):
     pass
@@ -343,7 +337,7 @@ class FlashBuilder(object):
             if page.same is None:
                 size = min(PAGE_ESTIMATE_SIZE, len(page.data))
                 data = self.flash.target.read_memory_block8(page.addr, size)
-                page_same = _same(data, page.data[0:size])
+                page_same = same(data, page.data[0:size])
                 if page_same is False:
                     page.same = False
 
@@ -535,7 +529,7 @@ class FlashBuilder(object):
             # Read page data if unknown - after this page.same will be True or False
             if page.same is None:
                 data = self.flash.target.read_memory_block8(page.addr, len(page.data))
-                page.same = _same(page.data, data)
+                page.same = same(page.data, data)
                 progress += page.get_verify_weight()
 
             # Program page if not the same
@@ -574,7 +568,7 @@ class FlashBuilder(object):
             # Read page data if unknown - after this page.same will be True or False
             if page.same is None:
                 data = self.flash.target.read_memory_block8(page.addr, len(page.data))
-                page.same = _same(page.data, data)
+                page.same = same(page.data, data)
                 progress += page.get_verify_weight()
                 count += 1
                 if page.same:

--- a/pyocd/flash/flash_builder.py
+++ b/pyocd/flash/flash_builder.py
@@ -47,12 +47,6 @@ def _same(d1, d2):
             return False
     return True
 
-def _erased(d):
-    for i in range(len(d)):
-        if d[i] != 0xFF:
-            return False
-    return True
-
 def _stub_progress(percent):
     pass
 
@@ -319,7 +313,7 @@ class FlashBuilder(object):
         chip_erase_weight += self.flash.get_flash_info().erase_weight
         for page in self.page_list:
             if page.erased is None:
-                page.erased = _erased(page.data)
+                page.erased = self.flash.region.is_erased(page.data)
             if not page.erased:
                 chip_erase_count += 1
                 chip_erase_weight += page.get_program_weight()

--- a/pyocd/utility/mask.py
+++ b/pyocd/utility/mask.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2015 ARM Limited
+ Copyright (c) 2015,2019 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -68,10 +68,18 @@ def bfi(value, msb, lsb, field):
     value |= (field << lsb) & mask
     return value
 
-def _msb( n ):
+def msb( n ):
     ndx = 0
     while ( 1 < n ):
         n = ( n >> 1 )
         ndx += 1
     return ndx
+
+def same(d1, d2):
+    if len(d1) != len(d2):
+        return False
+    for i in range(len(d1)):
+        if d1[i] != d2[i]:
+            return False
+    return True
 

--- a/test/cortex_test.py
+++ b/test/cortex_test.py
@@ -32,6 +32,7 @@ from pyocd.core.target import Target
 from pyocd.gdbserver.context_facade import GDBDebugContextFacade
 from pyocd.core.helpers import ConnectHelper
 from pyocd.utility.conversion import float32_to_u32, u32_to_float32
+from pyocd.utility.mask import same
 from pyocd.core import exceptions
 from pyocd.core.memory_map import MemoryType
 from pyocd.flash.loader import FileProgrammer
@@ -62,14 +63,6 @@ class CortexTest(Test):
         result.board = board
         result.test = self
         return result
-
-def same(d1, d2):
-    if len(d1) != len(d2):
-        return False
-    for i in range(len(d1)):
-        if d1[i] != d2[i]:
-            return False
-    return True
 
 def float_compare(f1, f2):
     return abs(f1 - f2) < 0.0001

--- a/test/flash_loader_test.py
+++ b/test/flash_loader_test.py
@@ -29,6 +29,7 @@ sys.path.insert(0, parentdir)
 from pyocd.core.helpers import ConnectHelper
 from pyocd.probe.pydapaccess import DAPAccess
 from pyocd.utility.conversion import float32_to_u32
+from pyocd.utility.mask import same
 from pyocd.core.memory_map import MemoryType
 from pyocd.flash.loader import (FileProgrammer, FlashEraser, FlashLoader)
 from test_util import (Test, TestResult, get_session_options)
@@ -58,15 +59,6 @@ class FlashLoaderTest(Test):
         result.board = board
         result.test = self
         return result
-
-
-def same(d1, d2):
-    if len(d1) != len(d2):
-        return False
-    for i in range(len(d1)):
-        if d1[i] != d2[i]:
-            return False
-    return True
 
 def flash_loader_test(board_id):
     with ConnectHelper.session_with_chosen_probe(unique_id=board_id, **get_session_options()) as session:

--- a/test/flash_loader_test.py
+++ b/test/flash_loader_test.py
@@ -68,9 +68,6 @@ def same(d1, d2):
             return False
     return True
 
-def is_erased(d):
-    return all((b == 0xff) for b in d)
-
 def flash_loader_test(board_id):
     with ConnectHelper.session_with_chosen_probe(unique_id=board_id, **get_session_options()) as session:
         board = session.board
@@ -133,7 +130,7 @@ def flash_loader_test(board_id):
         eraser = FlashEraser(session, FlashEraser.Mode.SECTOR)
         eraser.erase(["0x%x+0x%x" % (addr, boot_blocksize)])
         verify_data = target.read_memory_block8(addr, boot_blocksize)
-        if is_erased(verify_data):
+        if target.memory_map.get_region_for_address(addr).is_erased(verify_data):
             print("TEST PASSED")
             test_pass_count += 1
         else:
@@ -146,7 +143,7 @@ def flash_loader_test(board_id):
         loader.commit()
         verify_data = target.read_memory_block8(boot_start_addr, data_length)
         verify_data2 = target.read_memory_block8(addr, boot_blocksize * 2)
-        if same(verify_data, data) and is_erased(verify_data2):
+        if same(verify_data, data) and target.memory_map.get_region_for_address(addr).is_erased(verify_data2):
             print("TEST PASSED")
             test_pass_count += 1
         else:

--- a/test/flash_test.py
+++ b/test/flash_test.py
@@ -30,7 +30,7 @@ sys.path.insert(0, parentdir)
 from pyocd.core.helpers import ConnectHelper
 from pyocd.probe.pydapaccess import DAPAccess
 from pyocd.utility.conversion import float32_to_u32
-from pyocd.utility.mask import invert32
+from pyocd.utility.mask import (invert32, same)
 from pyocd.core.memory_map import MemoryType
 from pyocd.flash.flash import Flash
 from pyocd.flash.flash_builder import FlashBuilder
@@ -116,15 +116,6 @@ class FlashTest(Test):
         result.board = board
         result.test = self
         return result
-
-
-def same(d1, d2):
-    if len(d1) != len(d2):
-        return False
-    for i in range(len(d1)):
-        if d1[i] != d2[i]:
-            return False
-    return True
 
 
 def flash_test(board_id):

--- a/test/flash_test.py
+++ b/test/flash_test.py
@@ -30,6 +30,7 @@ sys.path.insert(0, parentdir)
 from pyocd.core.helpers import ConnectHelper
 from pyocd.probe.pydapaccess import DAPAccess
 from pyocd.utility.conversion import float32_to_u32
+from pyocd.utility.mask import invert32
 from pyocd.core.memory_map import MemoryType
 from pyocd.flash.flash import Flash
 from pyocd.flash.flash_builder import FlashBuilder
@@ -162,6 +163,10 @@ def flash_test(board_id):
 
             flash = rom_region.flash
             flash_info = flash.get_flash_info()
+            
+            # This can be any value, as long as it's not the erased byte value. We take the
+            # inverse of the erased value so that for most flash, the unerased value is 0x00.
+            unerasedValue = invert32(flash.region.erased_byte_value) & 0xff
 
             print("\n\n===== Testing flash region '%s' from 0x%08x to 0x%08x ====" % (rom_region.name, rom_region.start, rom_region.end))
 
@@ -181,6 +186,23 @@ def flash_test(board_id):
 
             # Turn on extra checks for the next 4 tests
             flash.set_flash_algo_debug(True)
+            
+            print("\n------ Test Erased Value Check ------")
+            d = [flash.region.erased_byte_value] * 128
+            if flash.region.is_erased(d):
+                print("TEST PASSED")
+                test_pass_count += 1
+            else:
+                print("TEST FAILED")
+            test_count += 1
+
+            d = [unerasedValue] + [flash.region.erased_byte_value] * 127
+            if not flash.region.is_erased(d):
+                print("TEST PASSED")
+                test_pass_count += 1
+            else:
+                print("TEST FAILED")
+            test_count += 1
 
             print("\n------ Test Basic Page Erase ------")
             info = flash.flash_block(addr, data, False, False, progress_cb=print_progress())
@@ -329,7 +351,7 @@ def flash_test(board_id):
             if rom_start == flash_info.rom_start:
                 print("\n------ Test Chip Erase Decision ------")
                 new_data = list(data)
-                new_data.extend([0xff] * unused) # Pad with 0xFF
+                new_data.extend([flash.region.erased_byte_value] * unused) # Pad with erased value
                 info = flash.flash_block(addr, new_data, progress_cb=print_progress())
                 if info.program_type == FlashBuilder.FLASH_CHIP_ERASE:
                     print("TEST PASSED")
@@ -341,7 +363,7 @@ def flash_test(board_id):
 
                 print("\n------ Test Chip Erase Decision 2 ------")
                 new_data = list(data)
-                new_data.extend([0x00] * unused) # Pad with 0x00
+                new_data.extend([unerasedValue] * unused) # Pad with unerased value
                 info = flash.flash_block(addr, new_data, progress_cb=print_progress())
                 if info.program_type == FlashBuilder.FLASH_CHIP_ERASE:
                     print("TEST PASSED")
@@ -353,7 +375,7 @@ def flash_test(board_id):
 
             print("\n------ Test Page Erase Decision ------")
             new_data = list(data)
-            new_data.extend([0x00] * unused) # Pad with 0x00
+            new_data.extend([unerasedValue] * unused) # Pad with unerased value
             info = flash.flash_block(addr, new_data, progress_cb=print_progress())
             if info.program_type == FlashBuilder.FLASH_PAGE_ERASE:
                 print("TEST PASSED")
@@ -370,7 +392,7 @@ def flash_test(board_id):
             new_data = list(data)
             size_same = unused * 5 // 6
             size_differ = unused - size_same
-            new_data.extend([0x00] * size_same) # Pad 5/6 with 0x00 and 1/6 with 0xFF
+            new_data.extend([unerasedValue] * size_same) # Pad 5/6 with unerased value and 1/6 with 0x55
             new_data.extend([0x55] * size_differ)
             info = flash.flash_block(addr, new_data, progress_cb=print_progress())
             if info.program_type == FlashBuilder.FLASH_PAGE_ERASE:


### PR DESCRIPTION
Certain rare flash memories have an erased value of all-zeroes instead of the much more common all-ones. This change set adds an `erased_byte_value` attribute for memory regions, and a `FlashRegion.is_erased()` utility method for checking if a block of data is all erased. The functional tests and `FlashBuilder` are updated.

Included with this change is some cleanup to refactor the utility routines for computing the MSB and comparing data blocks into common implementations.

Closes #498 