### PR TITLE
Generic object graph

### DIFF
--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -17,16 +17,19 @@
 
 from ..target import TARGET
 from ..target.pack import pack_target
+from ..utility.graph import GraphNode
 import logging
 import six
 
 log = logging.getLogger('board')
 
-class Board(object):
+class Board(GraphNode):
     """
     This class associates a target and flash to create a board.
     """
     def __init__(self, session, target=None):
+        super(Board, self).__init__()
+        
         # As a last resort, default the target to 'cortex_m'.
         if target is None:
             target = 'cortex_m'
@@ -47,6 +50,8 @@ class Board(object):
             log.error("target '%s' not recognized", self._target_type)
             six.raise_from(KeyError("target '%s' not recognized" % self._target_type), exc)
         self._inited = False
+        
+        self.add_child(self.target)
 
     ## @brief Initialize the board.
     def init(self):

--- a/pyocd/coresight/component.py
+++ b/pyocd/coresight/component.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018 Arm Limited
+# Copyright (c) 2018-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,17 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
+from ..utility.graph import GraphNode
 
-log = logging.getLogger("component")
+class CoreSightComponent(GraphNode):
+    """! @brief CoreSight component base class."""
 
-## @brief CoreSight component base class.
-#
-# x
-class CoreSightComponent(object):
-    ## @brief Constructor.
-    #
     def __init__(self, ap, cmpid=None, addr=None):
+        """! @brief Constructor."""
+        super(CoreSightComponent, self).__init__()
+        """! @brief Constructor."""
         self._ap = ap
         self._cmpid = cmpid
         self._address = addr or (cmpid.address if cmpid else None)

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -430,8 +430,8 @@ class CortexM(Target, CoreSightComponent):
         self.bp_manager.add_provider(self.sw_bp, Target.BREAKPOINT_SW)
 
     ## @brief Connect related CoreSight components.
-    def connect(self, cmp):
-        self.add_child(cmp)
+    def add_child(self, cmp):
+        super(CortexM, self).add_child(cmp)
         
         if isinstance(cmp, FPB):
             self.fpb = cmp

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -431,6 +431,8 @@ class CortexM(Target, CoreSightComponent):
 
     ## @brief Connect related CoreSight components.
     def connect(self, cmp):
+        self.add_child(cmp)
+        
         if isinstance(cmp, FPB):
             self.fpb = cmp
             self.bp_manager.add_provider(cmp, Target.BREAKPOINT_HW)

--- a/pyocd/coresight/dwt.py
+++ b/pyocd/coresight/dwt.py
@@ -58,7 +58,7 @@ class DWT(CoreSightComponent):
     def factory(cls, ap, cmpid, address):
         dwt = cls(ap, cmpid, address)
         assert ap.core
-        ap.core.connect(dwt)
+        ap.core.add_child(dwt)
         return dwt
 
     def __init__(self, ap, cmpid=None, addr=None):

--- a/pyocd/coresight/fpb.py
+++ b/pyocd/coresight/fpb.py
@@ -37,7 +37,7 @@ class FPB(BreakpointProvider, CoreSightComponent):
     def factory(cls, ap, cmpid, address):
         fpb = cls(ap, cmpid, address)
         assert ap.core
-        ap.core.connect(fpb)
+        ap.core.add_child(fpb)
         return fpb
 
     def __init__(self, ap, cmpid=None, addr=None):

--- a/pyocd/coresight/rom_table.py
+++ b/pyocd/coresight/rom_table.py
@@ -262,7 +262,8 @@ class ROMTable(CoreSightComponent):
         if addr is None:
             addr = ap.rom_addr
         super(ROMTable, self).__init__(ap, cmpid, addr)
-        self.parent = parent_table
+        if parent_table is not None:
+            self.parent.add_child(self)
         self.number = (self.parent.number + 1) if self.parent else 0
         self.components = []
         self.name = 'ROM'

--- a/pyocd/coresight/rom_table.py
+++ b/pyocd/coresight/rom_table.py
@@ -263,7 +263,7 @@ class ROMTable(CoreSightComponent):
             addr = ap.rom_addr
         super(ROMTable, self).__init__(ap, cmpid, addr)
         if parent_table is not None:
-            self.parent.add_child(self)
+            parent_table.add_child(self)
         self.number = (self.parent.number + 1) if self.parent else 0
         self.components = []
         self.name = 'ROM'

