### PR TITLE
Chip erase option for gdbserver monitor erase command

### DIFF
--- a/pyocd/flash/loader.py
+++ b/pyocd/flash/loader.py
@@ -244,7 +244,7 @@ class FlashEraser(object):
         for region in self._session.target.memory_map.get_regions_of_type(MemoryType.FLASH):
             if region.flash is not None:
                 if region.flash.is_erase_all_supported:
-                    region.flash.init(flash.Operation.ERASE)
+                    region.flash.init(region.flash.Operation.ERASE)
                     region.flash.erase_all()
                     region.flash.cleanup()
                 else:

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -1139,8 +1139,12 @@ class GDBServer(threading.Thread):
                 self.thread_provider.invalidate()
         elif cmdList[0] == b'erase':
             try:
-                eraser = FlashEraser(self.session, FlashEraser.Mode.SECTOR)
-                eraser.erase(to_str_safe(x) for x in cmdList[1:])
+                if cmdList[1] == b'--chip':
+                    eraser = FlashEraser(self.session, FlashEraser.Mode.CHIP)
+                    eraser.erase()
+                else:
+                    eraser = FlashEraser(self.session, FlashEraser.Mode.SECTOR)
+                    eraser.erase(to_str_safe(x) for x in cmdList[1:])
                 resp = hex_encode(b"Erase successful\n")
             except exceptions.Error as e:
                 resp = hex_encode(to_bytes_safe("Error: " + str(e) + "\n"))


### PR DESCRIPTION
Passing `--chip` to the `erase` monitor command will perform a chip erase.