### PR TITLE
Improve the unknown board ID warning

### DIFF
--- a/pyocd/board/mbed_board.py
+++ b/pyocd/board/mbed_board.py
@@ -48,7 +48,7 @@ class MbedBoard(Board):
             target = self.native_target
 
         if target is None:
-            log.warning("Unsupported board found %s", board_id)
+            log.warning("Board ID %s is not recognized; you will be able to use pyOCD but not program flash.", board_id)
             target = "cortex_m"
 
         super(MbedBoard, self).__init__(session, target)


### PR DESCRIPTION
The unknown board ID warning is changed to tell users that they can still use pyOCD, but cannot program flash. More than once, users have seen this warning and thought that pyOCD wouldn't work at all with their board.