### PR TITLE
Delegate and user script tweaks

### DIFF
--- a/docs/USER_SCRIPTS.md
+++ b/docs/USER_SCRIPTS.md
@@ -14,6 +14,12 @@ automatically detect it and load it as a user script. If you prefer another name
 line argument. If a relative path is set either with the option or command line, it will be searched
 for in the project directory.
 
+The arguments for hook functions defined in user scripts are the same arguments accepted by delegate
+methods. However, all arguments to user script functions are optional. If provided, the argument
+names must match the specification. But you can specify arguments in any order, and exclude any or
+all arguments if they are not needed. In fact, most arguments are not required because the same
+objects are available as script globals, for instance `board` and `target`.
+
 
 ## Examples
 
@@ -39,7 +45,8 @@ This example shows how to override the flash algorithm for an external flash mem
 ```py
 # This example applies to the NXP i.MX RT10x0 devices.
 
-def will_connect(board):
+# Unlike the previous example, the board argument is excluded here.
+def will_connect():
     # Look up the external flash memory region.
     extFlash = target.memory_map.get_region_by_name("flexspi")
 
@@ -54,7 +61,7 @@ This example demonstrates setting the DBGMCU_CR register on reset for STM32 devi
 
 DBG_CR = 0x40015804
 
-def did_reset(target, reset_type):
+def did_reset():
     # Set STANDBY, STOP, and SLEEP bits all to 1.
     target.write32(DBG_CR, 0x3)
 ```
@@ -74,7 +81,7 @@ both target related objects, as well as parts of the pyOCD Python API.
 | `FileProgrammer` | Utility class to program files to target flash. |
 | `FlashEraser` | Utility class to erase target flash. |
 | `FlashLoader` | Utility class to program raw binary data to target flash. |
-| `LOG` | Logger object. |
+| `LOG` | `Logger` object for the user script. |
 | `MemoryType` | Memory region type enumeation. |
 | `options` | The user options dictionary. |
 | `probe` | The connected debug probe object. |
@@ -86,6 +93,8 @@ both target related objects, as well as parts of the pyOCD Python API.
 
 
 ## Script functions
+
+This section documents all functions that user scripts can provide to modify pyOCD's behaviour.
 
 - `will_connect(board)`<br/>
     Pre-init hook for the board.

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -61,7 +61,7 @@ class Board(GraphNode):
         
         # Delegate pre-init hook.
         if (self.delegate is not None) and hasattr(self.delegate, 'will_connect'):
-            self.delegate.will_connect(self)
+            self.delegate.will_connect(board=self)
         
         # Init the target.
         self.target.init()
@@ -69,7 +69,7 @@ class Board(GraphNode):
         
         # Delegate post-init hook.
         if (self.delegate is not None) and hasattr(self.delegate, 'did_connect'):
-            self.delegate.did_connect(self)
+            self.delegate.did_connect(board=self)
 
     ## @brief Uninitialize the board.
     def uninit(self):

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -55,9 +55,9 @@ class Board(GraphNode):
 
     ## @brief Initialize the board.
     def init(self):
-        # If we don't have a delegate set yet, see if there is a user script delegate.
-        if (self.delegate is None) and (self.session.user_script_delegate is not None):
-            self.delegate = self.session.user_script_delegate
+        # If we don't have a delegate set yet, see if there is a session delegate.
+        if (self.delegate is None) and (self.session.delegate is not None):
+            self.delegate = self.session.delegate
         
         # Delegate pre-init hook.
         if (self.delegate is not None) and hasattr(self.delegate, 'will_connect'):

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -136,9 +136,9 @@ class CoreSightTarget(Target, GraphNode):
         return seq
     
     def init(self):
-        # If we don't have a delegate installed yet but there is a user script delegate, use it.
-        if (self.delegate is None) and (self.session.user_script_delegate is not None):
-            self.delegate = self.session.user_script_delegate
+        # If we don't have a delegate installed yet but there is a session delegate, use it.
+        if (self.delegate is None) and (self.session.delegate is not None):
+            self.delegate = self.session.delegate
         
         # Create and execute the init sequence.
         seq = self.create_init_sequence()

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -230,7 +230,7 @@ class CoreSightTarget(Target, GraphNode):
         return self.selected_core.resume()
 
     def mass_erase(self):
-        if not self.call_delegate('mass_erase', target=self, resume=resume):
+        if not self.call_delegate('mass_erase', target=self):
             # The default mass erase implementation is to simply perform a chip erase.
             FlashEraser(self.session, FlashEraser.Mode.CHIP).erase()
         return True


### PR DESCRIPTION
- Split `Session` delegate and user script proxy into separate properties, with the delegate being settable.
- The user script proxy becomes the session's delegate unless another delegate was already set.
- Corrected some delegate method parameters.
- Merged global and local namespace for user scripts, which allows script-level definitions such as constants and functions to be accessible from within other script functions.
- Made arguments to user script hook functions optional. Delegate method arguments are still required.