### PR TITLE
Improved reset configuration

### DIFF
--- a/docs/ADDING_NEW_TARGETS.md
+++ b/docs/ADDING_NEW_TARGETS.md
@@ -7,7 +7,8 @@ For background information, review the [architecture overview](ARCHITECTURE.md) 
 
 ### Steps to add a new target
 
-1. Create a new `CoreSightTarget` subclass and `Flash` subclass in a file under `pyocd/target/`. You can copy one of the existing target files like `pyocd/target/target_ncs36510.py` and rename the classes.
+1. Create a new `CoreSightTarget` subclass in a file under `pyocd/target/`. You can copy one of the
+    existing target files like `pyocd/target/target_ncs36510.py` and rename the class.
 
     The target source file name must follow
     the pattern "target\_\<device>.py", where "\<device>" is the device's `Dname` or `Dvariant` part
@@ -51,8 +52,11 @@ For background information, review the [architecture overview](ARCHITECTURE.md) 
         `analyzer_supported` key to True and the `analyzer_address` to the start address for an
         unused range of (1224 + 4 * number-of-flash-pages) bytes of RAM.
 
+    6. Pass the `flash_algo` dict for the `algo` parameter to the `FlashRegion` constructor in
+        your memory map. This binds the flash algo to that flash memory region.
+
 4. Edit `pyocd/target/__init__.py` to import your target source file and add your new target and
-    flash classes to the `TARGET` and `FLASH` dicts.
+    flash classes to the `TARGET` dict.
 
 Now your new target is available for use via the `--target` command line option!
 
@@ -86,4 +90,4 @@ Follow these steps:
 3. Place a test firmware binary file listed in the board info into the top-level `binaries/`
     directory. The test firmware can be nothing more than an LED blinky demo. It must not require
     any user input, and should provide immediate visual feedback that the code is successfully
-    running.
+    running, assuming there are LEDs on the board.

--- a/docs/API_EXAMPLES.md
+++ b/docs/API_EXAMPLES.md
@@ -16,13 +16,13 @@ with ConnectHelper.session_with_chosen_probe() as session:
 
     board = session.board
     target = board.target
-    flash = board.flash
+    flash = target.memory_map.get_boot_memory()
 
     # Load firmware into device.
     flash.flash_binary("my_firmware.bin")
 
     # Reset, run.
-    target.reset_stop_on_reset()
+    target.reset_and_halt()
     target.resume()
 
     # Read some registers.
@@ -35,7 +35,7 @@ with ConnectHelper.session_with_chosen_probe() as session:
     target.halt()
     print("pc: 0x%X" % target.read_core_register("pc"))
 
-    target.reset_stop_on_reset()
+    target.reset_and_halt()
 
     print("pc: 0x%X" % target.read_core_register("pc"))
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,8 +44,11 @@ used for potentially multiple boards, or there may not be board with the target.
 override the target type on the command line or when creating the `Session`.
 
 Each supported target is defined as a `CoreSightTarget` subclass held in a Python file in the
-`pyocd/target` directory. If the target has internal or connected flash, then a `Flash` subclass
-will be paired with it in the same source file. Some device families have family subclasses under
+`pyocd/target` directory. If the target has internal or connected flash, then a flash algo dict and
+possibly a `Flash` subclass will be paired with it in the same source file. The `Flash` subclass is
+only required if special flash programming semantics are needed, otherwise the base `Flash` class
+is automatically used. The flash algo dict and/or `Flash` subclass are set on flash memory regions
+when they are created in the memory map. Some device families have family subclasses under
 `pyocd/target/family`.
 
 #### Board information

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -82,18 +82,33 @@ mdm_ap.write_reg(0x4, 0x1)
 
 To control reset, there are several options.
 
-`DebugPort` methods for performing hardware reset:
+`DebugPort` has methods for driving the hardware reset signal:
 - `DebugPort.reset()`, asks the debug probe to perform a hardware reset of the target.
 - `DebugPort.assert_reset(asserted)` to directly control the nRESET signal. Pass True to drive
   nRESET low, False to drive high.
 
-`Target` methods:
-- `Target.reset(software_reset=None)`. Normally performs a software reset unless the optional parameter
+A wider range of reset options is provided by these `Target` methods:
+- `Target.reset(reset_type=None)`. Normally performs a software reset unless the optional parameter
   is set to False.
-- `Target.resetStopOnReset(software_reset=None)` to perform a halting reset. Again, the reset defaults
+- `Target.reset_and_halt(reset_type=None)` to perform a halting reset. Again, the reset defaults
   to software but may be set to hardware.
 
-Another option for performing a halting reset is by setting vector catch with the target's `setVectorCatch()`
+The `reset_type` parameter on the `Target` reset methods can be set to one of the `Target.ResetType`
+enums:
+- `ResetType.HW`: Hardware reset using the nRESET signal.
+- `ResetType.SW`: Uses the core's default software reset method.
+- `ResetType.SW_SYSRESETREQ`: Software reset using SYSRESETREQ, which usually resets the entire system
+on most MCUs.
+- `ResetType.SW_VECTRESET`: Software reset using VECTRESET, only available on v7-M targets. This
+resets only the core itself. If requested on non-v7-M targets, it will fall back to `SW_EMULATED`.
+- `ResetType.SW_EMULATED`: Restores the core to reset conditions by writing registers. However, this
+will not trigger a reset vector catch.
+
+The `CortexM` objects have `default_reset_type` and `default_software_reset_type` properties that
+let you control the overall default reset type (any one of the `ResetType` enums), as well as the
+default if `ResetType.SW` is selected, respectively.
+
+Another option for performing a halting reset is by setting vector catch with the target's `set_vector_catch()`
 method, then using a normal reset. This has the benefit of always halting at reset, if you leave the
 vector catch enabled.
 
