### PR TITLE
Replace encoded ellipses character with three periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Eclipse using the following software update server addresses:
 - GNU MCU Eclipse: http://gnu-mcu-eclipse.sourceforge.net/updates
 - Embedded System Register Viewer: http://embsysregview.sourceforge.net/update
 
-In Eclipse, select the "Help -> Install New Software…" menu item. Then either click the "Add…"
+In Eclipse, select the "Help -> Install New Software..." menu item. Then either click the "Add..."
 button and fill in the name and URL from above (once for each site), or simply copy the URL into the
 field where it says "type or select a site". Then you can select the software to install and click
 Next to start the process.


### PR DESCRIPTION
Certain terminals have issue with installing pyocd because the
long_description field in setup.py reads and parses README.md. This file
contains specially encoded ellipses characters which can cause
UnicodeDecodeErrors.

This issue was raised here https://github.com/ARMmbed/mbed-cli/issues/827#issuecomment-460123586. The `position 6073` shown in the error got me curious if there was a specific offending character, and these appear to be it!