### PR TITLE
User scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The API and tools provide these features:
 -  access CoreSight DP and APs
 -  and more!
 
+Configuration and customization is supported through config files and user scripts.
+
 
 Requirements
 ------------
@@ -49,9 +51,8 @@ Status
 
 PyOCD is functionally reliable and fully useable.
 
-The API is considered unstable because we are planning some breaking changes to bring the naming
-convention into compliance with PEP8 prior to releasing version 1.0. We also plan to merge the three
-command line tools into a single tool.
+The Python API is considered unstable as we are restructuring and cleaning it up prior to releasing
+version 1.0.
 
 
 Documentation
@@ -120,7 +121,7 @@ folder in the pyOCD repository. Just copy this file into `/etc/udev/rules.d` to 
 to both [DAPLink](https://os.mbed.com/handbook/DAPLink)-based debug probes as well as STLinkV2 and
 STLinkV3.
 
-If you use different, but compatible, debug probe, you can check the IDs with ``dmesg`` command.
+If you use different, but compatible, debug probe, you can check the IDs with the ``dmesg`` command.
 
    -  Run ``dmesg``
    -  Plug in your board

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,21 +1,41 @@
-Session Options
-===============
+Configuration
+=============
 
-This guide documents the session options that are supported by pyOCD and how to use them.
+This guide documents how to configure pyOCD and the supported set of options.
 
-Many of these options have dedicated command line arguments. Arbitrary options can be set
-individually with the `-Ooption=value` command line argument. You may also use a YAML config file to
-set multiple options. And if you are using the Python API, you may pass any session options directly
-to the `ConnectHelper` methods or `Session` constructor as keyword arguments.
+## Introduction
+
+pyOCD allows you to control many aspects of its behaviour by setting session options. There are
+multiple ways to set these options.
+
+- Many of the most commonly used user options have dedicated command line arguments.
+- Options can be placed in a YAML config file.
+- Arbitrary options can be set individually with the `-Ooption=value` command line argument.
+- If you are using the Python API, you may pass any option values directly
+    to the `ConnectHelper` methods or `Session` constructor as keyword arguments. You can also
+    pass a dictionary for the `options` parameter of these methods.
+
+## Project directory
+
+To help pyOCD automatically find configuration files and other resources, it has the concept of
+the project directory. By default this is simply the working directory where you ran the `pyocd`
+tool. You can set the project directory explicitly with the `-j` or `--dir` command line
+arguments. This can be helpful if you are running pyOCD from another tool or application.
+
+When pyOCD looks for files such as the config file or a user script, it first expands '~'
+references to the home directory. Then it checks whether the filename is absolute, and if so, it
+uses the filename as-is. Otherwise, it looks for the file in the project directory.
 
 ## Config file
 
-pyOCD supports a YAML configuration file that lets you provide session options that either apply to
+pyOCD supports a YAML configuration file that lets you set session options that either apply to
 all probes or to a single probe, based on the probe's unique ID.
 
-The easiest way to use a config file is to place a `pyocd.yaml` file in the working directory where
-you run the `pyocd` tool. Alternatively, you can use the `--config` command line option, for instance
-`--config=myconfig.yaml`. Finally, you can set the `config_file` session option.
+The easiest way to use a config file is to place a `pyocd.yaml` file in the project directory.
+An alternate `.yml` extension and
+optional dot prefix on the config file name are allowed. Alternatively, you can use the
+`--config` command line option, for instance `--config=myconfig.yaml`. Finally, you can set the
+`config_file` session option.
 
 The top level of the YAML file is a dictionary. The keys in the top-level dictionary must be names
 of session options, or the key `probes`. Session options are set to the value corresponding to the
@@ -31,7 +51,7 @@ will be applied to all matching probes.
 
 Options set in the config file will override any options set via the command line.
 
-Example board config file:
+Example config file:
 ````yaml
 probes:
   066EFF555051897267233656: # Probe's unique ID.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,8 @@
 
 ### User documentation
 
-- [Session options](SESSION_OPTIONS.md)
+- [Configuration](CONFIGURATION.md)
+- [User scripts](USER_SCRIPTS.md)
 - [Debugging multicore devices](MULTICORE_DEBUG.md)
 - [Introduction to pyOCD API](PYTHON_API.md)
 - [Python API Examples](API_EXAMPLES.md)

--- a/docs/SESSION_OPTIONS.md
+++ b/docs/SESSION_OPTIONS.md
@@ -64,6 +64,9 @@ frequency: 8000000 # Set 8 MHz SWD default for all probes
 - `pack`: (str or list of str) Path or list of paths to CMSIS Device Family Packs. Devices defined
     in the pack(s) are added to the list of available targets.
 
+- `project_dir`: (str) Path to the session's project directory. Defaults to the working directory
+    when the pyocd tool was executed.
+
 - `reset_type`: (str) Which type of reset to use by default (one of 'default', 'hw', 'sw', 'sw_sysresetreq',
     'sw_vectreset', 'sw_emulated'). The default is 'sw'.
 

--- a/docs/SESSION_OPTIONS.md
+++ b/docs/SESSION_OPTIONS.md
@@ -79,6 +79,8 @@ frequency: 8000000 # Set 8 MHz SWD default for all probes
     when set in a board config file for running the functional tests on boards that cannot be
     automatically detected.
 
+- `user_script`: (str) Path of the user script file.
+
 
 ## GDB server options list
 

--- a/docs/USER_SCRIPTS.md
+++ b/docs/USER_SCRIPTS.md
@@ -1,0 +1,167 @@
+User Scripts
+============
+
+## Introduction
+
+pyOCD has support for customization through what are called user scripts. These are Python scripts
+that are loaded by pyOCD before it connects to the target. A user script can define functions that
+are called as hooks at certain points in the connection lifetime, and can extend, modify, or
+completely override the default behaviour.
+
+If a file named `pyocd_user.py` or `.pyocd_user.py` is placed in the project directory, pyOCD will
+automatically detect it and load it as a user script. If you prefer another name, you can set the
+`user_script` option. Another alternative is to provide the filename using the `--script` command
+line argument. If a relative path is set either with the option or command line, it will be searched
+for in the project directory.
+
+
+## Examples
+
+This example user script shows how to add a new memory region.
+
+```py
+# This example applies to the Nordic nRF52 devices.
+
+def will_init_board(board):
+    # Create the new ROM region for the FICR.
+    ficr = pyocd.core.memory_map.RomRegion(
+                                        name="ficr",
+                                        start=0x10000000,
+                                        length=0x460
+                                        )
+
+    # Add the FICR region to the memory map.
+    target.memory_map.add_region(ficr)
+```
+
+This example shows how to override the flash algorithm for an external flash memory.
+
+```py
+# This example applies to the NXP i.MX RT10x0 devices.
+
+def will_init_board(board):
+    # Look up the external flash memory region.
+    extFlash = target.memory_map.get_region_by_name("flexspi")
+
+    # Set the path to an .FLM flash algorithm.
+    extFlash.flm = "MIMXRT105x_QuadSPI_4KB_SEC.FLM"
+```
+
+This example demonstrates setting the DBGMCU_CR register on reset for STM32 devices.
+
+```py
+# This example applies to the ST STM32L0x1 devicess.
+
+DBG_CR = 0x40015804
+
+def did_reset(target, reset_type):
+    # Set STANDBY, STOP, and SLEEP bits all to 1.
+    target.write32(DBG_CR, 0x3)
+```
+
+Another common use for a script is to initialize external memory such as SDRAM.
+
+## Script globals
+
+A number of useful symbols are made available in the global namespace of user scripts. These include
+both target related objects, as well as parts of the pyOCD Python API.
+
+| Symbol | Description |
+|--------|-------------|
+| `aps` | Dictionary of CoreSight Access Port (AP) objects. The keys are the APSEL value. |
+| `board` | The `Board` object. |
+| `dp` | The CoreSight Debug Port (DP) object. |
+| `FileProgrammer` | Utility class to program files to target flash. |
+| `FlashEraser` | Utility class to erase target flash. |
+| `FlashLoader` | Utility class to program raw binary data to target flash. |
+| `LOG` | Logger object. |
+| `MemoryType` | Memory region type enumeation. |
+| `options` | The user options dictionary. |
+| `probe` | The connected debug probe object. |
+| `pyocd` | The root pyOCD package. |
+| `ResetType` | Reset type enumeration. |
+| `session` | The session object, which is the root of the connection object graph. |
+| `Target` | Base class, mostly usefule for numerous constants that are defined within the class. |
+| `target` | The `CoreSightTarget` subclass instance representing the MCU. |
+
+
+## Script functions
+
+- `will_init_board(board)`<br/>
+    Pre-init hook for the board.
+
+    *board* - A `Board` instance that is about to be initialized.<br/>
+    **Result** - Ignored.
+
+- `did_init_board(board)`<br/>
+    Post-initialization hook for the board.
+
+    *board* - A `Board` instance.<br/>
+    **Result** - Ignored.
+
+- `will_init(target, init_sequence)`<br/>
+    Hook to review and modify init call sequence prior to execution.
+
+    *target* - A `CoreSightTarget` object about to be initialized.<br/>
+    *init_sequence* - The `CallSequence` that will be invoked. Because call sequences are
+        mutable, this parameter can be modified before return to change the init calls.<br/>
+    **Result** - Ignored.
+
+- `did_init(target)`<br/>
+    Post-initialization hook.
+
+    target - Either a `CoreSightTarget` or `CortexM` object.<br/>
+    **Result** - Ignored.
+
+- `will_disconnect(target, resume)`<br/>
+    Pre-disconnect hook.
+
+    *target* - Either a `CoreSightTarget` or `CortexM` object.<br/>
+    *resume* - The value of the `disconnect_on_resume` option.<br/>
+    **Result** - Ignored.
+
+- `did_disconnect(target, resume)`<br/>
+    Post-disconnect hook.
+
+    *target* - Either a `CoreSightTarget` or `CortexM` object.<br/>
+    *resume* - The value of the `disconnect_on_resume` option.<br/>
+    **Result** - Ignored.
+
+- `will_reset(target, reset_type)`<br/>
+    Pre-reset hook.
+
+    *target* - A CortexM instance.<br/>
+    *reset_type* - One of the `Target.ResetType` enumerations.<br/>
+    **Result** - *True* The hook performed the reset. *False/None* Caller should perform the normal
+        reset procedure.
+
+- `did_reset(target, reset_type)`<br/>
+    Post-reset hook.
+
+    *target* - A CortexM instance.<br/>
+    *reset_type* - One of the `Target.ResetType` enumerations.<br/>
+    **Result** - Ignored.
+
+- `set_reset_catch(target, reset_type)`<br/>
+    Hook to prepare target for halting on reset.
+
+    *target* - A CortexM instance.<br/>
+    *reset_type* - One of the `Target.ResetType` enumerations.<br/>
+    **Result** - *True* This hook handled setting up reset catch, caller should do nothing.
+                *False/None* Perform the default reset catch set using vector catch.
+
+- `clear_reset_catch(target, reset_type)`<br/>
+    Hook to clean up target after a reset and halt.
+
+    *target* - A `CortexM` instance.<br/>
+    *reset_type* - One of the `Target.ResetType` enumerations.<br/>
+    **Result** - Ignored.
+
+- `mass_erase(target)`<br/>
+    Hook to override mass erase.
+
+    *target* - A `CoreSightTarget` object.<br/>
+    **Result** - *True* Indicate that mass erase was performed by the hook.
+                *False/None* Mass erase was not overridden and the caller should proceed with the
+                    standard mass erase procedure.
+

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -23,6 +23,7 @@ import traceback
 import argparse
 import json
 import colorama
+import os
 
 from . import __version__
 from .core.helpers import ConnectHelper
@@ -123,6 +124,8 @@ class PyOCDTool(object):
         
         # Define common options for all subcommands, excluding --verbose and --quiet.
         commonOptionsNoLogging = argparse.ArgumentParser(description='common', add_help=False)
+        commonOptionsNoLogging.add_argument('-j', '--dir', metavar="PATH", dest="project_dir", default=os.getcwd(),
+            help="Set the project directory. Defaults to the directory where pyocd was run.")
         commonOptionsNoLogging.add_argument('--config', metavar="PATH",
             help="Specify YAML configuration file. Default is pyocd.yaml or pyocd.yml.")
         commonOptionsNoLogging.add_argument("--no-config", action="store_true",
@@ -351,6 +354,7 @@ class PyOCDTool(object):
         self._increase_logging(["pyocd.tools.loader", "pyocd", "flash", "flash_builder"])
         
         session = ConnectHelper.session_with_chosen_probe(
+                            project_dir=self._args.project_dir,
                             config_file=self._args.config,
                             no_config=self._args.no_config,
                             pack=self._args.pack,
@@ -374,6 +378,7 @@ class PyOCDTool(object):
         self._increase_logging(["pyocd.tools.loader", "pyocd"])
         
         session = ConnectHelper.session_with_chosen_probe(
+                            project_dir=self._args.project_dir,
                             config_file=self._args.config,
                             no_config=self._args.no_config,
                             pack=self._args.pack,
@@ -442,6 +447,7 @@ class PyOCDTool(object):
             
             session = ConnectHelper.session_with_chosen_probe(
                 blocking=(not self._args.no_wait),
+                project_dir=self._args.project_dir,
                 config_file=self._args.config,
                 no_config=self._args.no_config,
                 pack=self._args.pack,

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -130,6 +130,8 @@ class PyOCDTool(object):
             help="Specify YAML configuration file. Default is pyocd.yaml or pyocd.yml.")
         commonOptionsNoLogging.add_argument("--no-config", action="store_true",
             help="Do not use a configuration file.")
+        commonOptionsNoLogging.add_argument('--script', metavar="PATH",
+            help="Use the specified user script. Defaults to pyocd_user.py.")
         commonOptionsNoLogging.add_argument('-O', action='append', dest='options', metavar="OPTION=VALUE",
             help="Set named option.")
         commonOptionsNoLogging.add_argument("-da", "--daparg", dest="daparg", nargs='+',
@@ -356,6 +358,7 @@ class PyOCDTool(object):
         session = ConnectHelper.session_with_chosen_probe(
                             project_dir=self._args.project_dir,
                             config_file=self._args.config,
+                            user_script=self._args.script,
                             no_config=self._args.no_config,
                             pack=self._args.pack,
                             unique_id=self._args.unique_id,
@@ -380,6 +383,7 @@ class PyOCDTool(object):
         session = ConnectHelper.session_with_chosen_probe(
                             project_dir=self._args.project_dir,
                             config_file=self._args.config,
+                            user_script=self._args.script,
                             no_config=self._args.no_config,
                             pack=self._args.pack,
                             unique_id=self._args.unique_id,
@@ -448,6 +452,7 @@ class PyOCDTool(object):
             session = ConnectHelper.session_with_chosen_probe(
                 blocking=(not self._args.no_wait),
                 project_dir=self._args.project_dir,
+                user_script=self._args.script,
                 config_file=self._args.config,
                 no_config=self._args.no_config,
                 pack=self._args.pack,

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -33,6 +33,7 @@ class Board(object):
         self._session = session
         self._target_type = target.lower()
         self._test_binary = session.options.get('test_binary', None)
+        self._delegate = None
         
         # Create targets from provided CMSIS pack.
         if ('pack' in session.options) and (session.options['pack'] is not None):
@@ -49,8 +50,17 @@ class Board(object):
 
     ## @brief Initialize the board.
     def init(self):
+        # Delegate pre-init hook.
+        if (self.delegate is not None) and hasattr(self.delegate, 'will_init_board'):
+            self.delegate.will_init_board(self)
+        
+        # Init the target.
         self.target.init()
         self._inited = True
+        
+        # Delegate post-init hook.
+        if (self.delegate is not None) and hasattr(self.delegate, 'did_init_board'):
+            self.delegate.did_init_board(self)
 
     ## @brief Uninitialize the board.
     def uninit(self):
@@ -66,6 +76,14 @@ class Board(object):
     @property
     def session(self):
         return self._session
+    
+    @property
+    def delegate(self):
+        return self._delegate
+    
+    @delegate.setter
+    def delegate(self, the_delegate):
+        self._delegate = the_delegate
         
     @property
     def unique_id(self):

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -50,6 +50,10 @@ class Board(object):
 
     ## @brief Initialize the board.
     def init(self):
+        # If we don't have a delegate set yet, see if there is a user script delegate.
+        if (self.delegate is None) and (self.session.user_script_delegate is not None):
+            self.delegate = self.session.user_script_delegate
+        
         # Delegate pre-init hook.
         if (self.delegate is not None) and hasattr(self.delegate, 'will_init_board'):
             self.delegate.will_init_board(self)

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -132,6 +132,10 @@ class CoreSightTarget(Target):
         return seq
     
     def init(self):
+        # If we don't have a delegate installed yet but there is a user script delegate, use it.
+        if (self.delegate is None) and (self.session.user_script_delegate is not None):
+            self.delegate = self.session.user_script_delegate
+        
         # Create and execute the init sequence.
         seq = self.create_init_sequence()
         self.call_delegate('will_init', target=self, init_sequence=seq)

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -156,8 +156,8 @@ class CoreSightTarget(Target):
             klass = region.flash_class
             argspec = getargspec(klass.__init__)
             if 'flash_algo' in argspec.args:
-                if region.flash_algo is not None:
-                    obj = klass(self, region.flash_algo)
+                if region.algo is not None:
+                    obj = klass(self, region.algo)
                 else:
                     logging.warning("flash region '%s' has no flash algo" % region.name)
                     continue

--- a/pyocd/core/memory_map.py
+++ b/pyocd/core/memory_map.py
@@ -231,12 +231,20 @@ class FlashRegion(MemoryRegion):
             self._flash_class = Flash
     
     @property
-    def flash_algo(self):
+    def algo(self):
         return self._algo
+    
+    @algo.setter
+    def algo(self, flash_algo):
+        self._algo = flash_algo
     
     @property
     def flash_class(self):
         return self._flash_class
+    
+    @flash_class.setter
+    def flash_class(self, klass):
+        self._flash_class = klass
     
     @property
     def flash(self):

--- a/pyocd/core/memory_map.py
+++ b/pyocd/core/memory_map.py
@@ -222,6 +222,7 @@ class FlashRegion(MemoryRegion):
         attrs['erased_byte_value'] = attrs.get('erased_byte_value', 0xff)
         super(FlashRegion, self).__init__(type=MemoryType.FLASH, start=start, end=end, length=length, **attrs)
         self._algo = attrs.get('algo', None)
+        self._flm = None
         self._flash = None
         
         if 'flash_class' in attrs:
@@ -237,6 +238,14 @@ class FlashRegion(MemoryRegion):
     @algo.setter
     def algo(self, flash_algo):
         self._algo = flash_algo
+    
+    @property
+    def flm(self):
+        return self._flm
+    
+    @flm.setter
+    def flm(self, flm_path):
+        self._flm = flm_path
     
     @property
     def flash_class(self):

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -30,6 +30,7 @@ OPTIONS_INFO = {
     'target_override': OptionInfo('target_override', str, "Name of target to use instead of default."),
     'test_binary': OptionInfo('test_binary', str, "Name of test firmware binary."),
     'reset_type': OptionInfo('reset_type', str, "Which type of reset to use by default ('default', 'hw', 'sw', 'sw_sysresetreq', 'sw_vectreset', 'sw_emulated'). The default is 'sw'."),
+    'user_script': OptionInfo('user_script', str, "Path of the user script file."),
     'enable_multicore_debug': OptionInfo('enable_multicore', bool, "Whether to put pyOCD into multicore debug mode."),
 
     # GDBServer options

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -25,6 +25,7 @@ OPTIONS_INFO = {
     'frequency': OptionInfo('frequency', int, "SWD/JTAG frequency in Hertz."),
     'halt_on_connect': OptionInfo('halt_on_connect', bool, "Whether to halt CPU when connecting."),
     'no_config': OptionInfo('no_config', bool, "Do not use default config file."),
+    'project_dir': OptionInfo('project_dir', str, "Path to the session's project directory. Defaults to the working directory when the pyocd tool was executed."),
     'resume_on_disconnect': OptionInfo('resume_on_disconnect', bool, "Whether to run target on disconnect."),
     'target_override': OptionInfo('target_override', str, "Name of target to use instead of default."),
     'test_binary': OptionInfo('test_binary', str, "Name of test firmware binary."),

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -23,7 +23,7 @@ import os
 
 DEFAULT_CLOCK_FREQ = 1000000 # 1 MHz
 
-log = logging.getLogger('session')
+LOG = logging.getLogger(__name__)
 
 ## @brief Top-level object for a debug session.
 #
@@ -91,7 +91,7 @@ class Session(object):
         if probesConfig is not None:
             for uid, settings in probesConfig.items():
                 if str(uid).lower() in probe.unique_id.lower():
-                    log.info("Using config settings for board %s" % (probe.unique_id))
+                    LOG.info("Using config settings for board %s" % (probe.unique_id))
                     self._options.update(settings)
         
         # Ask the probe if it has an associated board, and if not then we create a generic one.
@@ -113,10 +113,10 @@ class Session(object):
             if isinstance(configPath, six.string_types):
                 try:
                     with open(configPath, 'r') as configFile:
-                        log.debug("loading config from '%s'", configPath)
+                        LOG.debug("loading config from '%s'", configPath)
                         return yaml.safe_load(configFile)
                 except IOError as err:
-                    log.warning("Error attempting to access config file '%s': %s", configPath, err)
+                    LOG.warning("Error attempting to access config file '%s': %s", configPath, err)
         
         return {}
     
@@ -164,21 +164,21 @@ class Session(object):
             return
         self._closed = True
 
-        log.debug("uninit session %s", self)
+        LOG.debug("uninit session %s", self)
         if self._inited:
             try:
                 self.board.uninit()
                 self._inited = False
             except:
-                log.error("exception during board uninit:", exc_info=True)
+                LOG.error("exception during board uninit:", exc_info=True)
         
         if self._probe.is_open:
             try:
                 self._probe.disconnect()
             except:
-                log.error("probe exception during disconnect:", exc_info=True)
+                LOG.error("probe exception during disconnect:", exc_info=True)
             try:
                 self._probe.close()
             except:
-                log.error("probe exception during close:", exc_info=True)
+                LOG.error("probe exception during close:", exc_info=True)
 

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -93,6 +93,7 @@ class Target(MemoryInterface, Notifier):
     def __init__(self, session, memoryMap=None):
         super(Target, self).__init__()
         self._session = session
+        self._delegate = None
         self.root_target = None
         self.vendor = self.VENDOR
         self.part_families = []
@@ -107,6 +108,24 @@ class Target(MemoryInterface, Notifier):
     @property
     def session(self):
         return self._session
+    
+    @property
+    def delegate(self):
+        return self._delegate
+    
+    @delegate.setter
+    def delegate(self, the_delegate):
+        self._delegate = the_delegate
+    
+    def delegate_implements(self, method_name):
+        return (self._delegate is not None) and (hasattr(self._delegate, method_name))
+    
+    def call_delegate(self, method_name, *args, **kwargs):
+        if self.delegate_implements(method_name):
+            return getattr(self._delegate, method_name)(*args, **kwargs)
+        else:
+            # The default action is always taken if None is returned.
+            return None
 
     @property
     def svd_device(self):

--- a/pyocd/core/target_delegate.py
+++ b/pyocd/core/target_delegate.py
@@ -1,0 +1,128 @@
+# pyOCD debugger
+# Copyright (c) 2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class TargetDelegateInterface(object):
+    """! @brief Abstract class defining the delegate interface for targets.
+    
+    Note that delegates don't actually have to derive from this class due to Python's
+    dynamic method dispatching.
+    """
+
+    def __init__(self, session):
+        self._session = session
+    
+    def will_init_board(self, board):
+        """! @brief Pre-init hook for the board.
+        
+        @param self
+        @param board A Board instance that is about to be initialized.
+        @return Ignored.
+        """
+        pass
+    
+    def did_init_board(self, board):
+        """! @brief Post-initialization hook for the board.
+        @param self
+        @param board A Board instance.
+        @return Ignored.
+        """
+        pass
+
+    def will_init(self, target, init_sequence):
+        """! @brief Hook to review and modify init call sequence prior to execution.
+        
+        @param self
+        @param target A CoreSightTarget object about to be initialized.
+        @param init_sequence The CallSequence that will be invoked. Because call sequences are
+            mutable, this parameter can be modified before return to change the init calls.
+        @return Ignored.
+        """
+        pass
+    
+    def did_init(self, target):
+        """! @brief Post-initialization hook.
+        @param self
+        @param target Either a CoreSightTarget or CortexM object.
+        @return Ignored.
+        """
+        pass
+
+    def will_disconnect(self, target, resume):
+        """! @brief Pre-disconnect hook.
+        @param self
+        @param target Either a CoreSightTarget or CortexM object.
+        @param resume The value of the `disconnect_on_resume` option.
+        @return Ignored.
+        """
+        pass
+
+    def did_disconnect(self, target, resume):
+        """! @brief Post-disconnect hook.
+        @param self
+        @param target Either a CoreSightTarget or CortexM object.
+        @param resume The value of the `disconnect_on_resume` option.
+        @return Ignored."""
+        pass
+
+    def will_reset(self, target, reset_type):
+        """! @brief Pre-reset hook.
+        @param self
+        @param target A CortexM instance.
+        @param reset_type One of the Target.ResetType enumerations.
+        @retval True
+        @retval "False or None"
+        """
+        pass
+
+    def did_reset(self, target, reset_type):
+        """! @brief Post-reset hook.
+        @param self
+        @param target A CortexM instance.
+        @param reset_type One of the Target.ResetType enumerations.
+        @return Ignored.
+        """
+        pass
+
+    def set_reset_catch(self, target, reset_type):
+        """! @brief Hook to prepare target for halting on reset.
+        @param self
+        @param target A CortexM instance.
+        @param reset_type One of the Target.ResetType enumerations.
+        @retval True
+        @retval "False or None"
+        """
+        pass
+
+    def clear_reset_catch(self, target, reset_type):
+        """! @brief Hook to clean up target after a reset and halt.
+        @param self
+        @param target A CortexM instance.
+        @param reset_type
+        @return Ignored.
+        """
+        pass
+
+    def mass_erase(self, target):
+        """! @brief Hook to override mass erase.
+        @param self
+        @param target A CoreSightTarget object.
+        @retval True Indicate that mass erase was performed by the hook.
+        @retval "False or None" Mass erase was not overridden and the caller should proceed with the standard
+            mass erase procedure.
+        """
+        pass
+    
+

--- a/pyocd/target/pack/flash_algo.py
+++ b/pyocd/target/pack/flash_algo.py
@@ -17,17 +17,22 @@
 from __future__ import print_function
 import os
 import struct
-import binascii
 import logging
-from collections import namedtuple
 import itertools
-from elftools.common.py3compat import bytes2str
 
 from ...debug.elf.elf import ELFBinaryFile
 from ...utility.py3_helpers import to_str_safe
 from ...core.memory_map import MemoryRange
+from ...core import exceptions
+from ...utility.conversion import byte_list_to_u32le_list
 
 LOG = logging.getLogger(__name__)
+
+FLASH_ALGO_STACK_SIZE = 512
+
+class FlashAlgoException(exceptions.Error):
+    """! @brief Exception class for errors parsing an FLM file."""
+    pass
 
 class PackFlashAlgo(object):
     """!
@@ -36,6 +41,8 @@ class PackFlashAlgo(object):
     This class is intended to provide easy access to the information
     provided by a flash algorithm, such as symbols and the flash
     algorithm itself.
+    
+    @sa PackFlashInfo
     """
 
     REQUIRED_SYMBOLS = {
@@ -57,8 +64,16 @@ class PackFlashAlgo(object):
         ("PrgData", "SHT_NOBITS"),
         )
 
+    ## @brief Standard flash blob header that starts with a breakpoint instruction.
+    _FLASH_BLOB_HEADER = [
+        0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040,
+        0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x04770D1F
+        ]
+    ## @brief Size of the flash blob header in bytes.
+    _FLASH_BLOB_HEADER_SIZE = len(_FLASH_BLOB_HEADER) * 4
+
     def __init__(self, data):
-        """! @brief Construct a PackFlashAlgo from an ELFBinaryFile"""
+        """! @brief Construct a PackFlashAlgo from a file-like object."""
         self.elf = ELFBinaryFile(data)
         self.flash_info = PackFlashInfo(self.elf)
 
@@ -77,7 +92,7 @@ class PackFlashAlgo(object):
         ro_rw_zi = self._algo_fill_zi_if_missing(ro_rw_zi)
         error_msg = self._algo_check_for_section_problems(ro_rw_zi)
         if error_msg is not None:
-            raise Exception(error_msg)
+            raise FlashAlgoException(error_msg)
 
         sect_ro, sect_rw, sect_zi = ro_rw_zi
         self.ro_start = sect_ro.start
@@ -89,6 +104,76 @@ class PackFlashAlgo(object):
 
         self.algo_data = self._create_algo_bin(ro_rw_zi)
 
+    def get_pyocd_flash_algo(self, blocksize, ram_region):
+        """! @brief Return a dictionary representing a pyOCD flash algorithm, or None.
+        
+        The most interesting operation this method performs is dynamically allocating memory
+        for the flash algo from a given RAM region. Note that the .data and .bss sections are
+        concatenated with .text. That's why there isn't a specific allocation for those sections.
+        
+        Double buffering is supported as long as there is enough RAM.
+        
+        Memory layout:
+        ```
+        [stack] [code] [buf1] [buf2]
+        ```
+        
+        @param self
+        @param blocksize The size to use for page buffers, normally the erase block size.
+        @param ram_region A RamRegion object where the flash algo will be allocated.
+        @return A pyOCD-style flash algo dictionary. If None is returned, the flash algo did
+            not fit into the provided ram_region.
+        """
+        instructions = self._FLASH_BLOB_HEADER + byte_list_to_u32le_list(self.algo_data)
+
+        offset = 0
+
+        # Stack
+        offset += FLASH_ALGO_STACK_SIZE
+        addr_stack = ram_region.start + offset
+
+        # Load address
+        addr_load = ram_region.start + offset
+        offset += len(instructions) * 4
+
+        # Data buffer 1
+        addr_data = ram_region.start + offset
+        offset += blocksize
+
+        if offset > ram_region.length:
+            # Not enough space for flash algorithm
+            LOG.warning("Not enough space for flash algorithm")
+            return None
+
+        # Data buffer 2
+        addr_data2 = ram_region.start + offset
+        offset += blocksize
+
+        if offset > ram_region.length:
+            page_buffers = [addr_data]
+        else:
+            page_buffers = [addr_data, addr_data2]
+
+        # TODO - analyzer support
+
+        code_start = addr_load + self._FLASH_BLOB_HEADER_SIZE
+        flash_algo = {
+            "load_address": addr_load,
+            "instructions": instructions,
+            "pc_init": code_start + self.symbols["Init"],
+            "pc_uninit": code_start + self.symbols["UnInit"],
+            "pc_eraseAll": code_start + self.symbols["EraseChip"],
+            "pc_erase_sector": code_start + self.symbols["EraseSector"],
+            "pc_program_page": code_start + self.symbols["ProgramPage"],
+            "page_buffers": page_buffers,
+            "begin_data": page_buffers[0],
+            "begin_stack": addr_stack,
+            "static_base": code_start + self.rw_start,
+            "min_program_length": self.page_size,
+            "analyzer_supported": False
+        }
+        return flash_algo
+
     def _extract_symbols(self, symbols, default=None):
         """! @brief Fill 'symbols' field with required flash algo symbols"""
         to_ret = {}
@@ -98,7 +183,7 @@ class PackFlashAlgo(object):
                 if default is not None:
                     to_ret[symbol] = default
                     continue
-                raise Exception("Missing symbol %s" % symbol)
+                raise FlashAlgoException("Missing symbol %s" % symbol)
             to_ret[symbol] = symbolInfo.address
         return to_ret
 
@@ -112,7 +197,7 @@ class PackFlashAlgo(object):
                 if name_and_type != (section_name, section_type):
                     continue
                 if sections[i] is not None:
-                    raise Exception("Elf contains duplicate section %s attr %s" %
+                    raise FlashAlgoException("Elf contains duplicate section %s attr %s" %
                                     (section_name, section_type))
                 sections[i] = section
         return sections

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -610,6 +610,7 @@ class PyOCDCommander(object):
         # Connect to board.
         self.session = ConnectHelper.session_with_chosen_probe(
                         blocking=(not self.args.no_wait),
+                        project_dir=self.args.project_dir,
                         config_file=self.args.config,
                         no_config=self.args.no_config,
                         pack=self.args.pack,
@@ -1526,6 +1527,8 @@ class PyOCDTool(object):
 
         parser = argparse.ArgumentParser(description='Target inspection utility', epilog=epi)
         parser.add_argument('--version', action='version', version=__version__)
+        parser.add_argument('-j', '--dir', metavar="PATH", dest="project_dir", default=os.getcwd(),
+            help="Set the project directory. Defaults to the directory where pyocd was run.")
         parser.add_argument('--config', metavar="PATH", default=None, help="Use a YAML config file.")
         parser.add_argument("--no-config", action="store_true", help="Do not use a configuration file.")
         parser.add_argument("--pack", metavar="PATH", help="Path to a CMSIS Device Family Pack")

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -612,6 +612,7 @@ class PyOCDCommander(object):
                         blocking=(not self.args.no_wait),
                         project_dir=self.args.project_dir,
                         config_file=self.args.config,
+                        user_script=self.args.script,
                         no_config=self.args.no_config,
                         pack=self.args.pack,
                         unique_id=self.args.unique_id,
@@ -1531,6 +1532,8 @@ class PyOCDTool(object):
             help="Set the project directory. Defaults to the directory where pyocd was run.")
         parser.add_argument('--config', metavar="PATH", default=None, help="Use a YAML config file.")
         parser.add_argument("--no-config", action="store_true", help="Do not use a configuration file.")
+        parser.add_argument('--script', metavar="PATH",
+            help="Use the specified user script. Defaults to pyocd_user.py.")
         parser.add_argument("--pack", metavar="PATH", help="Path to a CMSIS Device Family Pack")
         parser.add_argument("-H", "--halt", action="store_true", help="Halt core upon connect.")
         parser.add_argument("-N", "--no-init", action="store_true", help="Do not init debug system.")


### PR DESCRIPTION
This PR adds support for user-provided Python scripts that are loaded by pyOCD and can modify or extend the default behaviour. The user script implementation is based on new target delegate support, where a delegate object can be set on the board, target, or core to control or modify default behaviour. Documentation is provided for user scripts in the docs directory.

This PR also introduces the project directory, where config files and user scripts are searched for. By default the project dir is the working directory where the pyocd tool was run.