### PR TITLE
SWV fixes

### DIFF
--- a/pyocd/probe/pydapaccess/interface/interface.py
+++ b/pyocd/probe/pydapaccess/interface/interface.py
@@ -24,6 +24,10 @@ class Interface(object):
         self.vendor_name = ""
         self.product_name = ""
         self.packet_count = 1
+    
+    @property
+    def has_swo_ep(self):
+        return False
 
     def open(self):
         return

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -43,10 +43,6 @@ class PyUSBv2(Interface):
 
     def __init__(self):
         super(PyUSBv2, self).__init__()
-        self.vid = 0
-        self.pid = 0
-        self.product_name = None
-        self.vendor_name = None
         self.ep_out = None
         self.ep_in = None
         self.ep_swo = None


### PR DESCRIPTION
- Fixed missing `has_swo_ep` property on CMSIS-DAPv1 interfaces.
- `SWVReader` checks to make sure the debug probe actually supports SWO before continuing setup. If not, a warning is printed.
- Implemented support for 16- and 32-bit SWV events that output multiple characters.
- Some other improvements to `SWVReader`.