@@ -113,15 +128,20 @@ dp.assert_reset(False)
 ## Notes
 
 NXP Kinetis targets will normally automatically perform a mass erase upon connect if flash security is
-enabled. This can be disabled, but requires slightly different connect code.
+enabled. This can be disabled by setting the `auto_unlock` session option to false.
 
 You are encouraged to look through the code to see what additional functionality is available. The
 most interesting places to look at are:
 
 - `pyocd.core.target`: defines Target class, which is the main API.
+- `pyocd.core.coresight_target`: Represents the chip as a whole, provides access to DP and APs, as
+well as each of the cores.
 - `pyocd.coresight.cortex_m`: CortexM class to control a core, implements Target API and adds
 some stuff.
-- `pyocd.flash.flash`: flash programming API in the `Flash` class, accessible from the 'flash'
-attribute on a target (i.e., `session.board.target.flash`).
+- `pyocd.flash.loader`: high level flash programming and erasing API, provides both file programming,
+raw binary data programming, and erasing.
+- `pyocd.flash.flash`: low level flash programming API in the `Flash` class. Each flash memory region
+has a `Flash` class instance associated with it, accessible from the `flash` property on the region.
+To get the boot flash, call `target.memory_map.get_boot_memory()`.
 
 

--- a/docs/SESSION_OPTIONS.md
+++ b/docs/SESSION_OPTIONS.md
@@ -13,8 +13,9 @@ to the `ConnectHelper` methods or `Session` constructor as keyword arguments.
 pyOCD supports a YAML configuration file that lets you provide session options that either apply to
 all probes or to a single probe, based on the probe's unique ID.
 
-The easiest way to use a config file is to use the `--config` command line option, for instance
-`--config=myconfig.yaml`. Alternatively, you can set the `config_file` session option.
+The easiest way to use a config file is to place a `pyocd.yaml` file in the working directory where
+you run the `pyocd` tool. Alternatively, you can use the `--config` command line option, for instance
+`--config=myconfig.yaml`. Finally, you can set the `config_file` session option.
 
 The top level of the YAML file is a dictionary. The keys in the top-level dictionary must be names
 of session options, or the key `probes`. Session options are set to the value corresponding to the
@@ -22,7 +23,7 @@ dictionary entry. Unrecognized option names are ignored.
 
 If there is a top-level `probes` key, its value must be a dictionary with keys that match a
 substring of debug probe unique IDs. Usually you would just use the complete unique ID shown by
-listing connected boards (i.e., `pyocd-gdbserver --list`). The values for the unique ID entries are
+listing connected boards (i.e., `pyocd list`). The values for the unique ID entries are
 dictionaries containing session options, just like the top level of the YAML file. Of course, these
 session options are only applied when connecting with the given probe. If the probe unique ID
 substring listed in the config file matches more than one probe, the corresponding session options
@@ -49,11 +50,19 @@ frequency: 8000000 # Set 8 MHz SWD default for all probes
     order to gain debug access. Set this option to False to disable auto unlock. Default is True.
 
 - `config_file`: (str) Relative path to a YAML config file that lets you specify session options
-    either globally or per probe. No default. The format of the file is documented above. No default.
+    either globally or per probe. The format of the file is documented above. The default is a
+    `pyocd.yaml` or `pyocd.yml` file in the working directory.
+
+- `enable_multicore_debug`: (bool) Whether to put pyOCD into multicore debug mode. The primary effect
+    is to modify the default software reset type for secondary cores to use VECTRESET, which will
+    fall back to emulated reset if the secondary core is not v7-M.
 
 - `frequency`: (int) SWD/JTAG frequency in Hertz. Default is 1 MHz.
 
 - `halt_on_connect`: (bool) Whether to halt the target immediately upon connecting. Default is True.
+
+- `reset_type`: (str) Which type of reset to use by default (one of 'default', 'hw', 'sw', 'sw_sysresetreq',
+    'sw_vectreset', 'sw_emulated'). The default is 'sw'.
 
 - `resume_on_disconnect`: (bool) Whether to resume a halted target when disconnecting. Default is True.
 

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -260,8 +260,8 @@ class CoreSightTarget(Target):
     def reset(self, software_reset=None):
         return self.selected_core.reset(software_reset=software_reset)
 
-    def reset_stop_on_reset(self, software_reset=None):
-        return self.selected_core.reset_stop_on_reset(software_reset)
+    def reset_and_halt(self, reset_type=None):
+        return self.selected_core.reset_and_halt(reset_type)
 
     def set_target_state(self, state):
         return self.selected_core.set_target_state(state)

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -257,8 +257,8 @@ class CoreSightTarget(Target):
     def remove_watchpoint(self, addr, size, type):
         return self.selected_core.remove_watchpoint(addr, size, type)
 
-    def reset(self, software_reset=None):
-        return self.selected_core.reset(software_reset=software_reset)
+    def reset(self, reset_type=None):
+        return self.selected_core.reset(reset_type)
 
     def reset_and_halt(self, reset_type=None):
         return self.selected_core.reset_and_halt(reset_type)

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -263,9 +263,6 @@ class CoreSightTarget(Target):
     def reset_and_halt(self, reset_type=None):
         return self.selected_core.reset_and_halt(reset_type)
 
-    def set_target_state(self, state):
-        return self.selected_core.set_target_state(state)
-
     def get_state(self):
         return self.selected_core.get_state()
 

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018 Arm Limited
+# Copyright (c) 2018-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,8 @@ OPTIONS_INFO = {
     'resume_on_disconnect': OptionInfo('resume_on_disconnect', bool, "Whether to run target on disconnect."),
     'target_override': OptionInfo('target_override', str, "Name of target to use instead of default."),
     'test_binary': OptionInfo('test_binary', str, "Name of test firmware binary."),