--- a/pyocd/test/test_graph.py
+++ b/pyocd/test/test_graph.py
@@ -1,0 +1,110 @@
+# pyOCD debugger
+# Copyright (c) 2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyocd.utility.graph import GraphNode
+import pytest
+
+class BaseNode(GraphNode):
+    def __init__(self, value):
+        super(BaseNode, self).__init__()
+        self.value = value
+    
+    def __repr__(self):
+        return "<{}@{:#010x} {}".format(self.__class__.__name__, id(self), self.value)
+
+class NodeA(BaseNode):
+    pass
+
+class NodeB(BaseNode):
+    pass
+
+@pytest.fixture(scope='function')
+def a():
+    return NodeA(23)
+
+@pytest.fixture(scope='function')
+def b():
+    return NodeB(1)
+
+@pytest.fixture(scope='function')
+def c():
+    return NodeB(2)
+
+@pytest.fixture(scope='function')
+def graph(a, b, c):
+    p = GraphNode()
+    p.add_child(a)
+    a.add_child(b)
+    p.add_child(c)
+    return p
+
+class TestGraph:
+    def test_new(self):
+        n = GraphNode()
+        assert len(n.children) == 0
+        assert n.parent is None
+
+    def test_add_child(self):
+        p = GraphNode()
+        a = GraphNode()
+        p.add_child(a)
+        assert p.children == [a]
+        assert p.parent is None
+        assert a.parent is p
+        assert a.children == []
+
+    def test_multiple_child(self):
+        p = GraphNode()
+        a = GraphNode()
+        b = GraphNode()
+        c = GraphNode()
+        p.add_child(a)
+        p.add_child(b)
+        p.add_child(c)
+        assert p.children == [a, b, c]
+        assert p.parent is None
+        assert a.parent is p
+        assert b.parent is p
+        assert c.parent is p
+        assert a.children == []
+        assert b.children == []
+        assert c.children == []
+    
+    def test_multilevel(self, graph, a, b, c):
+        assert len(graph.children) == 2
+        assert graph.children == [a, c]
+        assert len(a.children) == 1
+        assert a.children == [b]
+        assert graph.parent is None
+        assert a.parent is graph
+        assert b.parent is a
+        assert c.parent is graph
+        assert b.children == []
+        assert c.children == []
+    
+    def test_find_breadth(self, graph, a, b, c):
+        assert graph.find_children(lambda n: n.value == 1) == [b]
+        assert graph.find_children(lambda n: n.value == 1 or n.value == 2) == [c, b]
+    
+    def test_find_depth(self, graph, a, b, c):
+        assert graph.find_children(lambda n: n.value == 1, breadth_first=False) == [b]
+        assert graph.find_children(lambda n: n.value == 1 or n.value == 2, breadth_first=False) == [b, c]
+    
+    def test_first(self, graph, a, b, c):
+        assert graph.get_first_child_of_type(NodeA) == a
+        assert graph.get_first_child_of_type(NodeB) == c
+        assert a.get_first_child_of_type(NodeB) == b
+        

--- a/pyocd/utility/graph.py
+++ b/pyocd/utility/graph.py
@@ -1,0 +1,92 @@
+# pyOCD debugger
+# Copyright (c) 2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class GraphNode(object):
+    """! @brief Simple graph node."""
+
+    def __init__(self):
+        """! @brief Constructor."""
+        super(GraphNode, self).__init__()
+        self._parent = None
+        self._children = []
+    
+    @property
+    def parent(self):
+        """! @brief This node's parent in the object graph."""
+        return self._parent
+    
+    @property
+    def children(self):
+        """! @brief Child nodes in the object graph."""
+        return self._children
+    
+    def add_child(self, node):
+        """! @brief Link a child node onto this object."""
+        node._parent = self
+        self._children.append(node)
+    
+    def find_children(self, predicate, breadth_first=True):
+        """! @brief Recursively search for children that match a given predicate.
+        @param self
+        @param predicate A callable accepting a single argument for the node to examine. If the
+            predicate returns True, then that node is added to the result list and no further
+            searches on that node's children are performed. A False predicate result causes the
+            node's children to be searched.
+        @param breadth_first Whether to search breadth first. Pass False to search depth first.
+        @returns List of matching child nodes, or an empty list if no matches were found.
+        """
+        def _search(node, klass):
+            results = []
+            childrenToExamine = []
+            for child in node.children:
+                if predicate(child):
+                    results.append(child)
+                elif not breadth_first:
+                    results.extend(_search(child, klass))
+                elif breadth_first:
+                    childrenToExamine.append(child)
+                
+            if breadth_first:
+                for child in childrenToExamine:
+                    results.extend(_search(child, klass))
+            return results
+        
+        return _search(self, predicate)
+    
+    def get_first_child_of_type(self, klass):
+        """! @brief Breadth-first search for a child of the given class.
+        @param self
+        @param klass The class type to search for. The first child at any depth that is an instance
+            of this class or a subclass thereof will be returned. Matching children at more shallow
+            nodes will take precedence over deeper nodes.
+        @returns Either a node object or None.
+        """
+        matches = self.find_children(lambda c: isinstance(c, klass))
+        if len(matches):
+            return matches[0]
+        else:
+            return None
+    
+def dump_graph(node):
+    """! @brief Draw the object graph."""
+    
+    def _dump(node, level):
+        name = node.__class__.__name__
+        print("  " * level + "- " + name)
+        for child in node.children:
+            _dump(child, level + 1)
+    
+    _dump(node, 0)


### PR DESCRIPTION
This PR creates a more explicit graph out of the various objects in a session. A `GraphNode` base class is added that provides parent and child links, plus a couple methods to search for children. The goal here is to make the relationships between objects more apparent, and to make it easier to find various objects as the graph becomes more complicated with additional CoreSight components being supported.

Classes will still have explicit references to the other objects they need to function, such as the `fpb` and `dwt` attributes on `CortexM`. But it is now possible to connect other components in the graph even if the parent doesn't directly use or support the child, for instance ITM or TPIU being associated with a core. Finally, this makes it easier to find components if they move around in the graph due to different CoreSight configurations, such as a TPIU being shared between multiple cores versus being attached directly to a single core.