### PR TITLE
Basic SWO/SWV support

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -112,6 +112,10 @@ These session options are currently only applied when running the GDB server.
 - `enable_semihosting`: (bool) Set to True to handle semihosting requests. Also see the
     `semihost_console_type` option. Default is False.
 
+- `enable_swv`: (bool) Whether to enable SWV printf output over the semihosting console. Requires
+    the `swv_system_clock` option to be set. The SWO baud rate can be controlled with the `swv_clock`
+    option.
+
 - `fast_program`: (bool) Setting this option to True will use CRC checks of existing flash sector
     contents to determine whether pages need to be programmed. Default is False.
 
@@ -143,6 +147,11 @@ These session options are currently only applied when running the GDB server.
 - `step_into_interrupt`: (bool) Set this option to True to enable interrupts when performing step
     operations. Otherwise interrupts will be disabled and step operations cannot be interrupted.
     Default is False.
+
+- `swv_clock`: (int) Frequency in Hertz of the SWO baud rate. Default is 1 MHz.
+
+- `swv_system_clock`: (int) Frequency in Hertz of the target's system clock. Used to compute the SWO
+    baud rate divider. No default.
 
 - `telnet_port`: (int) Base TCP port number for the semihosting telnet server. The core number,
     which will be 0 for the primary core, is added to this value. Default is 4444.

--- a/docs/USER_SCRIPTS.md
+++ b/docs/USER_SCRIPTS.md
@@ -200,3 +200,16 @@ This section documents all functions that user scripts can provide to modify pyO
                 *False/None* Mass erase was not overridden and the caller should proceed with the
                     standard mass erase procedure.
 
+- `trace_start(self, target, mode)`<br/>
+    Hook to prepare for tracing the target.
+
+    *target* - A CoreSightTarget object.<br/>
+    *mode* - The trace mode. Currently always 0 to indicate SWO.<br/>
+    *Result* - Ignored.
+
+- `trace_stop(self, target, mode)`<br/>
+    Hook to clean up after tracing the target.
+
+    *target* - A CoreSightTarget object.<br/>
+    *mode* - The trace mode. Currently always 0 to indicate SWO.<br/>
+    *Result* - Ignored.

--- a/pyocd/__init__.py
+++ b/pyocd/__init__.py
@@ -23,6 +23,7 @@ from . import gdbserver
 from . import target
 from . import utility
 from . import coresight
+from . import trace
 
 from ._version import version as __version__
 

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -333,5 +333,11 @@ class CoreSightTarget(Target, GraphNode):
                 self._irq_table = {i.value : i.name for i in
                     [i for p in self.svd_device.peripherals for i in p.interrupts]}
         return self._irq_table