+    'reset_type': OptionInfo('reset_type', str, "Which type of reset to use by default ('default', 'hw', 'sw', 'sw_sysresetreq', 'sw_vectreset', 'sw_emulated'). The default is 'sw'."),
+    'enable_multicore_debug': OptionInfo('enable_multicore', bool, "Whether to put pyOCD into multicore debug mode."),
 
     # GDBServer options
     'chip_erase': OptionInfo('chip_erase', str, "Whether to perform a chip erase or sector erases when programming flash."),

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -161,9 +161,6 @@ class Target(MemoryInterface, Notifier):
     def reset_and_halt(self, reset_type=None):
         raise NotImplementedError()
 
-    def set_target_state(self, state):
-        raise NotImplementedError()
-
     def get_state(self):
         raise NotImplementedError()
 

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -158,7 +158,7 @@ class Target(MemoryInterface, Notifier):
     def reset(self, software_reset=None):
         raise NotImplementedError()
 
-    def reset_stop_on_reset(self, software_reset=None):
+    def reset_and_halt(self, reset_type=None):
         raise NotImplementedError()
 
     def set_target_state(self, state):

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2018 ARM Limited
+ Copyright (c) 2006-2019 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 from .memory_interface import MemoryInterface
 from ..utility.notification import Notifier
 from .memory_map import MemoryMap
+from enum import Enum
 
 class Target(MemoryInterface, Notifier):
 
@@ -26,6 +27,21 @@ class Target(MemoryInterface, Notifier):
     TARGET_RESET = 3     # Core is being held in reset.
     TARGET_SLEEPING = 4  # Core is sleeping due to a wfi or wfe instruction.
     TARGET_LOCKUP = 5    # Core is locked up.
+
+    class ResetType(Enum):
+        """! @brief Available reset methods."""
+        ## Hardware reset via the nRESET signal.
+        HW = 1
+        ## Software reset using the core's default software reset method.
+        SW = 2
+        ## Software reset using the AIRCR.SYSRESETREQ bit.
+        SW_SYSRESETREQ = 3
+        ## Software reset using the AIRCR.VECTRESET bit.
+        #
+        # v6-M and v8-M targets do not support VECTRESET, so they will fall back to SW_EMULATED.
+        SW_VECTRESET = 4
+        ## Emulated software reset.
+        SW_EMULATED = 5
 
     # Types of breakpoints.
     #
@@ -155,7 +171,7 @@ class Target(MemoryInterface, Notifier):
     def remove_watchpoint(self, addr, size, type):
         raise NotImplementedError()
 
-    def reset(self, software_reset=None):
+    def reset(self, reset_type=None):
         raise NotImplementedError()
 
     def reset_and_halt(self, reset_type=None):

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2015 ARM Limited
+ Copyright (c) 2006-2019 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 
 from ..core.target import Target
 from ..core import exceptions
-from ..utility import conversion
+from ..utility import (cmdline, conversion, timeout)
 from ..utility.notification import Notification
 from .component import CoreSightComponent
 from .fpb import FPB
@@ -276,11 +276,36 @@ class CortexM(Target, CoreSightComponent):
     # Coprocessor Access Control Register
     CPACR = 0xE000ED88
     CPACR_CP10_CP11_MASK = (3 << 20) | (3 << 22)
+    
+    # Interrupt Control and State Register
+    ICSR = 0xE000ED04
+    ICSR_PENDSVCLR = (1 << 27)
+    ICSR_PENDSTCLR = (1 << 25)
+    
+    VTOR = 0xE000ED08
+    SCR = 0xE000ED10
+    SHPR1 = 0xE000ED18
+    SHPR2 = 0xE000ED1C
+    SHPR3 = 0xE000ED20
+    SHCSR = 0xE000ED24
+    FPCCR = 0xE000EF34
+    FPCAR = 0xE000EF38
+    FPDSCR = 0xE000EF3C
+    ICTR = 0xE000E004
 
     NVIC_AIRCR = (0xE000ED0C)
     NVIC_AIRCR_VECTKEY = (0x5FA << 16)
     NVIC_AIRCR_VECTRESET = (1 << 0)
+    NVIC_AIRCR_VECTCLRACTIVE = (1 << 1)
     NVIC_AIRCR_SYSRESETREQ = (1 << 2)
+    NVIC_AIRCR_PRIGROUP_MASK = 0x700
+    NVIC_AIRCR_PRIGROUP_SHIFT = 8
+    
+    NVIC_ICER0 = 0xE000E180 # NVIC Clear-Enable Register 0
+    NVIC_ICPR0 = 0xE000E280 # NVIC Clear-Pending Register 0
+    NVIC_IPR0 = 0xE000E400 # NVIC Interrupt Priority Register 0
+    
+    SYSTICK_CSR = 0xE000E010
 
     DBGKEY = (0xA05F << 16)
 
@@ -388,6 +413,16 @@ class CortexM(Target, CoreSightComponent):
         self._target_context = None
         self._elf = None
         self.target_xml = None
+        self._supports_vectreset = False
+        
+        # Default to software reset using the default software reset method.
+        self._default_reset_type = Target.ResetType.SW
+        
+        # Select default sw reset type based on whether multicore debug is enabled and which core
+        # this is.
+        self._default_software_reset_type = Target.ResetType.SW_SYSRESETREQ \
+                    if (not self.session.options.get('enable_multicore_debug', False)) or (self.core_number == 0) \
+                    else Target.ResetType.SW_VECTRESET
 
         # Set up breakpoints manager.
         self.sw_bp = SoftwareBreakpointProvider(self)
