### PR TITLE
Sector erase by default

### DIFF
--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -197,8 +197,8 @@ class PyOCDTool(object):
         # Create *flash* subcommand parser.
         flashParser = subparsers.add_parser('flash', parents=[commonOptions, connectOptions],
             help="Program an image to device flash.")
-        flashParser.add_argument("-e", "--erase", choices=ERASE_OPTIONS.keys(), default='auto',
-            help="Choose flash erase method. Default is auto.")
+        flashParser.add_argument("-e", "--erase", choices=ERASE_OPTIONS.keys(), default='sector',
+            help="Choose flash erase method. Default is sector.")
         flashParser.add_argument("-a", "--base-address", metavar="ADDR", type=int_base_0,
             help="Base address used for the address where to flash a binary. Defaults to start of flash.")
         flashParser.add_argument("--trust-crc", action="store_true",
@@ -222,8 +222,8 @@ class PyOCDTool(object):
             help="Keep GDB server running even after remote has detached.")
         gdbserverOptions.add_argument("--elf", metavar="PATH",
             help="Optionally specify ELF file being debugged.")
-        gdbserverOptions.add_argument("-e", "--erase", choices=('auto', 'chip', 'sector'), default='auto',
-            help="Choose flash erase method. Default is auto.")
+        gdbserverOptions.add_argument("-e", "--erase", choices=ERASE_OPTIONS.keys(), default='sector',
+            help="Choose flash erase method. Default is sector.")
         gdbserverOptions.add_argument("--trust-crc", action="store_true",
             help="Use only the CRC of each page to determine if it already has the same data.")
         gdbserverOptions.add_argument("-C", "--vector-catch", default='h',

--- a/pyocd/flash/loader.py
+++ b/pyocd/flash/loader.py
@@ -378,7 +378,7 @@ class FlashLoader(object):
 
         # We have to use a special sentinel object for chip_erase because None is a valid value.
         self._chip_erase = chip_erase if (chip_erase is not CHIP_ERASE_SENTINEL) \
-                            else self._session.options.get('chip_erase', None)
+                            else self._session.options.get('chip_erase', False)
         self._trust_crc = trust_crc if (trust_crc is not None) \
                             else self._session.options.get('fast_program', False)
         

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -278,7 +278,7 @@ class GDBServer(threading.Thread):
         self.step_into_interrupt = session.options.get('step_into_interrupt', False)
         self.persist = session.options.get('persist', False)
         self.soft_bkpt_as_hard = session.options.get('soft_bkpt_as_hard', False)
-        self.chip_erase = session.options.get('chip_erase', None)
+        self.chip_erase = session.options.get('chip_erase', False)
         self.hide_programming_progress = session.options.get('hide_programming_progress', False)
         self.fast_program = session.options.get('fast_program', False)
         self.enable_semihosting = session.options.get('enable_semihosting', False)


### PR DESCRIPTION
Changed the `chip_erase` user option to default to sector erase. Previously the default was auto, where it would select chip or sector erase based on which was estimated to be fastest. The problem is, it was unpredictable which method it would use, usually depending on both the previous flash contents and the image size.

Sector erase is a safer, more predictable default, particularly for devices with more complex memory arrangements where there might be multiple flash regions.