-        
+    
+    def trace_start(self):
+        self.call_delegate('trace_start', target=self, mode=0)
+    
+    def trace_stop(self):
+        self.call_delegate('trace_stop', target=self, mode=0)
+    
         

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -36,6 +36,7 @@ OPTIONS_INFO = {
     # GDBServer options
     'chip_erase': OptionInfo('chip_erase', str, "Whether to perform a chip erase or sector erases when programming flash."),
     'enable_semihosting': OptionInfo('enable_semihosting', str, "Set to True to handle semihosting requests."),
+    'enable_swv': OptionInfo('enable_swv', bool, "Whether to enable SWV printf output over the semihosting console. Requires the swv_system_clock option to be set. The SWO baud rate can be controlled with the swv_clock option."),
     'fast_program': OptionInfo('fast_program', str, "Setting this option to True will use CRC checks of existing flash sector contents to determine whether pages need to be programmed."),
     'gdbserver_port': OptionInfo('gdbserver_port', str, "Base TCP port for the gdbserver."),
     'hide_programming_progress': OptionInfo('hide_programming_progress', str, "Disables flash programming progress bar."),
@@ -46,6 +47,8 @@ OPTIONS_INFO = {
     'serve_local_only': OptionInfo('serve_local_only', str, "When this option is True, the GDB server and semihosting telnet ports are only served on localhost."),
     'soft_bkpt_as_hard': OptionInfo('soft_bkpt_as_hard', str, "Whether to force all breakpoints to be hardware breakpoints."),
     'step_into_interrupt': OptionInfo('step_into_interrupt', str, "Enable interrupts when performing step operations."),
+    'swv_clock': OptionInfo('swv_clock', int, "Frequency in Hertz of the SWO baud rate. Default is 1 MHz."),
+    'swv_system_clock': OptionInfo('swv_system_clock', int, "Frequency in Hertz of the target's system clock. Used to compute the SWO baud rate divider. No default."),
     'telnet_port': OptionInfo('telnet_port', str, "Base TCP port number for the semihosting telnet server."),
     'vector_catch': OptionInfo('vector_catch', str, "Enable vector catch sources."),
     }

--- a/pyocd/core/target_delegate.py
+++ b/pyocd/core/target_delegate.py
@@ -156,5 +156,23 @@ class TargetDelegateInterface(object):
             mass erase procedure.
         """
         pass
+
+    def trace_start(self, target, mode):
+        """! @brief Hook to prepare for tracing the target.
+        @param self
+        @param target A CoreSightTarget object.
+        @param mode The trace mode. Currently always 0 to indicate SWO.
+        @return Ignored.
+        """
+        pass
+
+    def trace_stop(self, target, mode):
+        """! @brief Hook to clean up after tracing the target.
+        @param self
+        @param target A CoreSightTarget object.
+        @param mode The trace mode. Currently always 0 to indicate SWO.
+        @return Ignored.
+        """
+        pass
     
 

--- a/pyocd/coresight/component.py
+++ b/pyocd/coresight/component.py
@@ -18,11 +18,18 @@ from ..utility.graph import GraphNode
 
 class CoreSightComponent(GraphNode):
     """! @brief CoreSight component base class."""
+    
+    @classmethod
+    def factory(cls, ap, cmpid, address):
+        """! @brief Common CoreSightComponent factory."""
+        cmp = cls(ap, cmpid, address)
+        if ap.core:
+            ap.core.add_child(cmp)
+        return cmp
 
     def __init__(self, ap, cmpid=None, addr=None):
         """! @brief Constructor."""
         super(CoreSightComponent, self).__init__()
-        """! @brief Constructor."""
         self._ap = ap
         self._cmpid = cmpid
         self._address = addr or (cmpid.address if cmpid else None)

--- a/pyocd/coresight/itm.py
+++ b/pyocd/coresight/itm.py
@@ -1,0 +1,109 @@
+# pyOCD debugger
+# Copyright (c) 2017-2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from ..core.target import Target
+from ..core import exceptions
+from .component import CoreSightComponent
+
+# Need a local copy to prevent circular import.
+# Debug Exception and Monitor Control Register
+DEMCR = 0xE000EDFC
+DEMCR_TRCENA = (1 << 24)
+
+class ITMOptions(object):
+    def __init__(self):
+        pass
+
+class ITM(CoreSightComponent):
+    """! @brief Instrumentation Trace Macrocell"""
+
+    # Register definitions.
+    #
+    # The addresses are offsets from the base address.
+    STIMn = 0x00000000
+    TERn = 0x00000e00
+    TPR = 0x00000e40
+
+    TCR = 0x00000e80
+    TCR_ITMENA_MASK = (1 << 0)
+    TCR_TSENA_MASK = (1 << 1)
+    TCR_SYNCENA_MASK = (1 << 2)
+    TCR_TXENA_MASK = (1 << 3)
+    TCR_SWOENA_MASK = (1 << 4)
+    TCR_TSPRESCALE_MASK = (0x3 << 8)
+    TCR_TSPRESCALE_SHIFT = 8
+    TCR_TSPRESCALE_DIV_1 = 0x0
+    TCR_TSPRESCALE_DIV_4 = 0x1
+    TCR_TSPRESCALE_DIV_16 = 0x2
+    TCR_TSPRESCALE_DIV_64 = 0x3
+    TCR_GTSFREQ_MASK = (0x3 << 10)
+    TCR_GTSFREQ_SHIFT = 10
+    TCR_TRACEBUSID_MASK = (0x7f << 16)
+    TCR_TRACEBUSID_SHIFT = 16
+    TCR_BUSY_MASK = (1 << 23)
+    
+    LAR = 0x00000fb0
+    LAR_KEY = 0xC5ACCE55
+    LSR = 0x00000fb4
+    LSR_SLK_MASK = (1 << 1)
+    LSR_SLI_MASK = (1 << 0)
+
+    def __init__(self, ap, cmpid=None, addr=None):
+        super(ITM, self).__init__(ap, cmpid, addr)
+        self._is_enabled = False
+
+    def init(self):
+        # Make sure trace is enabled.
+        demcr = self.ap.read32(DEMCR)
+        if (demcr & DEMCR_TRCENA) == 0:
+            demcr |= DEMCR_TRCENA
+            self.ap.write32(DEMCR, demcr)
+
+        # Unlock if required.
+        val = self.ap.read32(self.address + ITM.LSR)
+        if (val & (ITM.LSR_SLK_MASK | ITM.LSR_SLI_MASK)) == (ITM.LSR_SLK_MASK | ITM.LSR_SLI_MASK):
+            self.ap.write32(self.address + ITM.LAR, ITM.LAR_KEY)
+            val = self.ap.read32(self.address + ITM.LSR)
+            if val & ITM.LSR_SLK_MASK:
+                raise exceptions.Error("Failed to unlock ITM")
+        
+        # Disable the ITM until enabled.
+        self.disable()
+    
+    @property
+    def is_enabled(self):
+        return self._is_enabled
+
+    def enable(self, enabled_ports=0xffffffff):
+        self.ap.write32(self.address + ITM.TCR, ((1 << ITM.TCR_TRACEBUSID_SHIFT)
+                                    | ITM.TCR_ITMENA_MASK
+                                    | ITM.TCR_TSENA_MASK
+                                    | ITM.TCR_TXENA_MASK
+                                    | (ITM.TCR_TSPRESCALE_DIV_1 << ITM.TCR_TSPRESCALE_SHIFT)))
+        self.ap.write32(self.address + ITM.TERn, enabled_ports)
+        self.ap.write32(self.address + ITM.TPR, 0xf) # Allow unprivileged access to all 32 ports.
+        self._is_enabled = True
+
+    def set_enabled_ports(enabled_ports):
+        self.ap.write32(self.address + ITM.TERn, enabled_ports)
+    
+    def disable(self):
+        self.ap.write32(self.address + ITM.TERn, 0)
+        self.ap.write32(self.address + ITM.TCR, 0)
+        self._is_enabled = False
+        

--- a/pyocd/coresight/rom_table.py
+++ b/pyocd/coresight/rom_table.py
@@ -19,6 +19,8 @@ from .component import CoreSightComponent
 from .cortex_m import CortexM
 from .fpb import FPB
 from .dwt import DWT
+from .itm import ITM
+from .tpiu import TPIU
 from ..utility.mask import invert32
 from collections import namedtuple
 import logging
@@ -126,29 +128,29 @@ COMPONENT_MAP = {
     (ARM_ID, CORESIGHT_CLASS, 0x906, 0x14, 0)      : CmpInfo('CTI',       None            ),
     (ARM_ID, CORESIGHT_CLASS, 0x907, 0x21, 0)      : CmpInfo('ETB',       None            ),
     (ARM_ID, CORESIGHT_CLASS, 0x908, 0x12, 0)      : CmpInfo('CSTF',      None            ),
-    (ARM_ID, CORESIGHT_CLASS, 0x912, 0x11, 0)      : CmpInfo('TPIU',      None            ),
-    (ARM_ID, CORESIGHT_CLASS, 0x923, 0x11, 0)      : CmpInfo('TPIU-M3',   None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0x912, 0x11, 0)      : CmpInfo('TPIU',      TPIU.factory    ),
+    (ARM_ID, CORESIGHT_CLASS, 0x923, 0x11, 0)      : CmpInfo('TPIU-M3',   TPIU.factory    ),
     (ARM_ID, CORESIGHT_CLASS, 0x924, 0x13, 0)      : CmpInfo('ETM-M3',    None            ),
     (ARM_ID, CORESIGHT_CLASS, 0x925, 0x13, 0)      : CmpInfo('ETM-M4',    None            ),
     (ARM_ID, CORESIGHT_CLASS, 0x932, 0x31, 0x0a31) : CmpInfo('MTB-M0+',   None            ),
     (ARM_ID, CORESIGHT_CLASS, 0x975, 0x13, 0x4a13) : CmpInfo('ETM-M7',    None            ),
-    (ARM_ID, CORESIGHT_CLASS, 0x9a1, 0x11, 0)      : CmpInfo('TPIU-M4',   None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0x9a1, 0x11, 0)      : CmpInfo('TPIU-M4',   TPIU.factory    ),
     (ARM_ID, CORESIGHT_CLASS, 0x9a4, 0x34, 0x0a34) : CmpInfo('GPR',       None            ), # Granular Power Requestor
     (ARM_ID, CORESIGHT_CLASS, 0x9a6, 0x14, 0x1a14) : CmpInfo('CTI',       None            ),
-    (ARM_ID, CORESIGHT_CLASS, 0x9a9, 0x11, 0)      : CmpInfo('TPIU-M7',   None            ),
-    (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x11, 0)      : CmpInfo('TPIU-M23',  None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0x9a9, 0x11, 0)      : CmpInfo('TPIU-M7',   TPIU.factory    ),
+    (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x11, 0)      : CmpInfo('TPIU-M23',  TPIU.factory    ),
     (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x13, 0)      : CmpInfo('ETM-M23',   None            ),
     (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x00, 0x1a02) : CmpInfo('DWT',       DWT.factory     ), # M23
     (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x00, 0x1a03) : CmpInfo('BPU',       FPB.factory     ), # M23
     (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x00, 0x2a04) : CmpInfo('SCS-M23',   CortexM.factory ), # M23
-    (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x00, 0x1a01) : CmpInfo('ITM',       None            ), # M33
+    (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x00, 0x1a01) : CmpInfo('ITM',       ITM.factory     ), # M33
     (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x00, 0x1a02) : CmpInfo('DWT',       DWT.factory     ), # M33
     (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x00, 0x1a03) : CmpInfo('BPU',       FPB.factory     ), # M33
     (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x00, 0x1a14) : CmpInfo('CTI',       None            ), # M33
     (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x00, 0x2a04) : CmpInfo('SCS-M33',   CortexM.factory ), # M33
     (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x00, 0x4a13) : CmpInfo('ETM',       None            ), # M33
     (ARM_ID, GENERIC_CLASS,   0x000, 0x00, 0)      : CmpInfo('SCS-M3',    CortexM.factory ),
-    (ARM_ID, GENERIC_CLASS,   0x001, 0x00, 0)      : CmpInfo('ITM',       None            ),
+    (ARM_ID, GENERIC_CLASS,   0x001, 0x00, 0)      : CmpInfo('ITM',       ITM.factory     ),
     (ARM_ID, GENERIC_CLASS,   0x002, 0x00, 0)      : CmpInfo('DWT',       DWT.factory     ),
     (ARM_ID, GENERIC_CLASS,   0x003, 0x00, 0)      : CmpInfo('FPB',       FPB.factory     ),
     (ARM_ID, GENERIC_CLASS,   0x008, 0x00, 0)      : CmpInfo('SCS-M0+',   CortexM.factory ),

--- a/pyocd/coresight/tpiu.py
+++ b/pyocd/coresight/tpiu.py
@@ -1,0 +1,76 @@
+# pyOCD debugger
+# Copyright (c) 2017-2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from .component import CoreSightComponent
+
+class TPIU(CoreSightComponent):
+    """! @brief Trace Port Interface Unit"""
+
+    # Register definitions.
+    #
+    # The addresses are offsets from the base address.
+    ACPR = 0x00000010
+    ACPR_PRESCALER_MASK = 0x0000ffff
+
+    SPPR = 0x000000f0
+    SPPR_TXMODE_MASK = 0x00000003
+    SPPR_TXMODE_NRZ = 0x00000002
+
+    FFCR = 0x00000304
+    FFCR_ENFCONT_MASK = (1 << 1)
+
+    DEVID = 0x00000fc8
+    DEVID_NRZ_MASK = (1 << 11)
+
+    def __init__(self, ap, cmpid=None, addr=None):
+        """! @brief Standard CoreSight component constructor."""
+        super(TPIU, self).__init__(ap, cmpid, addr)
+        self._has_swo_uart = False
+    
+    @property
+    def has_swo_uart(self):
+        """! @brief Whether SWO UART mode is supported by the TPIU."""
+        return self._has_swo_uart
+
+    def init(self):
+        """! @brief Configures the TPIU for SWO UART mode."""
+        devid = self.ap.read32(self.address + TPIU.DEVID)
+        self._has_swo_uart = (devid & TPIU.DEVID_NRZ_MASK) != 0
+        
+        # Go ahead and configure for SWO.
+        self.ap.write32(self.address + TPIU.SPPR, TPIU.SPPR_TXMODE_NRZ) # Select SWO UART mode.
+        self.ap.write32(self.address + TPIU.FFCR, 0) # Disable formatter.
+    
+    def set_swo_clock(self, swo_clock, system_clock):
+        """! @brief Sets the SWO clock frequency based on the system clock.
+        
+        @param self
+        @param Desired SWO baud rate in Hertz.
+        @param system_clock The frequency of the SWO clock source in Hertz. This is almost always
+            the system clock, also called the HCLK or fast clock.
+        @return Boolean indicating if the requested frequency could be set within 3%.
+        """
+        div = (system_clock // swo_clock) - 1
+        actual = system_clock // (div + 1)
+        deltaPercent = abs(swo_clock - actual) / swo_clock
+        if deltaPercent > 0.03:
+            return False
+        self.ap.write32(self.address + TPIU.ACPR, div & TPIU.ACPR_PRESCALER_MASK)
+        return True
+
+

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -22,6 +22,7 @@ from ..utility.cmdline import convert_vector_catch
 from ..utility.conversion import (hex_to_byte_list, hex_encode, hex_decode, hex8_to_u32le)
 from ..utility.progress import print_progress
 from ..utility.py3_helpers import (iter_single_bytes, to_bytes_safe, to_str_safe)
+from ..utility.server import StreamServer
 from .gdb_socket import GDBSocket
 from .gdb_websocket import GDBWebSocket
 from .syscall import GDBSyscallIOHandler
@@ -331,11 +332,11 @@ class GDBServer(threading.Thread):
             semihost_io_handler = semihost.InternalSemihostIOHandler()
 
         if self.semihost_console_type == 'telnet':
-            self.telnet_console = semihost.TelnetSemihostIOHandler(self.telnet_port, self.serve_local_only)
-            semihost_console = self.telnet_console
+            self.telnet_server = StreamServer(self.telnet_port, self.serve_local_only, "Semihost", False)
+            semihost_console = semihost.ConsoleIOHandler(self.telnet_server)
         else:
             self.log.info("Semihosting will be output to console")
-            self.telnet_console = None
+            self.telnet_server = None
             semihost_console = semihost_io_handler
         self.semihost = semihost.SemihostAgent(self.target_context, io_handler=semihost_io_handler, console=semihost_console)
 
@@ -408,9 +409,9 @@ class GDBServer(threading.Thread):
         if self.semihost:
             self.semihost.cleanup()
             self.semihost = None
-        if self.telnet_console:
-            self.telnet_console.stop()
-            self.telnet_console = None
+        if self.telnet_server:
+            self.telnet_server.stop()
+            self.telnet_server = None
         self.abstract_socket.cleanup()
 
     def _cleanup_for_next_connection(self):

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -23,6 +23,7 @@ from ..utility.conversion import (hex_to_byte_list, hex_encode, hex_decode, hex8
 from ..utility.progress import print_progress
 from ..utility.py3_helpers import (iter_single_bytes, to_bytes_safe, to_str_safe)
 from ..utility.server import StreamServer
+from ..trace.swv import SWVReader
 from .gdb_socket import GDBSocket
 from .gdb_websocket import GDBWebSocket
 from .syscall import GDBSyscallIOHandler
@@ -333,12 +334,24 @@ class GDBServer(threading.Thread):
 
         if self.semihost_console_type == 'telnet':
             self.telnet_server = StreamServer(self.telnet_port, self.serve_local_only, "Semihost", False)
+            console_file = self.telnet_server
             semihost_console = semihost.ConsoleIOHandler(self.telnet_server)
         else:
             self.log.info("Semihosting will be output to console")
+            console_file = sys.stdout
             self.telnet_server = None
             semihost_console = semihost_io_handler
         self.semihost = semihost.SemihostAgent(self.target_context, io_handler=semihost_io_handler, console=semihost_console)
+        
+        self._swv_reader = None
+        if session.options.get("enable_swv", False):
+            if "swv_system_clock" not in session.options:
+                self.log.warning("Cannot enable SWV due to missing swv_system_clock option")
+            else:
+                sys_clock = int(session.options.get("swv_system_clock"))
+                swo_clock = int(session.options.get("swv_clock", 1000000))
+                self._swv_reader = SWVReader(session, self.core)
+                self._swv_reader.init(sys_clock, swo_clock, console_file)
 
         # pylint: disable=invalid-name
         
@@ -412,6 +425,9 @@ class GDBServer(threading.Thread):
         if self.telnet_server:
             self.telnet_server.stop()
             self.telnet_server = None
+        if self._swv_reader:
+            self._swv_reader.stop()
+            self._swv_reader = None
         self.abstract_socket.cleanup()
 
     def _cleanup_for_next_connection(self):

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -345,6 +345,42 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             self._invalidate_cached_registers()
             six.raise_from(self._convert_exception(exc), exc)
+    
+    # ------------------------------------------- #
+    #          SWO functions
+    # ------------------------------------------- #
+
+    def has_swo(self):
+        """! @brief Returns bool indicating whether the link supports SWO."""
+        try:
+            return self._link.has_swo()
+        except DAPAccess.Error as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def swo_start(self, baudrate):
+        """! @brief Start receiving SWO data at the given baudrate."""
+        try:
+            self._link.swo_configure(True, baudrate)
+            self._link.swo_control(True)
+        except DAPAccess.Error as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def swo_stop(self):
+        """! @brief Stop receiving SWO data."""
+        try:
+            self._link.swo_configure(False, 0)
+        except DAPAccess.Error as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def swo_read(self):
+        """! @brief Read buffered SWO data from the target.
+        
+        @eturn Bytearray of the received data.
+        """
+        try:
+            return self._link.swo_read()
+        except DAPAccess.Error as exc:
+            six.raise_from(self._convert_exception(exc), exc)
 
     def _invalidate_cached_registers(self):
         # Invalidate cached DP SELECT register.

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -140,5 +140,24 @@ class DebugProbe(object):
     
     def get_memory_interface_for_ap(self, apsel):
         return None
+    
+    def has_swo(self):
+        """! @brief Returns bool indicating whether the link supports SWO."""
+        raise NotImplementedError()
+
+    def swo_start(self, baudrate):
+        """! @brief Start receiving SWO data at the given baudrate."""
+        raise NotImplementedError()
+
+    def swo_stop(self):
+        """! @brief Stop receiving SWO data."""
+        raise NotImplementedError()
+
+    def swo_read(self):
+        """! @brief Read buffered SWO data from the target.
+        
+        @eturn Bytearray of the received data.
+        """
+        raise NotImplementedError()
   
 

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -189,6 +189,32 @@ class DAPAccessIntf(object):
     def vendor(self, index, data=None):
         """Send a vendor specific command"""
         raise NotImplementedError()
+    
+    def has_swo(self):
+        """Returns bool indicating whether the link supports SWO."""
+        raise NotImplementedError()
+
+    def swo_configure(self, enabled, rate):
+        """Enable or disable SWO and set the baud rate."""
+        raise NotImplementedError()
+
+    def swo_control(self, start):
+        """Pass True to start recording SWO data, False to stop."""
+        raise NotImplementedError()
+
+    def get_swo_status(self):
+        """Returns a 2-tuple with a status mask at index 0, and the number of buffered
+        SWO data bytes at index 1."""
+        raise NotImplementedError()
+
+    def swo_read(self, count=None):
+        """Read buffered SWO data from the target. The count parameter is optional. If
+        provided, it is the number of bytes to read, which must be less than the packet size.
+        If count is not provided, the packet size will be used instead.
+        
+        Returns a 3-tuple containing the status mask at index 0, the number of buffered
+        SWO data bytes at index 1, and a list of the received data bytes at index 2."""
+        raise NotImplementedError()
 
     # ------------------------------------------- #
     #          DAP Access functions

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -319,3 +319,23 @@ class STLink(object):
         response = self._device.transfer(cmd, readSize=2)
         self._check_status(response)
 
+    def swo_start(self, baudrate):
+        bufferSize = 4096
+        cmd = [Commands.JTAG_COMMAND, Commands.SWV_START_TRACE_RECEPTION]
+        cmd.extend(six.iterbytes(struct.pack('<HI', bufferSize, baudrate)))
+        response = self._device.transfer(cmd, readSize=2)
+        self._check_status(response)
+
+    def swo_stop(self):
+        cmd = [Commands.JTAG_COMMAND, Commands.SWV_STOP_TRACE_RECEPTION]
+        response = self._device.transfer(cmd, readSize=2)
+        self._check_status(response)
+    
+    def swo_read(self):
+        cmd = [Commands.JTAG_COMMAND, Commands.SWV_GET_TRACE_NEW_RECORD_NB]
+        response = self._device.transfer(cmd, readSize=2)
+        bytesAvailable, = struct.unpack('<H', response)
+        if bytesAvailable:
+            return self._device.read_swv(bytesAvailable)
+        else:
+            return bytearray()

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -21,6 +21,7 @@ from ...coresight import dap
 import logging
 import struct
 import six
+import threading
 from enum import Enum
 
 log = logging.getLogger('stlink')
@@ -60,16 +61,19 @@ class STLink(object):
         self._version_str = None
         self._target_voltage = 0
         self._protocol = None
+        self._lock = threading.RLock()
     
     def open(self):
-        self._device.open()
-        self.enter_idle()
-        self.get_version()
-        self.get_target_voltage()
+        with self._lock:
+            self._device.open()
+            self.enter_idle()
+            self.get_version()
+            self.get_target_voltage()
 
     def close(self):
-        self.enter_idle()
-        self._device.close()
+        with self._lock:
+            self.enter_idle()
+            self._device.close()
 
     def get_version(self):
         # GET_VERSION response structure:
@@ -154,54 +158,61 @@ class STLink(object):
         self._protocol = None
 
     def set_swd_frequency(self, freq=1800000):
-        for f, d in SWD_FREQ_MAP.items():
-            if freq >= f:
-                response = self._device.transfer([Commands.JTAG_COMMAND, Commands.SWD_SET_FREQ, d], readSize=2)
-                self._check_status(response)
-                return
-        raise STLinkException("Selected SWD frequency is too low")
+        with self._lock:
+            for f, d in SWD_FREQ_MAP.items():
+                if freq >= f:
+                    response = self._device.transfer([Commands.JTAG_COMMAND, Commands.SWD_SET_FREQ, d], readSize=2)
+                    self._check_status(response)
+                    return
+            raise STLinkException("Selected SWD frequency is too low")
 
     def set_jtag_frequency(self, freq=1120000):
-        for f, d in JTAG_FREQ_MAP.items():
-            if freq >= f:
-                response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_SET_FREQ, d], readSize=2)
-                self._check_status(response)
-                return
-        raise STLinkException("Selected JTAG frequency is too low")
+        with self._lock:
+            for f, d in JTAG_FREQ_MAP.items():
+                if freq >= f:
+                    response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_SET_FREQ, d], readSize=2)
+                    self._check_status(response)
+                    return
+            raise STLinkException("Selected JTAG frequency is too low")
 
     def enter_debug(self, protocol):
-        self.enter_idle()
+        with self._lock:
+            self.enter_idle()
         
-        if protocol == self.Protocol.SWD:
-            protocolParam = Commands.JTAG_ENTER_SWD
-        elif protocol == self.Protocol.JTAG:
-            protocolParam = Commands.JTAG_ENTER_JTAG_NO_CORE_RESET
-        response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_ENTER2, protocolParam, 0], readSize=2)
-        self._check_status(response)
-        self._protocol = protocol
+            if protocol == self.Protocol.SWD:
+                protocolParam = Commands.JTAG_ENTER_SWD
+            elif protocol == self.Protocol.JTAG:
+                protocolParam = Commands.JTAG_ENTER_JTAG_NO_CORE_RESET
+            response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_ENTER2, protocolParam, 0], readSize=2)
+            self._check_status(response)
+            self._protocol = protocol
     
     def open_ap(self, apsel):
-        if self._jtag_version < self.MIN_JTAG_VERSION_MULTI_AP:
-            return
-        cmd = [Commands.JTAG_COMMAND, Commands.JTAG_INIT_AP, apsel, Commands.JTAG_AP_NO_CORE]
-        response = self._device.transfer(cmd, readSize=2)
-        self._check_status(response)
+        with self._lock:
+            if self._jtag_version < self.MIN_JTAG_VERSION_MULTI_AP:
+                return
+            cmd = [Commands.JTAG_COMMAND, Commands.JTAG_INIT_AP, apsel, Commands.JTAG_AP_NO_CORE]
+            response = self._device.transfer(cmd, readSize=2)
+            self._check_status(response)
     
     def close_ap(self, apsel):
-        if self._jtag_version < self.MIN_JTAG_VERSION_MULTI_AP:
-            return
-        cmd = [Commands.JTAG_COMMAND, Commands.JTAG_CLOSE_AP_DBG, apsel]
-        response = self._device.transfer(cmd, readSize=2)
-        self._check_status(response)
+        with self._lock:
+            if self._jtag_version < self.MIN_JTAG_VERSION_MULTI_AP:
+                return
+            cmd = [Commands.JTAG_COMMAND, Commands.JTAG_CLOSE_AP_DBG, apsel]
+            response = self._device.transfer(cmd, readSize=2)
+            self._check_status(response)
 
     def target_reset(self):
-        response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_DRIVE_NRST, Commands.JTAG_DRIVE_NRST_PULSE], readSize=2)
-        self._check_status(response)
+        with self._lock:
+            response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_DRIVE_NRST, Commands.JTAG_DRIVE_NRST_PULSE], readSize=2)
+            self._check_status(response)
     
     def drive_nreset(self, isAsserted):
-        value = Commands.JTAG_DRIVE_NRST_LOW if isAsserted else Commands.JTAG_DRIVE_NRST_HIGH
-        response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_DRIVE_NRST, value], readSize=2)
-        self._check_status(response)
+        with self._lock:
+            value = Commands.JTAG_DRIVE_NRST_LOW if isAsserted else Commands.JTAG_DRIVE_NRST_HIGH
+            response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_DRIVE_NRST, value], readSize=2)
+            self._check_status(response)
     
     def _check_status(self, response):
         status, = struct.unpack('<H', response)
@@ -209,63 +220,66 @@ class STLink(object):
             raise STLinkException("STLink error (%d): " % status + Status.MESSAGES.get(status, "Unknown error"))
 
     def _clear_sticky_error(self):
-        if self._protocol == self.Protocol.SWD:
-            self.write_dap_register(self.DP_PORT, dap.DP_ABORT, dap.ABORT_STKERRCLR)
-        elif self._protocol == self.Protocol.JTAG:
-            self.write_dap_register(self.DP_PORT, dap.DP_CTRL_STAT, dap.CTRLSTAT_STICKYERR)
+        with self._lock:
+            if self._protocol == self.Protocol.SWD:
+                self.write_dap_register(self.DP_PORT, dap.DP_ABORT, dap.ABORT_STKERRCLR)
+            elif self._protocol == self.Protocol.JTAG:
+                self.write_dap_register(self.DP_PORT, dap.DP_CTRL_STAT, dap.CTRLSTAT_STICKYERR)
     
     def _read_mem(self, addr, size, memcmd, max, apsel):
-        result = []
-        while size:
-            thisTransferSize = min(size, max)
+        with self._lock:
+            result = []
+            while size:
+                thisTransferSize = min(size, max)
             
-            cmd = [Commands.JTAG_COMMAND, memcmd]
-            cmd.extend(six.iterbytes(struct.pack('<IHB', addr, thisTransferSize, apsel)))
-            result += self._device.transfer(cmd, readSize=thisTransferSize)
+                cmd = [Commands.JTAG_COMMAND, memcmd]
+                cmd.extend(six.iterbytes(struct.pack('<IHB', addr, thisTransferSize, apsel)))
+                result += self._device.transfer(cmd, readSize=thisTransferSize)
             
-            addr += thisTransferSize
-            size -= thisTransferSize
+                addr += thisTransferSize
+                size -= thisTransferSize
             
-            # Check status of this read.
-            response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_GETLASTRWSTATUS2], readSize=12)
-            status, _, faultAddr = struct.unpack('<HHI', response[0:8])
-            if status in (Status.JTAG_UNKNOWN_ERROR, Status.SWD_AP_FAULT, Status.SWD_DP_FAULT):
-                # Clear sticky errors.
-                self._clear_sticky_error()
+                # Check status of this read.
+                response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_GETLASTRWSTATUS2], readSize=12)
+                status, _, faultAddr = struct.unpack('<HHI', response[0:8])
+                if status in (Status.JTAG_UNKNOWN_ERROR, Status.SWD_AP_FAULT, Status.SWD_DP_FAULT):
+                    # Clear sticky errors.
+                    self._clear_sticky_error()
                 
-                exc = exceptions.TransferFaultError()
-                exc.fault_address = faultAddr
-                exc.fault_length = thisTransferSize - (faultAddr - addr)
-                raise exc
-            elif status != Status.JTAG_OK:
-                raise STLinkException("STLink error ({}): {}".format(status, Status.MESSAGES.get(status, "Unknown error")))
-        return result
+                    exc = exceptions.TransferFaultError()
+                    exc.fault_address = faultAddr
+                    exc.fault_length = thisTransferSize - (faultAddr - addr)
+                    raise exc
+                elif status != Status.JTAG_OK:
+                    raise STLinkException("STLink error ({}): {}".format(status, Status.MESSAGES.get(status, "Unknown error")))
+            return result
 
     def _write_mem(self, addr, data, memcmd, max, apsel):
-        while len(data):
-            thisTransferSize = min(len(data), max)
-            thisTransferData = data[:thisTransferSize]
+        with self._lock:
+            while len(data):
+                thisTransferSize = min(len(data), max)
+                thisTransferData = data[:thisTransferSize]
             
-            cmd = [Commands.JTAG_COMMAND, memcmd]
-            cmd.extend(six.iterbytes(struct.pack('<IHB', addr, thisTransferSize, apsel)))
-            self._device.transfer(cmd, writeData=thisTransferData)
+                cmd = [Commands.JTAG_COMMAND, memcmd]
+                cmd.extend(six.iterbytes(struct.pack('<IHB', addr, thisTransferSize, apsel)))
+                self._device.transfer(cmd, writeData=thisTransferData)
             
-            addr += thisTransferSize
-            data = data[thisTransferSize:]
+                addr += thisTransferSize
+                data = data[thisTransferSize:]
             
-            # Check status of this write.
-            response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_GETLASTRWSTATUS2], readSize=12)
-            status, _, faultAddr = struct.unpack('<HHI', response[0:8])
-            if status in (Status.JTAG_UNKNOWN_ERROR, Status.SWD_AP_FAULT, Status.SWD_DP_FAULT):
-                # Clear sticky errors.
-                self._clear_sticky_error()
+                # Check status of this write.
+                response = self._device.transfer([Commands.JTAG_COMMAND, Commands.JTAG_GETLASTRWSTATUS2], readSize=12)
+                status, _, faultAddr = struct.unpack('<HHI', response[0:8])
+                if status in (Status.JTAG_UNKNOWN_ERROR, Status.SWD_AP_FAULT, Status.SWD_DP_FAULT):
+                    # Clear sticky errors.
+                    self._clear_sticky_error()
                 
-                exc = exceptions.TransferFaultError()
-                exc.fault_address = faultAddr
-                exc.fault_length = thisTransferSize - (faultAddr - addr)
-                raise exc
-            elif status != Status.JTAG_OK:
-                raise STLinkException("STLink error ({}): {}".format(status, Status.MESSAGES.get(status, "Unknown error")))
+                    exc = exceptions.TransferFaultError()
+                    exc.fault_address = faultAddr
+                    exc.fault_length = thisTransferSize - (faultAddr - addr)
+                    raise exc
+                elif status != Status.JTAG_OK:
+                    raise STLinkException("STLink error ({}): {}".format(status, Status.MESSAGES.get(status, "Unknown error")))
 
     def read_mem32(self, addr, size, apsel):
         assert (addr & 0x3) == 0 and (size & 0x3) == 0, "address and size must be word aligned"
@@ -304,38 +318,55 @@ class STLink(object):
         assert ((addr & 0xf0) == 0) or (port != self.DP_PORT), "banks are not allowed for DP registers"
         assert (addr >> 16) == 0, "register address must be 16-bit"
         
-        cmd = [Commands.JTAG_COMMAND, Commands.JTAG_READ_DAP_REG]
-        cmd.extend(six.iterbytes(struct.pack('<HH', port, addr)))
-        response = self._device.transfer(cmd, readSize=8)
-        self._check_status(response[:2])
-        value, = struct.unpack('<I', response[4:8])
-        return value
+        with self._lock:
+            cmd = [Commands.JTAG_COMMAND, Commands.JTAG_READ_DAP_REG]
+            cmd.extend(six.iterbytes(struct.pack('<HH', port, addr)))
+            response = self._device.transfer(cmd, readSize=8)
+            self._check_status(response[:2])
+            value, = struct.unpack('<I', response[4:8])
+            return value
     
     def write_dap_register(self, port, addr, value):
         assert ((addr & 0xf0) == 0) or (port != self.DP_PORT), "banks are not allowed for DP registers"
         assert (addr >> 16) == 0, "register address must be 16-bit"
-        cmd = [Commands.JTAG_COMMAND, Commands.JTAG_WRITE_DAP_REG]
-        cmd.extend(six.iterbytes(struct.pack('<HHI', port, addr, value)))
-        response = self._device.transfer(cmd, readSize=2)
-        self._check_status(response)
+
+        with self._lock:
+            cmd = [Commands.JTAG_COMMAND, Commands.JTAG_WRITE_DAP_REG]
+            cmd.extend(six.iterbytes(struct.pack('<HHI', port, addr, value)))
+            response = self._device.transfer(cmd, readSize=2)
+            self._check_status(response)
 
     def swo_start(self, baudrate):
-        bufferSize = 4096
-        cmd = [Commands.JTAG_COMMAND, Commands.SWV_START_TRACE_RECEPTION]
-        cmd.extend(six.iterbytes(struct.pack('<HI', bufferSize, baudrate)))
-        response = self._device.transfer(cmd, readSize=2)
-        self._check_status(response)
+        with self._lock:
+            bufferSize = 4096
+            cmd = [Commands.JTAG_COMMAND, Commands.SWV_START_TRACE_RECEPTION]
+            cmd.extend(six.iterbytes(struct.pack('<HI', bufferSize, baudrate)))
+            response = self._device.transfer(cmd, readSize=2)
+            self._check_status(response)
 
     def swo_stop(self):
-        cmd = [Commands.JTAG_COMMAND, Commands.SWV_STOP_TRACE_RECEPTION]
-        response = self._device.transfer(cmd, readSize=2)
-        self._check_status(response)
+        with self._lock:
+            cmd = [Commands.JTAG_COMMAND, Commands.SWV_STOP_TRACE_RECEPTION]
+            response = self._device.transfer(cmd, readSize=2)
+            self._check_status(response)
     
     def swo_read(self):
-        cmd = [Commands.JTAG_COMMAND, Commands.SWV_GET_TRACE_NEW_RECORD_NB]
-        response = self._device.transfer(cmd, readSize=2)
-        bytesAvailable, = struct.unpack('<H', response)
-        if bytesAvailable:
-            return self._device.read_swv(bytesAvailable)
-        else:
-            return bytearray()
+        with self._lock:
+            response = None
+            bytesAvailable = None
+            try:
+                cmd = [Commands.JTAG_COMMAND, Commands.SWV_GET_TRACE_NEW_RECORD_NB]
+                response = self._device.transfer(cmd, readSize=2)
+                bytesAvailable, = struct.unpack('<H', response)
+                if bytesAvailable:
+                    return self._device.read_swv(bytesAvailable)
+                else:
+                    return bytearray()
+            except KeyboardInterrupt:
+                # If we're interrupted after sending the SWV_GET_TRACE_NEW_RECORD_NB command,
+                # we have to read the queued SWV data before any other commands can be sent.
+                if response is not None:
+                    if bytesAvailable is None:
+                        bytesAvailable, = struct.unpack('<H', response)
+                    if bytesAvailable:
+                        self._device.read_swv(bytesAvailable)

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -212,7 +212,7 @@ class STLinkUSBInterface(object):
         return None
 
     def read_swv(self, size, timeout=1000):
-        return self._ep_swv.read(size, timeout)
+        return bytearray(self._ep_swv.read(size, timeout))
     
     def __repr__(self):
         return "<{} @ {:#x} vid={:#06x} pid={:#06x} sn={} version={}>".format(

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -222,6 +222,34 @@ class StlinkProbe(DebugProbe):
         else:
             return exc
 
+    def has_swo(self):
+        """! @brief Returns bool indicating whether the link supports SWO."""
+        return True
+
+    def swo_start(self, baudrate):
+        """! @brief Start receiving SWO data at the given baudrate."""
+        try:
+            self._link.swo_start(baudrate)
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def swo_stop(self):
+        """! @brief Stop receiving SWO data."""
+        try:
+            self._link.swo_stop()
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def swo_read(self):
+        """! @brief Read as much buffered SWO data from the target as possible.
+        
+        @eturn Bytearray of the received data.
+        """
+        try:
+            return self._link.swo_read()
+        except STLinkException as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
 ## @brief Concrete memory interface for a single AP.
 class STLinkMemoryInterface(MemoryInterface):
     def __init__(self, link, apsel):

--- a/pyocd/rtos/argon.py
+++ b/pyocd/rtos/argon.py
@@ -21,6 +21,8 @@ from ..core import exceptions
 from ..core.target import Target
 from ..debug.context import DebugContext
 from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index)
+from ..trace import events
+from ..trace.sink import TraceEventFilter
 import logging
 
 IS_RUNNING_OFFSET = 0x54
@@ -427,4 +429,78 @@ class ArgonThreadProvider(ThreadProvider):
         flag = self._target_context.read8(self.g_ar + IS_RUNNING_OFFSET)
         return flag != 0
 
+## @brief Argon kernel trace event.
+class ArgonTraceEvent(events.TraceEvent):
+    kArTraceThreadSwitch = 1 # 2 value: 0=previous thread's new state, 1=new thread id
+    kArTraceThreadCreated = 2 # 1 value
+    kArTraceThreadDeleted = 3 # 1 value
+    
+    def __init__(self, eventID, threadID, name, state, ts=0):
+        super(ArgonTraceEvent, self).__init__("argon", ts)
+        self._event_id = eventID
+        self._thread_id = threadID
+        self._thread_name = name
+        self._prev_thread_state = state
+    
+    @property
+    def event_id(self):
+        return self._event_id
+    
+    @property
+    def thread_id(self):
+        return self._thread_id
+    
+    @property
+    def thread_name(self):
+        return self._thread_name
+    
+    @property
+    def prev_thread_state(self):
+        return self._prev_thread_state
+    
+    def __str__(self):
+        if self.event_id == ArgonTraceEvent.kArTraceThreadSwitch:
+            stateName = ArgonThread.STATE_NAMES.get(self.prev_thread_state, "<invalid state>")
+            desc = "New thread = {}; old thread state = {}".format(self.thread_name, stateName)
+        elif self.event_id == ArgonTraceEvent.kArTraceThreadCreated:
+            desc = "Created thread {}".format(self.thread_id)
+        elif self.event_id == ArgonTraceEvent.kArTraceThreadDeleted:
+            desc = "Deleted thread {}".format(self.thread_id)
+        else:
+            desc = "Unknown kernel event #{}".format(self.event_id)
+        return "[{}] Argon: {}".format(self.timestamp, desc)
+
+## @brief Trace event filter to identify Argon kernel trace events sent via ITM.
+#
+# As Argon kernel trace events are identified, the ITM trace events are replaced with instances
+# of ArgonTraceEvent.
+class ArgonTraceEventFilter(TraceEventFilter):
+    def __init__(self, threads):
+        super(ArgonTraceEventFilter, self).__init__()
+        self._threads = threads
+        self._is_thread_event_pending = False
+        self._pending_event = None
+        
+    def filter(self, event):
+        if isinstance(event, events.TraceITMEvent):
+            if event.port == 31:
+                eventID = event.data >> 24
+                if eventID in (ArgonTraceEvent.kArTraceThreadSwitch, ArgonTraceEvent.kArTraceThreadCreated, ArgonTraceEvent.kArTraceThreadDeleted):
+                    self._is_thread_event_pending = True
+                    self._pending_event = event
+                    # Swallow the event.
+                    return
+            elif event.port == 30 and self._is_thread_event_pending:
+                eventID = self._pending_event.data >> 24
+                threadID = event.data
+                name = self._threads.get(threadID, "<unknown thread>")
+                state = self._pending_event.data & 0x00ffffff
+                
+                # Create the Argon event.
+                event = ArgonTraceEvent(eventID, threadID, name, state, self._pending_event.timestamp)
+
+                self._is_thread_event_pending = False
+                self._pending_event = None
+
+        return event        
 

--- a/pyocd/trace/__init__.py
+++ b/pyocd/trace/__init__.py
@@ -1,0 +1,15 @@
+# pyOCD debugger
+# Copyright (c) 2017 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/pyocd/trace/events.py
+++ b/pyocd/trace/events.py
@@ -1,0 +1,233 @@
+# pyOCD debugger
+# Copyright (c) 2017-2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+class TraceEvent(object):
+    """! @brief Base trace event class."""
+    def __init__(self, desc="", ts=0):
+        self._desc = desc
+        self._timestamp = ts
+    
+    @property
+    def timestamp(self):
+        return self._timestamp
+    
+    @timestamp.setter
+    def timestamp(self, ts):
+        self._timestamp = ts
+        
+    def __str__(self):
+        return "[{}] {}".format(self._timestamp, self._desc)
+
+    def __repr__(self):
+        return "<{}: {}>".format(self.__class__.__name__, str(self))
+
+class TraceOverflow(TraceEvent):
+    """! @brief Trace overflow event."""
+    def __init__(self, ts=0):
+        super(TraceOverflow, self).__init__("overflow", ts)
+
+class TraceTimestamp(TraceEvent):
+    """! @brief Trace local timestamp."""
+    def __init__(self, tc, ts=0):
+        super(TraceTimestamp, self).__init__("timestamp", ts)
+        self._tc = 0
+    
+    @property
+    def tc(self):
+        return self._tc
+        
+    def __str__(self):
+        return "[{}] local timestamp TC={:#x} {}".format(self._timestamp, self.tc, self.timestamp)
+
+class TraceITMEvent(TraceEvent):
+    """! @brief Trace ITM stimulus port event."""
+    def __init__(self, port, data, width, ts=0):
+        super(TraceITMEvent, self).__init__("itm", ts)
+        self._port = port
+        self._data = data
+        self._width = width
+    
+    @property
+    def port(self):
+        return self._port
+    
+    @property
+    def data(self):
+        return self._data
+    
+    @property
+    def width(self):
+        return self._width
+    
+    def __str__(self):
+        width = self.width
+        if width == 1:
+            d = "{:#04x}".format(self.data)
+        elif width == 2:
+            d = "{:#06x}".format(self.data)
+        else:
+            d = "{:#010x}".format(self.data)
+        return "[{}] ITM: port={:d} data={}".format(self.timestamp, self.port, d)
+
+class TraceEventCounter(TraceEvent):
+    """! @brief Trace DWT counter overflow event."""
+    CPI_MASK = 0x01
+    EXC_MASK = 0x02
+    SLEEP_MASK = 0x04
+    LSU_MASK = 0x08
+    FOLD_MASK = 0x10
+    CYC_MASK = 0x20
+
+    def __init__(self, counterMask, ts=0):
+        super(TraceEventCounter, self).__init__("exception", ts)
+        self._mask = counterMask
+    
+    @property
+    def counter_mask(self):
+        return self._mask
+    
+    def _get_event_desc(self, evt):
+        msg = ""
+        if evt & TraceEventCounter.CYC_MASK:
+            msg += " Cyc"
+        if evt & TraceEventCounter.FOLD_MASK:
+            msg += " Fold"
+        if evt & TraceEventCounter.LSU_MASK:
+            msg += " LSU"
+        if evt & TraceEventCounter.SLEEP_MASK:
+            msg += " Sleep"
+        if evt & TraceEventCounter.EXC_MASK:
+            msg += " Exc"
+        if evt & TraceEventCounter.CPI_MASK:
+            msg += " CPI"
+        return msg
+    
+    def __str__(self):
+        return "[{}] DWT: Event:{}".format(self.timestamp, self._get_event_desc(self.counter_mask))
+
+class TraceExceptionEvent(TraceEvent):
+    """! @brief Exception trace event."""
+    ENTERED = 1
+    EXITED = 2
+    RETURNED = 3
+
+    ACTION_DESC = {
+        ENTERED : "Entered",
+        EXITED : "Exited",
+        RETURNED : "Returned"
+        }
+    
+    def __init__(self, exceptionNumber, exceptionName, action, ts=0):
+        super(TraceExceptionEvent, self).__init__("exception", ts)
+        self._number = exceptionNumber
+        self._name = exceptionName
+        self._action = action
+    
+    @property
+    def exception_number(self):
+        return self._number
+    
+    @property
+    def exception_name(self):
+        return self._name
+    
+    @property
+    def action(self):
+        return self._action
+    
+    def __str__(self):
+        action = TraceExceptionEvent.ACTION_DESC.get(self.action, "<invalid action>")
+        return "[{}] DWT: Exception #{:d} {} {}".format(self.timestamp, self.exception_number, action, self.exception_name)
+
+class TracePeriodicPC(TraceEvent):
+    """! @brief Periodic PC trace event."""
+    def __init__(self, pc, ts=0):
+        super(TracePeriodicPC, self).__init__("pc", ts)
+        self._pc = pc
+
+    @property
+    def pc(self):
+        return self._pc
+    
+    def __str__(self):
+        return "[{}] DWT: PC={:#010x}".format(self.timestamp, self.pc)
+
+class TraceDataTraceEvent(TraceEvent):
+    """! @brief DWT data trace event.
+    
+    Valid combinations:
+    - PC value.
+    - Bits[15:0] of a data address.
+    - Data value, whether it was read or written, and the transfer size.
+    - PC value, data value, whether it was read or written, and the transfer size.
+    - Bits[15:0] of a data address, data value, whether it was read or written, and the transfer size.
+    """
+    def __init__(self, cmpn=None, pc=None, addr=None, value=None, rnw=None, sz=None, ts=0):
+        super(TraceDataTraceEvent, self).__init__("data-trace", ts)
+        self._cmpn = cmpn
+        self._pc = pc
+        self._addr = addr
+        self._value = value
+        self._rnw = rnw
+        self._sz = sz
+
+    @property
+    def comparator(self):
+        return self._cmpn
+
+    @property
+    def pc(self):
+        return self._pc
+    
+    @property
+    def address(self):
+        return self._addr
+    
+    @property
+    def value(self):
+        return self._value
+    
+    @property
+    def is_read(self):
+        return self._rnw
+    
+    @property
+    def transfer_size(self):
+        return self._sz
+    
+    def __str__(self):
+        hasPC = self.pc is not None
+        hasAddress = self.address is not None
+        hasValue = self.value is not None
+        if hasPC:
+            msg = "PC={:#010x}".format(self.pc)
+        elif hasAddress:
+            msg = "Addr[15:0]={:#06x}".format(self.address)
+        else:
+            msg = ""
+        if hasValue:
+            width = self.transfer_size
+            rnw = "R" if self.is_read else "W"
+            if width == 1:
+                msg +=  " Value={}:{:#04x}".format(rnw, self.value)
+            elif width == 2:
+                msg +=  " Value={}:{:#06x}".format(rnw, self.value)
+            else:
+                msg += " Value={}:{:#010x}".format(rnw, self.value)
+        return "[{}] DWT: Data Trace {}".format(self.timestamp, msg.strip())
+

--- a/pyocd/trace/sink.py
+++ b/pyocd/trace/sink.py
@@ -1,0 +1,92 @@
+# pyOCD debugger
+# Copyright (c) 2017-2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import collections
+
+class TraceEventSink(object):
+    """! @brief Abstract interface for a trace event sink."""
+    def receive(self, event):
+        """! @brief Handle a single trace event.
+        @param self
+        @param event An instance of TraceEvent or one of its subclasses.
+        """
+        raise NotImplementedError()
+
+class TraceEventFilter(TraceEventSink):
+    """! @brief Abstract interface for a trace event filter."""
+    
+    def __init__(self, sink=None):
+        self._sink = sink
+
+    def connect(self, sink):
+        """! @brief Connect the downstream trace sink or filter."""
+        self._sink = sink
+    
+    def receive(self, event):
+        """! @brief Handle a single trace event.
+        
+        Passes the event through the filter() method. If one or more objects are returned, they
+        are then passed to the trace sink connected to this filter (which may be another filter).
+        
+        @param self
+        @param event An instance of TraceEvent or one of its subclasses.
+        """
+        event = self.filter(event)
+        if (event is not None) and (self._sink is not None):
+            if isinstance(event, collections.Iterable):
+                for e in event:
+                    self._sink.receive(event)
+            else:
+                self._sink.receive(event)
+    
+    def filter(self, event):
+        """! @brief Filter a single trace event.
+        
+        @param self
+        @param event An instance of TraceEvent or one of its subclasses.
+        @return Either None, a single TraceEvent, or a sequence of TraceEvents.
+        """
+        raise NotImplementedError()
+
+class TraceEventTee(TraceEventSink):
+    """! @brief Trace event sink that replicates events to multiple sinks."""
+    
+    def __init__(self):
+        self._sinks = []
+
+    def connect(self, sinks):
+        """! @brief Connect one or more downstream trace sinks.
+        
+        @param self
+        @param sinks If this parameter is a single object, it will be added to the list of
+          downstream trace event sinks. If it is an iterable (list, tuple, etc.), then it will
+          completely replace the current list of trace event sinks.
+        """
+        if isinstance(sinks, collections.Iterable):
+            self._sinks = sinks
+        elif sinks not in self._sinks:
+            self._sinks.append(sinks)
+
+    def receive(self, event):
+        """! @brief Replicate a single trace event to all connected downstream trace event sinks.
+        
+        @param self
+        @param event An instance of TraceEvent or one of its subclasses.
+        """
+        for sink in self._sinks:
+            sink.receive(event)
+

--- a/pyocd/trace/swo.py
+++ b/pyocd/trace/swo.py
@@ -1,0 +1,274 @@
+# pyOCD debugger
+# Copyright (c) 2017-2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from . import events
+
+class SWOParser(object):
+    """! @brief SWO data stream parser.
+    
+    Processes a stream of SWO data and generates TraceEvent objects. SWO data is passed to the
+    parse() method. It processes the data and creates TraceEvent objects which are passed to an
+    event sink object that is a subclass of TraceEventSink. The event sink must either be provided
+    when the SWOParser is constructed, or can be set using the connect() method.
+    
+    A SWOParser instance can be reused for multiple SWO sessions. If a break in SWO data streaming
+    occurs, the reset() method should be called before passing further data to parse().
+    """
+    def __init__(self, core, sink=None):
+        self.reset()
+        self._core = core
+        self._sink = sink
+    
+    def reset(self):
+        self._bytes_parsed = 0
+        self._itm_page = 0
+        self._timestamp = 0
+        self._pending_events = []
+        self._pending_data_trace = None
+        
+        # Get generator instance and prime it.
+        self._parser = self._parse()
+        next(self._parser)
+    
+    def connect(self, sink):
+        """! @brief Connect the downstream trace sink or filter."""
+        self._sink = sink
+
+    @property
+    def bytes_parsed(self):
+        """! @brief The number of bytes of SWO data parsed thus far."""
+        return self._bytes_parsed
+
+    def parse(self, data):
+        """! @brief Process SWO data.
+        
+        This method will return once the provided data is consumed, and can be called again when
+        more data is available. There is no minimum or maximum limit on the size of the provided
+        data. As trace events are identified during parsing, they will be passed to the event
+        sink object passed into the constructor or connect().
+        
+        @param self
+        @param data A sequence of integer byte values, usually a bytearray.
+        """
+        for value in data:
+            self._parser.send(value)
+            self._bytes_parsed += 1
+    
+    def _flush_events(self):
+        """! @brief Send all pending events to event sink."""
+        if self._sink is not None:
+            for event in self._pending_events:
+                self._sink.receive(event)
+        self._pending_events = []
+    
+    def _merge_data_trace_events(self, event):
+        """! @brief Look for pairs of data trace events and merge."""
+        if isinstance(event, events.TraceDataTraceEvent):
+            # Record the first data trace event.
+            if self._pending_data_trace is None:
+                self._pending_data_trace = event
+            else:
+                # We've got the second in a pair. If the comparator numbers are the same, then
+                # we can merge the two events. Otherwise we just add them to the pending event
+                # queue separately.
+                if event.comparator == self._pending_data_trace.comparator:
+                    # Merge the two data trace events.
+                    ev = events.TraceDataTraceEvent(cmpn=event.comparator,
+                        pc=(event.pc or self._pending_data_trace.pc),
+                        addr=(event.address or self._pending_data_trace.address),
+                        value=(event.value or self._pending_data_trace.value),
+                        rnw=(event.is_read or self._pending_data_trace.is_read),
+                        sz=(event.transfer_size or self._pending_data_trace.transfer_size),
+                        ts=self._pending_data_trace.timestamp)
+                else:
+                    ev = self._pending_data_trace
+                self._pending_events.append(ev)
+                self._pending_data_trace = None
+            return True
+        # If we get a non-data-trace event while waiting for a second data trace event, then
+        # just place the pending data trace event in the pending event queue.
+        elif self._pending_data_trace is not None:
+            self._pending_events.append(self._pending_data_trace)
+            self._pending_data_trace = None
+        return False
+    
+    def _send_event(self, event):
+        """! @brief Process event objects and decide when to send to event sink.
+        
+        This method handles the logic to associate a timestamp event with the prior other
+        event. A list of pending events is built up until either a timestamp or overflow event
+        is generated, at which point all pending events are flushed to the event sink. If a
+        timestamp is seen, the timestamp of all pending events is set prior to flushing.
+        """
+        flush = False
+        
+        # Handle merging data trace events.
+        if self._merge_data_trace_events(event):
+            return
+        
+        if isinstance(event, events.TraceTimestamp):
+            for ev in self._pending_events:
+                ev.timestamp = event.timestamp
+            flush = True
+        else:
+            self._pending_events.append(event)
+            if isinstance(event, events.TraceOverflow):
+                flush = True
+        
+        if flush:
+            self._flush_events()
+    
+    def _parse(self):
+        """! @brief SWO parser as generator function coroutine.
+        
+        The generator yields every time it needs a byte of SWO data. The caller must use the
+        generator's send() method to provide the next byte.
+        """
+        timestamp = 0
+        invalid = False
+        while True:
+            byte = yield
+            hdr = byte
+            
+            # Sync packet.
+            if hdr == 0:
+                packets = 0
+                while True:
+                    # Check for final 1 bit after at least 5 all-zero sync packets
+                    if (packets >= 5) and (byte == 0x80):
+                        break
+                    elif byte == 0:
+                        packets += 1
+                    else:
+                        # Get early non-zero packet, reset sync packet counter.
+                        #packets = 0
+                        invalid = True
+                        break
+                    byte = yield
+                self._itm_page = 0
+            # Overflow packet.
+            elif hdr == 0x70:
+                self._send_event(events.TraceOverflow(timestamp))
+            # Protocol packet.
+            elif (hdr & 0x3) == 0:
+                c = (hdr >> 7) & 0x1
+                d = (hdr >> 4) & 0b111
+                # Local timestamp.
+                if (hdr & 0xf) == 0 and d not in (0x0, 0x3):
+                    ts = 0
+                    tc = 0
+                    # Local timestamp packet format 1.
+                    if c == 1:
+                        tc = (hdr >> 4) & 0x3
+                        while c == 1:
+                            byte = yield
+                            ts = (ts << 7) | (byte & 0x7f)
+                            c = (byte >> 7) & 0x1
+                    # Local timestamp packet format 2.
+                    else:
+                        ts = (hdr >> 4) & 0x7
+                    timestamp += ts
+                    self._send_event(events.TraceTimestamp(tc, timestamp))
+                # Global timestamp.
+                elif hdr in (0b10010100, 0b10110100):
+                    t = (hdr >> 5) & 0x1
+                    # TODO handle global timestamp
+                # Extension.
+                elif (hdr & 0x8) == 0x8:
+                    sh = (hdr >> 2) & 0x1
+                    if c == 0:
+                        ex = (hdr >> 4) & 0x7
+                    else:
+                        ex = 0
+                        while c == 1:
+                            byte = yield
+                            ex = (ex << 7) | (byte & 0x7f)
+                            c = (byte >> 7) & 0x1
+                    if sh == 0:
+                        # Extension packet with sh==0 sets ITM stimulus page.
+                        self._itm_page = ex
+                    else:
+                        #self._send_event(events.TraceEvent("Extension: SH={:d} EX={:#x}\n".format(sh, ex), timestamp))
+                        invalid = True
+                # Reserved packet.
+                else:
+                    invalid = True
+            # Source packet.
+            else:
+                ss = hdr & 0x3
+                l = 1 << (ss - 1)
+                a = (hdr >> 3) & 0x1f
+                if l == 1:
+                    payload = yield
+                elif l == 2:
+                    byte1 = yield
+                    byte2 = yield
+                    payload = (byte1 | 
+                                (byte2 << 8))
+                else:
+                    byte1 = yield
+                    byte2 = yield
+                    byte3 = yield
+                    byte4 = yield
+                    payload = (byte1 | 
+                                (byte2 << 8) |
+                                (byte3 << 16) |
+                                (byte4 << 24))
+                
+                # Instrumentation packet.
+                if (hdr & 0x4) == 0:
+                    port = (self._itm_page * 32) + a
+                    self._send_event(events.TraceITMEvent(port, payload, l, timestamp))
+                # Hardware source packets...
+                # Event counter
+                elif a == 0:
+                    self._send_event(events.TraceEventCounter(payload, timestamp))
+                # Exception trace
+                elif a == 1:
+                    exceptionNumber = payload & 0x1ff
+                    exceptionName = self._core.exception_number_to_name(exceptionNumber, True)
+                    fn = (payload >> 12) & 0x3
+                    if 1 <= fn <= 3:
+                        self._send_event(events.TraceExceptionEvent(exceptionNumber, exceptionName, fn, timestamp))
+                    else:
+                        invalid = True
+                # Periodic PC
+                elif a == 2:                        
+                    # A payload of 0 indicates a period PC sleep event.
+                    self._send_event(events.TracePeriodicPC(payload, timestamp))
+                # Data trace
+                elif 8 <= a <= 23:
+                    type = (hdr >> 6) & 0x3
+                    cmpn = (hdr >> 4) & 0x3
+                    bit3 = (hdr >> 3) & 0x1
+                    # PC value
+                    if type == 0b01 and bit3 == 0:
+                        self._send_event(events.TraceDataTraceEvent(cmpn=cmpn, pc=payload, ts=timestamp))
+                    # Address
+                    elif type == 0b01 and bit3 == 1:
+                        self._send_event(events.TraceDataTraceEvent(cmpn=cmpn, addr=payload, ts=timestamp))
+                    # Data value
+                    elif type == 0b10:
+                        self._send_event(events.TraceDataTraceEvent(cmpn=cmpn, value=payload, rnw=(bit3 == 0), sz=l, ts=timestamp))
+                    else:
+                        invalid = True
+                # Invalid DWT 'a' value.
+                else:
+                    invalid = True
+        
+
+

--- a/pyocd/trace/swv.py
+++ b/pyocd/trace/swv.py
@@ -1,0 +1,138 @@
+# pyOCD debugger
+# Copyright (c) 2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import threading
+import sys
+from time import sleep
+
+from .sink import TraceEventSink
+from .events import TraceITMEvent
+from .swo import SWOParser
+from ..coresight.itm import ITM
+from ..coresight.tpiu import TPIU
+
+LOG = logging.getLogger(__name__)
+
+class SWVEventSink(TraceEventSink):
+    """! @brief Trace event sink that converts ITM packets to a text stream."""
+    
+    def __init__(self, console):
+        """! @brief Constructor.
+        @param self
+        @param console File-like object to which SWV data will be written.
+        """
+        self._console = console
+    
+    def receive(self, event):
+        """! @brief Handle an SWV trace event.
+        @param self
+        @param event An instance of TraceITMEvent. If the event is not this class, or isn't
+            for ITM port 0, then it will be ignored.
+        """
+        if not isinstance(event, TraceITMEvent):
+            return
+        
+        if not event.port == 0:
+            return
+        
+        self._console.write(chr(event.data))
+
+class SWVReader(threading.Thread):
+    """! @brief Sets up SWV and processes data in a background thread."""
+
+    def __init__(self, session, core_number=0):
+        """! @brief Constructor.
+        @param self
+        @param session The Session instance.
+        @param core_number The number of the core being traced. Default is core 0.
+        """
+        super(SWVReader, self).__init__()
+        self.name = "SWVReader"
+        self.daemon = True
+        self._session = session
+        self._core_number = core_number
+        self._shutdown_event = threading.Event()
+        self._swo_clock = 0
+        
+    def init(self, sys_clock, swo_clock, console):
+        """! @brief Configures trace graph and starts thread.
+        
+        This method performs all steps required to start up SWV. It first calls the target's
+        trace_start() method, which allows for target-specific trace initialization. Then it
+        configures the TPIU and ITM modules. A simple trace data processing graph is created that
+        connects an SWVEventSink with a SWOParser. Finally, the reader thread is started.
+        
+        @param self
+        @param sys_clock
+        @param swo_clock
+        @param console
+        """
+        self._swo_clock = swo_clock
+        
+        self._session.target.trace_start()
+        
+        itm = self._session.target.get_first_child_of_type(ITM)
+        tpiu = self._session.target.get_first_child_of_type(TPIU)
+
+        itm.init()
+        itm.enable()
+        tpiu.init()
+
+        if tpiu.set_swo_clock(swo_clock, sys_clock):
+            LOG.info("Set SWO clock to %d", swo_clock)
+        else:
+            LOG.warning("Failed to set SWO clock rate")
+            return
+
+        self._parser = SWOParser(self._session.target.cores[self._core_number])
+        self._sink = SWVEventSink(console)
+        self._parser.connect(self._sink)
+        
+        self.start()
+    
+    def stop(self):
+        """! @brief Stops processing SWV data.
+        
+        The reader thread is terminated first, then the ITM is disabled. The last step is to call
+        the target's trace_stop() method.
+        """
+        self._shutdown_event.set()
+        self.join()
+
+        itm = self._session.target.get_first_child_of_type(ITM)
+        itm.disable()
+        
+        self._session.target.trace_stop()
+    
+    def run(self):
+        """! @brief SWV reader thread routine.
+        
+        Starts the probe receiving SWO data by calling DebugProbe.swo_start(). For as long as the
+        thread runs, it reads SWO data from the probe and passes it to the SWO parser created in
+        init(). When the thread is signaled to stop, it calls DebugProbe.swo_stop() before exiting.
+        """
+        self._session.probe.swo_start(self._swo_clock)
+        
+        while not self._shutdown_event.is_set():
+            data = self._session.probe.swo_read()
+            if data:
+                self._parser.parse(data)
+        
+            sleep(0.001)
+            
+        self._session.probe.swo_stop()
+

--- a/pyocd/utility/server.py
+++ b/pyocd/utility/server.py
@@ -1,0 +1,169 @@
+# pyOCD debugger
+# Copyright (c) 2015-2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import threading
+import socket
+from ..gdbserver.gdb_socket import GDBSocket
+from .py3_helpers import to_bytes_safe
+
+LOG = logging.getLogger(__name__)
+
+class StreamServer(threading.Thread):
+    """! @brief File-like object that serves data over a TCP socket.
+    
+    The user can connect to the socket with telnet or netcat.
+    
+    The server thread will automatically be started by the constructor. To shut down the
+    server and its thread, call the stop() method.
+    """
+    
+    def __init__(self, port, serve_local_only=True, name=None, is_read_only=True):
+        """! @brief Constructor.
+        
+        Starts the server immediately.
+        
+        @param self
+        @param port The TCP/IP port number on which the server should listen. If 0 is passed,
+            then an arbitrary unused port is selected by the OS. In this case, the `port` property
+            can be used to get the actual port number.
+        @param serve_local_only Whether to allow connections from remote clients.
+        @param name Optional server name.
+        @param is_read_only If the server is read-only, from the perspective of the client,
+            then any incoming data sent by the client is discarded. Otherwise it is buffered so
+            it can be read with the read() methods.
+        """
+        super(StreamServer, self).__init__()
+        self.name = name
+        self._name = name
+        self._formatted_name = (name + " ") if (name is not None) else ""
+        self._is_read_only = is_read_only
+        self._abstract_socket = None
+        self._abstract_socket = GDBSocket(port, 4096)
+        if serve_local_only:
+            self._abstract_socket.host = 'localhost'
+        self._abstract_socket.init()
+        self._port = self._abstract_socket.port
+        self._buffer = bytearray()
+        self._buffer_lock = threading.Lock()
+        self.connected = None
+        self._shutdown_event = threading.Event()
+        self.daemon = True
+        self.start()
+    
+    @property
+    def port(self):
+        return self._port
+
+    def stop(self):
+        self._shutdown_event.set()
+        self.join()
+
+    def run(self):
+        LOG.info("%sserver started on port %d", self._formatted_name, self._port)
+        self.connected = None
+        try:
+            while not self._shutdown_event.is_set():
+                # Wait for a client to connect.
+                # TODO support multiple client connections
+                while not self._shutdown_event.is_set():
+                    self.connected = self._abstract_socket.connect()
+                    if self.connected is not None:
+                        LOG.debug("%sclient connected", self._formatted_name)
+                        break
+
+                if self._shutdown_event.is_set():
+                    break
+
+                # Set timeout on new connection.
+                self._abstract_socket.set_timeout(0.1)
+
+                # Keep reading from the client until we either get a shutdown event, or
+                # the client disconnects. The incoming data is appended to our read buffer.
+                while not self._shutdown_event.is_set():
+                    try:
+                        data = self._abstract_socket.read()
+                        if len(data) == 0:
+                            # Client disconnected.
+                            self._abstract_socket.close()
+                            self.connected = None
+                            break
+
+                        if not self._is_read_only:
+                            self._buffer_lock.acquire()
+                            self._buffer += bytearray(data)
+                            self._buffer_lock.release()
+                    except socket.timeout:
+                        pass
+        finally:
+            self._abstract_socket.cleanup()
+        LOG.info("%sserver stopped", self._formatted_name)
+
+    def write(self, data):
+        """! @brief Write bytes into the connection."""
+        # If nobody is connected, act like all data was written anyway.
+        if self.connected is None:
+            return 0
+        data = to_bytes_safe(data)
+        size = len(data)
+        remaining = size
+        while remaining:
+            count = self._abstract_socket.write(data)
+            remaining -= count
+            if remaining:
+                data = data[count:]
+        return size
+
+    def _get_input(self, length):
+        """! @brief Extract requested amount of data from the read buffer."""
+        self._buffer_lock.acquire()
+        try:
+            if length == -1:
+                actualLength = len(self._buffer)
+            else:
+                actualLength = min(length, len(self._buffer))
+            if actualLength:
+                data = self._buffer[:actualLength]
+                self._buffer = self._buffer[actualLength:]
+            else:
+                data = bytearray()
+            return data
+        finally:
+            self._buffer_lock.release()
+
+    def read(self, size=-1):
+        """! @brief Return bytes read from the connection."""
+        if self.connected is None:
+            return None
+
+        # Extract requested amount of data from the read buffer.
+        data = self._get_input(size)
+
+        return data
+
+    def readinto(self, b):
+        """! @brief Read bytes into a mutable buffer."""
+        if self.connected is None:
+            return None
+
+        # Extract requested amount of data from the read buffer.
+        b[:] = self._get_input(size)
+
+        if len(b):
+            return len(b)
+        else:
+            return None
+


### PR DESCRIPTION
This PR adds support for Serial Wire Output (SWO) for both CMSIS-DAP and STLink probes. ITM and TPIU classes are added for those CoreSight components. A full SWO parser is provided, along with classes for building a trace data processing graph. The `SWOParser` class accepts raw SWO data and outputs `TraceEvent` objects to a connected trace data sink.

In addition, support for SWV printf-style output is provided. A few user options are added to control this features:

- `enable_swv` - Flag to enable SWV output.
- `swv_system_clock` - Required system clock frequency. Used to compute TPIU baud rate divider.
- `swv_clock` - Optional baud rate for SWO, which defaults to 1 MHz if not set.

If `enable_swv` is true, pyOCD will set up ITM and TPIU to output ITM stimulus ports over SWO at the specified baud rate. A thread reads the data from the probe and parses it. The SWV stream from ITM port 0 will be output to the semihosting console, either the telnet server or stdout depending on the `semihost_console_type` option. You currently need to enable semihosting for SWV to work.

Two new delegate or user script methods are supported to allow for customization of the trace setup and teardown: `trace_start()` and `trace_stop()`.

An example of running the gdbserver with SWV output is:

```
pyocd gdb -S -Oenable_swv=1 -Oswv_system_clock=80000000 -Osemihost_console_type=stdout
```

This will turn on semihosting and SWV with the default 1 MHz baud rate, an 80 MHz system clock, and output to stdout.