@@ -409,6 +444,31 @@ class CortexM(Target, CoreSightComponent):
     @elf.setter
     def elf(self, elffile):
         self._elf = elffile
+    
+    @property
+    def default_reset_type(self):
+        return self._default_reset_type
+    
+    @default_reset_type.setter
+    def default_reset_type(self, reset_type):
+        assert isinstance(reset_type, Target.ResetType)
+        self._default_reset_type = reset_type
+    
+    @property
+    def default_software_reset_type(self):
+        return self._default_software_reset_type
+    
+    @default_software_reset_type.setter
+    def default_software_reset_type(self, reset_type):
+        """! @brief Modify the default software reset method.
+        @param self
+        @param reset_type Must be one of the software reset types: Target.ResetType.SW_SYSRESETREQ,
+            Target.ResetType.SW_VECTRESET, or Target.ResetType.SW_EMULATED.
+        """
+        assert isinstance(reset_type, Target.ResetType)
+        assert reset_type in (Target.ResetType.SW_SYSRESETREQ, Target.ResetType.SW_VECTRESET,
+                                Target.ResetType.SW_EMULATED)
+        self._default_software_reset_type = reset_type
 
     def init(self):
         """
@@ -471,6 +531,10 @@ class CortexM(Target, CoreSightComponent):
         
         self.cpu_revision = (cpuid & CortexM.CPUID_VARIANT_MASK) >> CortexM.CPUID_VARIANT_POS
         self.cpu_patch = (cpuid & CortexM.CPUID_REVISION_MASK) >> CortexM.CPUID_REVISION_POS
+        
+        # Only v7-M supports VECTRESET.
+        if self.arch == CortexM.ARMv7M:
+            self._supports_vectreset = True
         
         if self.core_type in CORE_TYPE_NAME:
             logging.info("CPU core is %s r%dp%d", CORE_TYPE_NAME[self.core_type], self.cpu_revision, self.cpu_patch)
@@ -619,43 +683,165 @@ class CortexM(Target, CoreSightComponent):
 
     def clear_debug_cause_bits(self):
         self.write_memory(CortexM.DFSR, CortexM.DFSR_VCATCH | CortexM.DFSR_DWTTRAP | CortexM.DFSR_BKPT | CortexM.DFSR_HALTED)
-
-    def reset(self, software_reset=None):
+    
+    def _perform_emulated_reset(self):
+        """! @brief Emulate a software reset by writing registers.
+        
+        All core registers are written to reset values. This includes setting the initial PC and SP
+        to values read from the vector table, which is assumed to be located at the based of the
+        boot memory region.
+        
+        If the memory map does not provide a boot region, then the current value of the VTOR register
+        is reused, as it should at least point to a valid vector table.
+        
+        The current value of DEMCR.VC_CORERESET determines whether the core will be resumed or
+        left halted.
+        
+        Note that this reset method will not set DHCSR.S_RESET_ST or DFSR.VCATCH.
         """
-        reset a core. After a call to this function, the core
-        is running
+        # Halt the core before making changes.
+        self.halt()
+        
+        bootMemory = self.memory_map.get_boot_memory()
+        if bootMemory is None:
+            # Reuse current VTOR value if we don't know the boot memory region.
+            vectorBase = self.read32(self.VTOR)
+        else:
+            vectorBase = bootMemory.start
+        
+        # Read initial SP and PC.
+        initialSp = self.read32(vectorBase)
+        initialPc = self.read32(vectorBase + 4)
+        
+        # Init core registers.
+        regList = ['r0', 'r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'r10', 'r11', 'r12',
+                    'psp', 'msp', 'lr', 'pc', 'xpsr', 'cfbp']
+        valueList = [0] * 13 + \
+                    [
+                        0,          # PSP
+                        initialSp,  # MSP
+                        0xffffffff, # LR
+                        initialPc,  # PC
+                        0x01000000, # XPSR
+                        0,          # CFBP
+                    ]
+        
+        if self.has_fpu:
+            regList += [('s%d' % n) for n in range(32)] + ['fpscr']
+            valueList += [0] * 33
+        
+        self.write_core_registers_raw(regList, valueList)
+        
+        # "Reset" SCS registers.
+        data = [
+                (self.ICSR_PENDSVCLR | self.ICSR_PENDSTCLR),  # ICSR
+                vectorBase,                   # VTOR
+                (self.NVIC_AIRCR_VECTKEY | self.NVIC_AIRCR_VECTCLRACTIVE),    # AIRCR
+                0,  # SCR
+                0,  # CCR
+                0,  # SHPR1
+                0,  # SHPR2
+                0,  # SHPR3
+                0,  # SHCSR
+                0,  # CFSR
+                ]
+        self.write_memory_block32(self.ICSR, data)
+        self.write32(self.CPACR, 0)
+        
+        if self.has_fpu:
+            data = [
+                    0,  # FPCCR
+                    0,  # FPCAR
+                    0,  # FPDSCR
+                    ]
+            self.write_memory_block32(self.FPCCR, data)
+        
+        # "Reset" SysTick.
+        self.write_memory_block32(self.SYSTICK_CSR, [0] * 3)
+        
+        # "Reset" NVIC registers.
+        numregs = (self.read32(self.ICTR) & 0xf) + 1
+        self.write_memory_block32(self.NVIC_ICER0, [0xffffffff] * numregs)
+        self.write_memory_block32(self.NVIC_ICPR0, [0xffffffff] * numregs)
+        self.write_memory_block32(self.NVIC_IPR0, [0xffffffff] * (numregs * 8))
+
+    def reset(self, reset_type=None):
+        """! @brief Reset the core.
+        
+        The reset method is selectable via the reset_type parameter as well as the reset_type
+        session option. If the reset_type parameter is not specified or None, then the reset_type
+        option will be used. If the option is not set, or if it is set to a value of 'default', the
+        the core's default_reset_type property value is used. So, the session option overrides the
+        core's default, while the parameter overrides everything.
+        
+        Note that only v7-M cores support the `VECTRESET` software reset method. If this method
+        is chosen but the core doesn't support it, the the reset method will fall back to an
+        emulated software reset.
+        
+        After a call to this function, the core is running.
         """
         self.notify(Notification(event=Target.EVENT_PRE_RESET, source=self))
 
-        if software_reset == None:
-            # Default to software reset if nothing is specified
-            software_reset = True
+        # Default to reset_type session option if reset_type parameter is None. If the session
+        # option isn't set, then use the core's default reset type.
+        if reset_type is None:
+            if 'reset_type' not in self.session.options:
+                reset_type = self.default_reset_type
+            else:
+                try:
+                    # Convert session option value to enum.
+                    resetOption = self.session.options['reset_type']
+                    reset_type = cmdline.convert_reset_type(resetOption)
+                    
+                    # The converted option will be None if the option value is 'default'.
+                    if reset_type is None:
+                        reset_type = self.default_reset_type
+                except ValueError:
+                    reset_type = self.default_reset_type
+        else:
+            assert isinstance(reset_type, Target.ResetType)
+        
+        # If the reset type is just SW, then use our default software reset type.
+        if reset_type is Target.ResetType.SW:
+            reset_type = self.default_software_reset_type
+        
+        # Fall back to emulated sw reset if the vectreset is specified and the core doesn't support it.
+        if (reset_type is Target.ResetType.SW_VECTRESET) and (not self._supports_vectreset):
+            reset_type = Target.ResetType.SW_EMULATED
 
         self._run_token += 1
 
-        if software_reset:
-            # Perform the reset.
+        # Perform the reset.
+        if reset_type is Target.ResetType.HW:
+            self.session.probe.reset()
+        elif reset_type is Target.ResetType.SW_EMULATED:
+            self._perform_emulated_reset()
+        else:
+            if reset_type is Target.ResetType.SW_SYSRESETREQ:
+                mask = CortexM.NVIC_AIRCR_SYSRESETREQ
+            elif reset_type is Target.ResetType.SW_VECTRESET:
+                mask = CortexM.NVIC_AIRCR_VECTRESET
+            else:
+                raise RuntimeError("internal error, unhandled reset type")
+            
             try:
-                self.write_memory(CortexM.NVIC_AIRCR, CortexM.NVIC_AIRCR_VECTKEY | CortexM.NVIC_AIRCR_SYSRESETREQ)
+                self.write_memory(CortexM.NVIC_AIRCR, CortexM.NVIC_AIRCR_VECTKEY | mask)
                 # Without a flush a transfer error can occur
                 self.flush()
             except exceptions.TransferError:
                 self.flush()
 
-        else:
-            self.session.probe.reset()
-
         # Now wait for the system to come out of reset. Keep reading the DHCSR until
         # we get a good response with S_RESET_ST cleared, or we time out.
-        startTime = time()
-        while time() - startTime < 2.0:
-            try:
-                dhcsr = self.read32(CortexM.DHCSR)
-                if (dhcsr & CortexM.S_RESET_ST) == 0:
-                    break
-            except exceptions.TransferError:
-                self.flush()
-                sleep(0.01)
+        with timeout.Timeout(2.0) as t_o:
+            while t_o.check():
+                try:
+                    dhcsr = self.read32(CortexM.DHCSR)
+                    if (dhcsr & CortexM.S_RESET_ST) == 0:
+                        break
+                except exceptions.TransferError:
+                    self.flush()
+                    sleep(0.01)
 
         self.notify(Notification(event=Target.EVENT_POST_RESET, source=self))
 
@@ -663,8 +849,6 @@ class CortexM(Target, CoreSightComponent):
         """
         perform a reset and stop the core on the reset handler
         """
-        logging.debug("reset stop on Reset")
-
         # halt the target
         self.halt()
 
@@ -677,8 +861,11 @@ class CortexM(Target, CoreSightComponent):
         self.reset(reset_type)
 
         # wait until the unit resets
-        while (self.is_running()):
-            pass
+        with timeout.Timeout(2.0) as t_o:
+            while t_o.check():
+                if self.get_state() not in (Target.TARGET_RESET, Target.TARGET_RUNNING):
+                    break
+                sleep(0.01)
 
         # Make sure the thumb bit is set in XPSR in case the reset handler
         # points to an invalid address.
@@ -942,7 +1129,7 @@ class CortexM(Target, CoreSightComponent):
 
     ## @brief Set a hardware or software breakpoint at a specific location in memory.
     #
-    # @retval True Breakpoint was set.
+    # @: True Breakpoint was set.
     # @retval False Breakpoint could not be set.
     def set_breakpoint(self, addr, type=Target.BREAKPOINT_AUTO):
         return self.bp_manager.set_breakpoint(addr, type)

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -656,7 +656,7 @@ class CortexM(Target, CoreSightComponent):
 
         self.notify(Notification(event=Target.EVENT_POST_RESET, source=self))
 
-    def reset_stop_on_reset(self, software_reset=None):
+    def reset_and_halt(self, reset_type=None):
         """
         perform a reset and stop the core on the reset handler
         """
@@ -671,7 +671,7 @@ class CortexM(Target, CoreSightComponent):
         # enable the vector catch
         self.write_memory(CortexM.DEMCR, demcr | CortexM.DEMCR_VC_CORERESET)
 
-        self.reset(software_reset)
+        self.reset(reset_type)
 
         # wait until the unit resets
         while (self.is_running()):

--- a/pyocd/flash/flash.py
+++ b/pyocd/flash/flash.py
@@ -167,7 +167,7 @@ class Flash(object):
         self.target.halt()
         if not self._did_prepare_target:
             if reset:
-                self.target.set_target_state("PROGRAM")
+                self.target.reset_and_halt(Target.ResetType.SW)
             self.prepare_target()
 
             # Load flash algo code into target RAM.

--- a/pyocd/flash/flash_builder.py
+++ b/pyocd/flash/flash_builder.py
@@ -260,7 +260,7 @@ class FlashBuilder(object):
 
         # Cleanup flash algo and reset target after programming.
         self.flash.cleanup()
-        self.flash.target.reset_stop_on_reset()
+        self.flash.target.reset_and_halt()
 
         program_finish = time()
         self.perf.program_time = program_finish - program_start

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -565,7 +565,7 @@ class GDBServer(threading.Thread):
         return self.create_rsp_packet(b"")
     
     def restart(self, data):
-        self.target.reset_stop_on_reset()
+        self.target.reset_and_halt()
         # No reply.
 
     def breakpoint(self, data):
@@ -1167,17 +1167,10 @@ class GDBServer(threading.Thread):
 
             # Run cmds in proper order
             if (resultMask & 0x6) == 0x6:
-                if self.core == 0:
-                    self.target.reset_stop_on_reset()
-                else:
-                    self.log.debug("Ignoring reset request for core #%d", self.core)
+                self.target.reset_and_halt()
             elif resultMask & 0x2:
                 # on 'reset' still do a reset halt
-                if self.core == 0:
-                    self.target.reset_stop_on_reset()
-                else:
-                    self.log.debug("Ignoring reset request for core #%d", self.core)
-                # self.target.reset()
+                self.target.reset_and_halt()
             elif resultMask & 0x4:
                 self.target.halt()
 

--- a/pyocd/target/target_CC3220SF.py
+++ b/pyocd/target/target_CC3220SF.py
@@ -1,6 +1,6 @@
 """
  mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013 ARM Limited
