### PR TITLE
Added catch for unknown directory when parsing ELF symbols

### DIFF
--- a/pyocd/debug/elf/decoder.py
+++ b/pyocd/debug/elf/decoder.py
@@ -182,9 +182,16 @@ class DwarfAddressDecoder(object):
 
                 # Looking for a range of addresses in two consecutive states.
                 if prevstate and not skipThisSequence:
-                    fileinfo = lineprog['file_entry'][prevstate.file - 1]
-                    filename = fileinfo.name
-                    dirname = lineprog['include_directory'][fileinfo.dir_index - 1]
+                    try:
+                        fileinfo = lineprog['file_entry'][prevstate.file - 1]
+                        filename = fileinfo.name
+                        try:
+                            dirname = lineprog['include_directory'][fileinfo.dir_index - 1]
+                        except IndexError:
+                            dirname = ""
+                    except IndexError:
+                        filename = ""
+                        dirname = ""
                     info = LineInfo(cu=cu, filename=filename, dirname=dirname, line=prevstate.line)
                     fromAddr = prevstate.address
                     toAddr = entry.state.address


### PR DESCRIPTION
Hit this issue when parsing elf file containing Pelion example + Mbed OS. (https://os.mbed.com/teams/ST/code/pelion-example-disco-iot01/). Note that this binary includes the bootloader, which doesn't have symbol information, maybe that is the source of the problem?

Not sure if this is a good fix, but didn't want to lose this bug. This solved the issue for us.

cc @flit, @korjaa 
