### PR TITLE
Add missing % to format strings

### DIFF
--- a/pyocd/flash/loader.py
+++ b/pyocd/flash/loader.py
@@ -113,7 +113,7 @@ class FileProgrammer(object):
         
         # Check the format is one we understand.
         if format not in self._format_handlers:
-            raise ArgumentError("unknown file format '%s'", format)
+            raise ArgumentError("unknown file format '%s'" % format)
             
         self._loader = FlashLoader(self._session,
                                     progress=self._progress,
@@ -290,7 +290,7 @@ class FlashEraser(object):
                 page_info = flash.get_page_info(page_addr)
                 if not page_info:
                     # Should not fail to get page info within a flash region.
-                    raise RuntimeError("sector address 0x%08x within flash region '%s' is invalid", page_addr, region.name)
+                    raise RuntimeError("sector address 0x%08x within flash region '%s' is invalid" % (page_addr, region.name))
                 
                 # Align first page address.
                 delta = page_addr % page_info.size

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -896,10 +896,10 @@ class PyOCDCommander(object):
             # Look up flash region.
             region = self.session.target.memory_map.get_region_for_address(addr)
             if not region:
-                print("address 0x%08x is not within a memory region", pagaddre_addr)
+                print("address 0x%08x is not within a memory region" % addr)
                 return 1
             if not region.is_flash:
-                print("address 0x%08x is not in flash", addr)
+                print("address 0x%08x is not in flash" % addr)
                 return 1
             assert region.flash is not None
             
@@ -925,10 +925,10 @@ class PyOCDCommander(object):
             # Look up the flash region so we can get the page size.
             region = self.session.target.memory_map.get_region_for_address(addr)
             if not region:
-                print("address 0x%08x is not within a memory region", addr)
+                print("address 0x%08x is not within a memory region" % addr)
                 break
             if not region.is_flash:
-                print("address 0x%08x is not in flash", addr)
+                print("address 0x%08x is not in flash" % addr)
                 break
             
             # Erase this page.

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -130,6 +130,6 @@ def convert_reset_type(value):
     """
     value = value.lower()
     if value not in RESET_TYPE_MAP:
-        raise ValueError("unexpected value for reset_type option ('%s')", value)
+        raise ValueError("unexpected value for reset_type option ('%s')" % value)
     return RESET_TYPE_MAP[value]
 


### PR DESCRIPTION
A few strings around the code base are not being properly formatted with %. Fix them.

Please note: I've accepted the contributor agreement under username https://os.mbed.com/users/martifoundries/.