+ Copyright (c) 2018-2019 ARM Limited
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -124,29 +124,9 @@ class CC3220SF(CoreSightTarget):
 
     def create_init_sequence(self):
         seq = super(CC3220SF,self).create_init_sequence()
-        seq.replace_task('create_cores', self.create_CC3220SF_core)
+        seq.wrap_task('create_cores', self.setup_CC3220SF_core)
         return seq
 
-    def create_CC3220SF_core(self):
-        core0 = CortexM_CC3220SF(self, self.aps[0], self.memory_map)
-        self.aps[0].core = core0
-        core0.init()
-        self.add_core(core0)
+    def setup_CC3220SF_core(self, arg):
+        self.cores[0].default_reset_type = self.ResetType.SW_VECTRESET
         
-
-
-
-class CortexM_CC3220SF(CortexM):
-
-    def __init__(self, rootTarget, ap, memoryMap=None, core_num=0, cmpid=None, address=None):
-        super(CortexM_CC3220SF, self).__init__(rootTarget, ap, memoryMap, core_num, cmpid, address)
-
-    def reset(self, software_reset=None):
-        if software_reset:
-            # Perform the reset.
-            try:
-                self.write_memory(CortexM.NVIC_AIRCR, CortexM.NVIC_AIRCR_VECTKEY | CortexM.NVIC_AIRCR_VECTRESET)
-                # Without a flush a transfer error can occur
-                self.flush()
-            except exceptions.TransferError:
-                self.flush()

