### PR TITLE
usb_backend.read: yield to other threads if receive buffer is empty

### DIFF
--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -21,6 +21,7 @@ import logging
 import os
 import threading
 import six
+from time import sleep
 
 log = logging.getLogger('pyusb')
 
@@ -201,7 +202,8 @@ class PyUSB(Interface):
         read data on the IN endpoint associated to the HID interface
         """
         while len(self.rcv_data) == 0:
-            pass
+            sleep(0)
+
         if self.rcv_data[0] is None:
             raise DAPAccessIntf.DeviceError("Device %s read thread exited" %
                                             self.serial_number)

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -20,7 +20,7 @@ from ..dap_access_api import DAPAccessIntf
 import logging
 import os
 import collections
-from time import time
+from time import time, sleep
 import six
 
 OPEN_TIMEOUT_S = 60.0
@@ -154,6 +154,7 @@ class PyWinUSB(Interface):
         """
         start = time()
         while len(self.rcv_data) == 0:
+            sleep(0)
             if time() - start > timeout:
                 # Read operations should typically take ~1-2ms.
                 # If this exception occurs, then it could indicate


### PR DESCRIPTION
usb_backend.read method spins in endless loop waiting for receive thread to read some data from the DAPLink. This waists CPU cycles and causes high CPU load, especially on Python 3.

Yield to other threads by calling sleep(0) if receive buffer is empty.

This change improves read performance no Python 3. As a result, PSoC6 Flash programming performance is improved by a factor of three.

speed_test.py, original code:
Python2:
  Reading 65536 byte took 1.430 seconds: 45814.825 B/s
  Flash programming speed: 18 KB/s
Python3:
  Reading 65536 byte took 1.976 seconds: **32160.097 B/s**
  Flash programming speed: **6 KB/s**

with this change:
Python2:
  Reading 65536 byte took 1.352 seconds: 48477.784 B/s
  Flash programming speed: 18 KB/s
Python3:
  Reading 65536 byte took 1.365 seconds: **48016.460 B/s**
  Flash programming speed: **18 KB/s**

Closes #530 