### PR TITLE
add support for STM32L031x6

### DIFF
--- a/pyocd/target/__init__.py
+++ b/pyocd/target/__init__.py
@@ -57,6 +57,7 @@ from . import target_STM32F051T8
 from . import target_STM32F412xx
 from . import target_STM32F439xx
 from . import target_STM32L475xx
+from . import target_STM32L031x6
 from . import target_MAX32600
 from . import target_w7500
 from . import target_LPC1114FN28_102
@@ -119,6 +120,7 @@ TARGET = {
           'stm32l475xc' : target_STM32L475xx.STM32L475xC,
           'stm32l475xe' : target_STM32L475xx.STM32L475xE,
           'stm32l475xg' : target_STM32L475xx.STM32L475xG,
+          'stm32l031x6' : target_STM32L031x6.STM32L031x6,
           'max32600': target_MAX32600.MAX32600,
           'w7500': target_w7500.W7500,
           'lpc11xx_32': target_LPC1114FN28_102.LPC11XX_32,

--- a/pyocd/target/target_STM32L031x6.py
+++ b/pyocd/target/target_STM32L031x6.py
@@ -1,0 +1,77 @@
+# pyOCD debugger
+# Copyright (c) 2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..flash.flash import Flash
+from ..core.coresight_target import CoreSightTarget
+from ..core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ..debug.svd import SVDFile
+
+FLASH_ALGO = {
+    'load_address' : 0x20000000,
+
+    # Flash algorithm as a hex string
+    'instructions': [
+    0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,
+    0xd0012a01, 0xd1172a02, 0x6981483b, 0x0212220f, 0x61814311, 0x60c14939, 0x60c14939, 0x61014939,
+    0x61014939, 0x02c069c0, 0x4839d406, 0x60014937, 0x60412106, 0x60814937, 0x47702000, 0xd0012801,
+    0xd1082802, 0x6841482c, 0x43112202, 0x68416041, 0x43112201, 0x20006041, 0xb5304770, 0x684a4926,
+    0x4322154c, 0x684a604a, 0x432a2508, 0x2200604a, 0x48296002, 0xe0004a26, 0x698b6010, 0xd1fb07db,
+    0x43a06848, 0x68486048, 0x604843a8, 0xbd302000, 0x47702001, 0x4c18b5f0, 0x15252300, 0x313f2608,
+    0x468c0989, 0x6861e024, 0x60614329, 0x43316861, 0x21406061, 0xc080ca80, 0x29001f09, 0x4916d1fa,
+    0x07ff69a7, 0x4f12d002, 0xe7f96039, 0x050969a1, 0xd0060f09, 0x210f69a0, 0x43080209, 0x200161a0,
+    0x6861bdf0, 0x606143a9, 0x43b16861, 0x1c5b6061, 0xd8d8459c, 0xbdf02000, 0x40022000, 0x89abcdef,
+    0x02030405, 0x8c9daebf, 0x13141516, 0x00005555, 0x40003000, 0x00000fff, 0x0000aaaa, 0x00000000
+    ],
+
+    # Relative function addresses
+    'pc_init': 0x20000021,
+    'pc_unInit': 0x2000005d,
+    'pc_program_page': 0x200000b5,
+    'pc_erase_sector': 0x2000007b,
+    'pc_eraseAll': 0x12000001,
+
+    'static_base' : 0x20000000 + 0x00000020 + 0x0000011c,
+    'begin_stack' : 0x20000400,
+    'begin_data' : 0x20000000 + 0x1000,
+    'page_size' : 0x400,
+    'analyzer_supported' : False,
+    'analyzer_address' : 0x00000000,
+    'page_buffers' : [0x20001000, 0x20001400],   # Enable double buffering
+    'min_program_length' : 0x400,
+
+    # Flash information
+    'flash_start': 0x8000000,
+    'flash_size': 0x8000,
+    'sector_sizes': (
+        (0x0, 0x80),
+    )
+}
+
+
+class STM32L031x6(CoreSightTarget):
+
+    memoryMap = MemoryMap(
+        FlashRegion(start=0x08000000, length=0x8000, blocksize=0x1000,  is_boot_memory=True, algo=FLASH_ALGO),
+        RamRegion(start=0x20000000, length=0x2000),
+        FlashRegion(start=0x08080000, length=0x400, blocksize=0x400, algo=FLASH_ALGO)
+        )
+
+    def __init__(self, link):
+        super(STM32L031x6, self).__init__(link, self.memoryMap)
+
+    def create_init_sequence(self):
+        seq = super(STM32L031x6, self).create_init_sequence()
+        return seq


### PR DESCRIPTION
Adds support for the STM32L031x6, tested on STM32L031K6.
Programming/reading the flash (0x8000000) and ram (0x20000000) works.
Reading the eeprom (0x08080000) works as well.
Programming the eeprom raises an exception but succeeds.
Reading the eeprom confirms the file was programmed.

Code ran:
~~~
from pyocd.core.helpers import ConnectHelper
from pyocd.core.session import Session
from pyocd.flash.loader import FileProgrammer

allProbes = ConnectHelper.get_all_connected_probes()
probe = allProbes[0]
session = Session(probe, target_override="stm32l031x6")
session.open()
FileProgrammer(session).program("/home/meechee/project/github/pyOCD/whoo.bin", base_address=0x08080000)
~~~

Output:
~~~
[---|---|---|---|---|---|---|---|---|----]
[Traceback (most recent call last):
  File "/home/user/pyOCD/test/pyocd test.py", line 9, in <module>
    FileProgrammer(session).program("/home/user/pyOCD/whoo.bin", base_address=0x08080000)
  File "/home/user/pyOCD/pyocd/flash/loader.py", line 135, in program
    self._loader.commit()
  File "/home/user/pyOCD/pyocd/flash/loader.py", line 457, in commit
    perf = builder.program(chip_erase=chipErase, progress_cb=self._progress_cb, fast_verify=self._trust_crc)
  File "/home/user/pyOCD/pyocd/flash/flash_builder.py", line 257, in program
    flash_operation = self._page_erase_program_double_buffer(progress_cb)
  File "/home/user/pyOCD/pyocd/flash/flash_builder.py", line 640, in _page_erase_program_double_buffer
    result = self.flash.wait_for_completion()
  File "/home/user/pyOCD/pyocd/flash/flash.py", line 440, in wait_for_completion
    while(self.target.get_state() == Target.TARGET_RUNNING):
  File "/home/user/pyOCD/pyocd/core/coresight_target.py", line 270, in get_state
    return self.selected_core.get_state()
  File "/home/user/pyOCD/pyocd/coresight/cortex_m.py", line 691, in get_state
    dhcsr = self.read_memory(CortexM.DHCSR)
  File "/home/user/pyOCD/pyocd/coresight/cortex_m.py", line 525, in read_memory
    result = self.ap.read_memory(addr, transfer_size, now)
  File "/home/user/pyOCD/pyocd/probe/stlink_probe.py", line 249, in read_memory
    result = conversion.byte_list_to_u32le_list(self._link.read_mem32(addr, 4, self._apsel))[0]
  File "/home/user/pyOCD/pyocd/probe/stlink/stlink.py", line 272, in read_mem32
    return self._read_mem(addr, size, Commands.JTAG_READMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
  File "/home/user/pyOCD/pyocd/probe/stlink/stlink.py", line 241, in _read_mem
    raise STLinkException("STLink error ({}): {}".format(status, Status.MESSAGES.get(status, "Unknown error")))
pyocd.probe.stlink.STLinkException: STLink error (20): DP wait
~~~