--- a/pyocd/target/target_CC3220SF.py
+++ b/pyocd/target/target_CC3220SF.py
@@ -79,7 +79,7 @@ class Flash_cc3220sf(Flash):
         """
 
         self.target.halt()
-        self.target.set_target_state("PROGRAM")
+        self.target.reset_and_halt()
 
         # update core register to execute the init subroutine
 
@@ -102,7 +102,7 @@ class Flash_cc3220sf(Flash):
         self.target.dp.power_up_debug()
 
         self.target.halt()
-        self.target.set_target_state("PROGRAM")
+        self.target.reset_and_halt()
 
         # update core register to execute the init subroutine
         result = self._call_function_and_wait(self.flash_algo['pc_init'], init=True)

--- a/pyocd/target/target_LPC1114FN28_102.py
+++ b/pyocd/target/target_LPC1114FN28_102.py
@@ -76,8 +76,8 @@ class LPC11XX_32(CoreSightTarget):
     def __init__(self, link):
         super(LPC11XX_32, self).__init__(link, self.memoryMap)
 
-    def reset_stop_on_reset(self, software_reset=None, map_to_user=True):
-        super(LPC11XX_32, self).reset_stop_on_reset(software_reset)
+    def reset_and_halt(self, reset_type=None, map_to_user=True):
+        super(LPC11XX_32, self).reset_and_halt(reset_type)
 
         # Remap to use flash and set SP and SP accordingly
         if map_to_user:

--- a/pyocd/target/target_LPC11U24FBD64_401.py
+++ b/pyocd/target/target_LPC11U24FBD64_401.py
@@ -72,8 +72,8 @@ class LPC11U24(CoreSightTarget):
         super(LPC11U24, self).__init__(link, self.memoryMap)
         self._svd_location = SVDFile(vendor="NXP", filename="LPC11Uxx_v7.svd", is_local=False)
 
-    def reset_stop_on_reset(self, software_reset=None, map_to_user=True):
-        super(LPC11U24, self).reset_stop_on_reset(software_reset)
+    def reset_and_halt(self, reset_type=None, map_to_user=True):
+        super(LPC11U24, self).reset_and_halt(reset_type)
 
         # Remap to use flash and set SP and SP accordingly
         if map_to_user:

--- a/pyocd/target/target_LPC1768.py
+++ b/pyocd/target/target_LPC1768.py
@@ -109,8 +109,8 @@ class LPC1768(CoreSightTarget):
     def reset(self, software_reset=False):
         super(LPC1768, self).reset(False)
 
-    def reset_stop_on_reset(self, software_reset=False, map_to_user=True):
-        super(LPC1768, self).reset_stop_on_reset()
+    def reset_and_halt(self, reset_type=False, map_to_user=True):
+        super(LPC1768, self).reset_and_halt()
 
         # Remap to use flash and set SP and SP accordingly
         if map_to_user:

--- a/pyocd/target/target_LPC1768.py
+++ b/pyocd/target/target_LPC1768.py
@@ -106,10 +106,10 @@ class LPC1768(CoreSightTarget):
         super(LPC1768, self).__init__(link, self.memoryMap)
         self._svd_location = SVDFile(vendor="NXP", filename="LPC176x5x_v0.2.svd", is_local=False)
 
-    def reset(self, software_reset=False):
-        super(LPC1768, self).reset(False)
+    def reset(self, reset_type=None):
+        super(LPC1768, self).reset(self.ResetType.HW)
 
-    def reset_and_halt(self, reset_type=False, map_to_user=True):
+    def reset_and_halt(self, reset_type=None, map_to_user=True):
         super(LPC1768, self).reset_and_halt()
 
         # Remap to use flash and set SP and SP accordingly

--- a/pyocd/target/target_LPC4088FBD144.py
+++ b/pyocd/target/target_LPC4088FBD144.py
@@ -99,8 +99,8 @@ class LPC4088(CoreSightTarget):
         # Use hardware reset since software reset cause a debug logic reset
         super(LPC4088, self).reset(False)
 
-    def reset_stop_on_reset(self, software_reset=None, map_to_user=True):
-        super(LPC4088, self).reset_stop_on_reset(software_reset)
+    def reset_and_halt(self, reset_type=None, map_to_user=True):
+        super(LPC4088, self).reset_and_halt(reset_type)
 
         # Remap to use flash and set SP and SP accordingly
         if map_to_user:

--- a/pyocd/target/target_LPC4088FBD144.py
+++ b/pyocd/target/target_LPC4088FBD144.py
@@ -95,9 +95,9 @@ class LPC4088(CoreSightTarget):
         self.ignoreReset = False
         self._svd_location = SVDFile(vendor="NXP", filename="LPC408x_7x_v0.7.svd", is_local=False)
 
-    def reset(self, software_reset=None):
+    def reset(self, reset_type=None):
         # Use hardware reset since software reset cause a debug logic reset
-        super(LPC4088, self).reset(False)
+        super(LPC4088, self).reset(self.ResetType.HW)
 
     def reset_and_halt(self, reset_type=None, map_to_user=True):
         super(LPC4088, self).reset_and_halt(reset_type)

--- a/pyocd/target/target_LPC4330.py
+++ b/pyocd/target/target_LPC4330.py
@@ -329,12 +329,12 @@ class LPC4330(CoreSightTarget):
         self.ignoreReset = False
         self._svd_location = SVDFile(vendor="NXP", filename="LPC43xx_svd_v5.svd", is_local=False)
 
-    def reset(self, software_reset=False):
+    def reset(self, reset_type=None):
         # Always use software reset for LPC4330 since the hardware version
         # will reset the DAP.
-        super(LPC4330, self).reset(True)
+        super(LPC4330, self).reset(self.ResetType.SW)
 
-    def reset_and_halt(self, reset_type=False):
+    def reset_and_halt(self, reset_type=None):
         if self.ignoreReset:
             return
 
@@ -348,7 +348,7 @@ class LPC4330(CoreSightTarget):
 
         # Always use software reset for LPC4330 since the hardware version
         # will reset the DAP.
-        super(LPC4330, self).reset_and_halt(True)
+        super(LPC4330, self).reset_and_halt(self.ResetType.SW)
 
         # Map shadow memory to SPIFI FLASH
         self.write_memory(0x40043100, 0x80000000)

--- a/pyocd/target/target_LPC4330.py
+++ b/pyocd/target/target_LPC4330.py
@@ -334,7 +334,7 @@ class LPC4330(CoreSightTarget):
         # will reset the DAP.
         super(LPC4330, self).reset(True)
 
-    def reset_stop_on_reset(self, software_reset=False):
+    def reset_and_halt(self, reset_type=False):
         if self.ignoreReset:
             return
 
@@ -348,7 +348,7 @@ class LPC4330(CoreSightTarget):
 
         # Always use software reset for LPC4330 since the hardware version
         # will reset the DAP.
-        super(LPC4330, self).reset_stop_on_reset(True)
+        super(LPC4330, self).reset_and_halt(True)
 
         # Map shadow memory to SPIFI FLASH
         self.write_memory(0x40043100, 0x80000000)

--- a/pyocd/target/target_LPC54114J256BD64.py
+++ b/pyocd/target/target_LPC54114J256BD64.py
@@ -84,8 +84,8 @@ class LPC54114(CoreSightTarget):
         self.ignoreReset = False
         self._svd_location = SVDFile(vendor="NXP", filename="LPC54114_cm0plus.svd", is_local=False)
 
-    def reset_stop_on_reset(self, software_reset=None, map_to_user=True):
-        super(LPC54114, self).reset_stop_on_reset(software_reset)
+    def reset_and_halt(self, reset_type=None, map_to_user=True):
+        super(LPC54114, self).reset_and_halt(reset_type)
 
         # Remap to use flash and set SP and SP accordingly
         if map_to_user:

--- a/pyocd/target/target_LPC54608J512ET180.py
+++ b/pyocd/target/target_LPC54608J512ET180.py
@@ -80,8 +80,8 @@ class LPC54608(CoreSightTarget):
         self.ignoreReset = False
         self._svd_location = SVDFile(vendor="NXP", filename="LPC54608.svd", is_local=False)
 
-    def reset_stop_on_reset(self, software_reset=None, map_to_user=True):
-        super(LPC54608, self).reset_stop_on_reset(software_reset)
+    def reset_and_halt(self, reset_type=None, map_to_user=True):
+        super(LPC54608, self).reset_and_halt(reset_type)
 
         # Remap to use flash and set SP and SP accordingly
         if map_to_user:

--- a/pyocd/target/target_LPC824M201JHI33.py
+++ b/pyocd/target/target_LPC824M201JHI33.py
@@ -71,8 +71,8 @@ class LPC824(CoreSightTarget):
     def __init__(self, link):
         super(LPC824, self).__init__(link, self.memoryMap)
 
-    def reset_stop_on_reset(self, software_reset=None, map_to_user=True):
-        super(LPC824, self).reset_stop_on_reset(software_reset)
+    def reset_and_halt(self, reset_type=None, map_to_user=True):
+        super(LPC824, self).reset_and_halt(reset_type)
 
         # Remap to use flash and set SP and SP accordingly
         if map_to_user:

--- a/pyocd/target/target_lpc800.py
+++ b/pyocd/target/target_lpc800.py
@@ -59,8 +59,8 @@ class LPC800(CoreSightTarget):
         super(LPC800, self).__init__(link, self.memoryMap)
         self._svd_location = SVDFile(vendor="NXP", filename="LPC800_v0.3.svd", is_local=False)
 
-    def reset_stop_on_reset(self, software_reset=None, map_to_user=True):
-        super(LPC800, self).reset_stop_on_reset(software_reset)
+    def reset_and_halt(self, reset_type=None, map_to_user=True):
+        super(LPC800, self).reset_and_halt(reset_type)
 
         # Remap to use flash and set SP and SP accordingly
         if map_to_user:

--- a/pyocd/test/test_semihosting.py
+++ b/pyocd/test/test_semihosting.py
@@ -37,7 +37,7 @@ def tgt(request):
         return
     board = session.board
     session.options['resume_on_disconnect'] = False
-    board.target.reset_stop_on_reset()
+    board.target.reset_and_halt()
 
     def cleanup():
         board.uninit()

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -764,7 +764,7 @@ class PyOCDCommander(object):
     def handle_reset(self, args, other):
         print("Resetting target")
         if args.halt:
-            self.target.reset_stop_on_reset()
+            self.target.reset_and_halt()
 
             status = self.target.get_state()
             if status != Target.TARGET_HALTED:

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -108,3 +108,28 @@ def convert_session_options(option_list):
             options[name] = value
     return options
 
+## Map to convert from reset type names to enums.
+RESET_TYPE_MAP = {
+        'default': None,
+        'hw': Target.ResetType.HW,
+        'sw': Target.ResetType.SW,
+        'hardware': Target.ResetType.HW,
+        'software': Target.ResetType.SW,
+        'sw_sysresetreq': Target.ResetType.SW_SYSRESETREQ,
+        'sw_vectreset': Target.ResetType.SW_VECTRESET,
+        'sw_emulated': Target.ResetType.SW_EMULATED,
+        'sysresetreq': Target.ResetType.SW_SYSRESETREQ,
+        'vectreset': Target.ResetType.SW_VECTRESET,
+        'emulated': Target.ResetType.SW_EMULATED,
+    }
+
+def convert_reset_type(value):
+    """! @brief Convert a reset_type session option value to the Target.ResetType enum.
+    @param value The value of the reset_type session option.
+    @exception ValueError Raised if an unknown reset_type value is passed.
+    """
+    value = value.lower()
+    if value not in RESET_TYPE_MAP:
+        raise ValueError("unexpected value for reset_type option ('%s')", value)
+    return RESET_TYPE_MAP[value]
+

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -121,7 +121,7 @@ def basic_test(board_id, file):
         print("\n\n------ TEST STEP ------")
 
         print("reset and halt")
-        target.reset_stop_on_reset()
+        target.reset_and_halt()
         currentPC = target.read_core_register('pc')
         print("HALT: pc: 0x%X" % currentPC)
         sleep(0.2)

--- a/test/blank_test.py
+++ b/test/blank_test.py
@@ -60,7 +60,7 @@ print("\n\n------ Testing Attaching to regular board ------")
 for i in range(0, 10):
     with ConnectHelper.session_with_chosen_probe(**get_session_options()) as session:
         board = session.board
-        board.target.reset_stop_on_reset()
+        board.target.reset_and_halt()
         board.target.halt()
         sleep(0.2)
         board.target.resume()


### PR DESCRIPTION
This set of changes enhances the reset management for cores.

- `reset_stop_on_reset()` was renamed to `reset_and_halt()`.
- Added `Target.ResetType` enums.
- The `reset()` and `reset_and_halt()` APIs take a `ResetType` enum instead of bool|None.
- Added an emulated software reset capability, so that cores that don't support `VECTRESET` have something to fall back to that doesn't reset the entire system as does `SYSRESETREQ` (nominally, at least).
- `CortexM` has two new properties, `default_reset_type` and `default_software_reset_type`.
- Removed `set_target_state()` API that was only used to prepare the core for flash programming. The check to ensure the Thumb bit in XPSR is set was moved to `reset_and_halt()`.

Documentation has also been updated, both to match the reset changes as well as to fix several cases where it was out of date with recent changes (especially the per-region flash instances).

Closes #500 
Closes #479 