### PR TITLE
Python 2 CMSIS DFP and other fixes

### DIFF
--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 import logging
 import six
 
-from .pack import (CmsisPack, MalformedCmsisPackError)
+from .cmsis_pack import (CmsisPack, MalformedCmsisPackError)
 from ..family import FAMILIES
 from .. import TARGET
 from ...core.coresight_target import CoreSightTarget

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -57,7 +57,9 @@ def _find_family_class(dev):
         # Scan each level of families
         for familyName in dev.families:
             for regex in familyInfo.matches:
-                if regex.fullmatch(familyName):
+                # Require the regex to match the entire family name.
+                match = regex.match(familyName)
+                if match and match.span() == (0, len(familyName)):
                     return familyInfo.klass
     else:
         # Default target superclass.

--- a/pyocd/test/test_py3_helpers.py
+++ b/pyocd/test/test_py3_helpers.py
@@ -1,0 +1,51 @@
+# pyOCD debugger
+# Copyright (c) 2019 Arm Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyocd.utility.py3_helpers import (
+    PY3,
+    iter_single_bytes,
+    to_bytes_safe,
+    to_str_safe,
+)
+import pytest
+import six
+
+class TestPy3Helpers(object):
+    def test_iter_single_bytes_bytes(self):
+        i = iter_single_bytes(b"1234")
+        assert next(i) == b'1'
+        assert next(i) == b'2'
+        assert next(i) == b'3'
+        assert next(i) == b'4'
+    
+    def test_to_bytes_safe(self):
+        if PY3:
+            assert to_bytes_safe(b"hello") == b"hello"
+            assert to_bytes_safe("string") == b"string"
+        else:
+            assert to_bytes_safe(b"hello") == b"hello"
+            assert to_bytes_safe("string") == b"string"
+            assert to_bytes_safe(u"unicode") == b"unicode"
+    
+    def test_to_str_safe(self):
+        if PY3:
+            assert to_str_safe(b"bytes") == "bytes"
+            assert to_str_safe("string") == "string"
+            assert to_str_safe('System Administrator\u2019s Mouse') == 'System Administrator\u2019s Mouse'
+        else:
+            assert to_str_safe(b"bytes") == "bytes"
+            assert to_str_safe("string") == "string"
+            assert to_str_safe(u"string") == "string"
+            assert to_str_safe(u'System Administrator\u2019s Mouse') == 'System Administrator\xe2\x80\x99s Mouse'

--- a/pyocd/utility/py3_helpers.py
+++ b/pyocd/utility/py3_helpers.py
@@ -34,13 +34,13 @@ else:
 if PY3:
     def to_bytes_safe(v):
         if type(v) is str:
-            return v.encode('latin-1')
+            return v.encode('utf-8')
         else:
             return v
 else:
     def to_bytes_safe(v):
         if type(v) is unicode:
-            return v.encode('latin-1')
+            return v.encode('utf-8')
         else:
             return v
 
@@ -52,11 +52,11 @@ if PY3:
         if type(v) is str:
             return v
         else:
-            return v.decode('latin-1')
+            return v.decode('utf-8')
 else:
     def to_str_safe(v):
         if type(v) is unicode:
-            return v.decode('latin-1')
+            return v.encode('utf-8')
         else:
             return v
 


### PR DESCRIPTION
Two fixes for Python 2 incompatibilities plus some cleanup.

- Fixed `to_str_safe()` to work in Python 2 in the case where the string has non-ASCII (<128) characters.
- Fixed a call to a Python 3 only `re.Pattern` method.
- Renamed `pyocd.target.pack.pack` to pyocd.target.pack.cmsis_pack`.
- Some refactoring of code in `CmsisPack` that scans the XML elements from a DFP's PDSC file.