### PR TITLE
MbedBoard changes for generic board ID and DAPLink

### DIFF
--- a/pyocd/board/mbed_board.py
+++ b/pyocd/board/mbed_board.py
@@ -1,35 +1,37 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from .board import Board
 from .board_ids import BOARD_ID_TO_INFO
 import logging
 
-log = logging.getLogger('mbed_board')
+LOG = logging.getLogger(__name__)
 
 class MbedBoard(Board):
-    """
-    This class inherits from Board and is specific to mbed boards.
-    Particularly, this class allows you to dynamically determine
-    the type of all boards connected based on the id board
+    """! @brief Mbed board class.
+    
+    This class inherits from Board and is specific to mbed boards. Particularly, this class
+    will dynamically determine the type of connected board based on the board ID encoded in
+    the debug probe's serial number.
     """
     def __init__(self, session, target=None):
-        """
-        Init the board
+        """! @brief Constructor.
+        
+        This constructor attempts to use the board ID from the serial number to determine
+        the target type. See #BOARD_ID_TO_INFO.
         """
         target = session.options.get('target_override', target)
         unique_id = session.probe.unique_id
@@ -48,7 +50,7 @@ class MbedBoard(Board):
             target = self.native_target
 
         if target is None:
-            log.warning("Board ID %s is not recognized; you will be able to use pyOCD but not program flash.", board_id)
+            LOG.warning("Board ID %s is not recognized; you will be able to use pyOCD but not program flash.", board_id)
             target = "cortex_m"
 
         super(MbedBoard, self).__init__(session, target)
@@ -59,15 +61,11 @@ class MbedBoard(Board):
 
     @property
     def name(self):
-        """
-        Return board name
-        """
+        """! @brief Return board name."""
         return self._name
 
     @property
     def description(self):
-        """
-        Return info on the board
-        """
+        """! @brief Return description of the board."""
         return self.name + " [" + self.target_type + "]"
 

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -64,6 +64,9 @@ class CMSISDAPProbe(DebugProbe):
         ( 1,    0xC ) : DAPAccess.REG.AP_0xC,
         }
     
+    ## USB VID and PID pair for DAPLink firmware.
+    DAPLINK_VIDPID = (0x0d28, 0x0204)
+    
     @classmethod
     def get_all_connected_probes(cls):
         try:
@@ -121,7 +124,13 @@ class CMSISDAPProbe(DebugProbe):
         return self._is_open
 
     def create_associated_board(self, session):
-        return MbedBoard(session)
+        # Only support associated Mbed boards for DAPLink firmware. We can't assume other
+        # CMSIS-DAP firmware is using the same serial number format, so we cannot reliably
+        # extract the board ID.
+        if self._link.vidpid == self.DAPLINK_VIDPID:
+            return MbedBoard(session)
+        else:
+            return None
     
     def open(self):
         try:

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -117,6 +117,11 @@ class DAPAccessIntf(object):
     @property
     def product_name(self):
         raise NotImplementedError()
+    
+    @property
+    def vidpid(self):
+        """! @brief A tuple of USB VID and PID, in that order."""
+        raise NotImplementedError()
 
     # ------------------------------------------- #
     #          Host control functions

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -494,10 +494,12 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
             self._unique_id = _get_unique_id(interface)
             self._vendor_name = interface.vendor_name
             self._product_name = interface.product_name
+            self._vidpid = (interface.vid, interface.pid)
         else:
             self._unique_id = unique_id
             self._vendor_name = ""
             self._product_name = ""
+            self._vidpid = 0
         self._interface = None
         self._deferred_transfer = False
         self._protocol = None  # TODO, c1728p9 remove when no longer needed
@@ -519,6 +521,11 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     @property
     def product_name(self):
         return self._product_name
+    
+    @property
+    def vidpid(self):
+        """! @brief A tuple of USB VID and PID, in that order."""
+        return self._vidpid
 
     def open(self):
         if self._interface is None:
@@ -538,6 +545,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
         self._vendor_name = self._interface.vendor_name
         self._product_name = self._interface.product_name
