### PR TITLE
Fixed uninit for FLM-based flash algos

### DIFF
--- a/pyocd/target/pack/flash_algo.py
+++ b/pyocd/target/pack/flash_algo.py
@@ -161,7 +161,7 @@ class PackFlashAlgo(object):
             "load_address": addr_load,
             "instructions": instructions,
             "pc_init": code_start + self.symbols["Init"],
-            "pc_uninit": code_start + self.symbols["UnInit"],
+            "pc_unInit": code_start + self.symbols["UnInit"],
             "pc_eraseAll": code_start + self.symbols["EraseChip"],
             "pc_erase_sector": code_start + self.symbols["EraseSector"],
             "pc_program_page": code_start + self.symbols["ProgramPage"],


### PR DESCRIPTION
The `PackFlashAlgo` class had a typo in the flash algo dict `pc_unInit` key. This caused flash algos generated from FLM files, like those from CMSIS-Packs, to not have the `UnInit()` algo routine. On certain targets, such as STM32, this is required to be called before re-initing the flash algo.