+        self._vidpid = (self._interface.vid, self._interface.pid)
 
         self._interface.open()
         self._protocol = CMSISDAPProtocol(self._interface)

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -483,6 +483,21 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
                             val = False
                         setattr(DAPSettings, attr, val)
 
+    @staticmethod
+    def _lookup_interface_for_unique_id(unique_id):
+        result_interface = None
+        all_interfaces = _get_interfaces()
+        for interface in all_interfaces:
+            try:
+                if _get_unique_id(interface) == unique_id:
+                    # This assert could indicate that two boards
+                    # had the same ID
+                    assert result_interface is None, "More than one probes with ID {}".format(unique_id)
+                    result_interface = interface
+            except Exception:
+                logger = logging.getLogger(__name__)
+                logger.error('Failed to get unique id for open', exc_info=True)
+        return result_interface
 
     # ------------------------------------------- #
     #          CMSIS-DAP and Other Functions
@@ -490,17 +505,24 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     def __init__(self, unique_id, interface=None):
         assert isinstance(unique_id, six.string_types) or (unique_id is None and interface is not None)
         super(DAPAccessCMSISDAP, self).__init__()
+
+        # Search for a matching interface if one wasn't provided.
+        if interface is None:
+            interface = DAPAccessCMSISDAP._lookup_interface_for_unique_id(unique_id)
+
         if interface is not None:
             self._unique_id = _get_unique_id(interface)
             self._vendor_name = interface.vendor_name
             self._product_name = interface.product_name
             self._vidpid = (interface.vid, interface.pid)
         else:
+            # Set default values for an unknown interface.
             self._unique_id = unique_id
             self._vendor_name = ""
             self._product_name = ""
-            self._vidpid = 0
-        self._interface = None
+            self._vidpid = (0, 0)
+            
+        self._interface = interface
         self._deferred_transfer = False
         self._protocol = None  # TODO, c1728p9 remove when no longer needed
         self._packet_count = None
@@ -529,23 +551,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
     def open(self):
         if self._interface is None:
-            all_interfaces = _get_interfaces()
-            for interface in all_interfaces:
-                try:
-                    unique_id = _get_unique_id(interface)
-                    if self._unique_id == unique_id:
-                        # This assert could indicate that two boards
-                        # had the same ID
-                        assert self._interface is None
-                        self._interface = interface
-                except Exception:
-                    self._logger.error('Failed to get unique id for open', exc_info=True)
-            if self._interface is None:
-                raise DAPAccessIntf.DeviceError("Unable to open device")
-
-        self._vendor_name = self._interface.vendor_name
-        self._product_name = self._interface.product_name
-        self._vidpid = (self._interface.vid, self._interface.pid)
+            raise DAPAccessIntf.DeviceError("Unable to open device with no interface")
 
         self._interface.open()
         self._protocol = CMSISDAPProtocol(self._interface)

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -286,6 +286,9 @@ class HasCmsisDapv2Interface(object):
         except IndexError as error:
             LOG.warning("Internal pyusb error: %s", error)
             return False
+        except NotImplementedError as error:
+            LOG.debug("Received USB unimplemented error (VID=%04x PID=%04x)", dev.idVendor, dev.idProduct)
+            return False
 
         if cmsis_dap_interface is None:
             return False


### PR DESCRIPTION
Several changes here:
- `DAPAccessIntf` has a `vidpid` property to return a tuple of USB VID and PID.
- `DAPAccessCMSISDAP` now searches for an interface matching the given unique ID in its constructor, if it wasn't called with an interface object, rather than waiting until `open()` is called. This makes the VID/PID and names available prior to `open()`.
- The `MbedBoard` class is only used when we know the CMSIS-DAP probe is DAPLink by comparing the USB VID and PID. This prevents attempting to extract the board ID from the probe's serial number when it doesn't make sense.
- `MbedBoard` is aware that a board ID of "0000" is a generic build of DAPLink without a board, probably a standalone probe. This is specifically to support the new "no-target" builds of DAPLink.
- Cleaned up comments in `mbed_board.py`.
- Catching `NotImplementedError` in `PyUSBv2` interface match class, to resolve a failure on Windows.