### PR TITLE
License headers take 2 and more

### DIFF
--- a/pyocd/board/__init__.py
+++ b/pyocd/board/__init__.py
@@ -1,17 +1,16 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..target import TARGET
 from ..target.pack import pack_target

--- a/pyocd/gdbserver/context_facade.py
+++ b/pyocd/gdbserver/context_facade.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2016,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2016,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..utility import conversion
 from ..core.memory_map import MemoryType

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import array
 from .dap_access_api import DAPAccessIntf

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 from enum import Enum

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 import re

--- a/pyocd/probe/pydapaccess/interface/interface.py
+++ b/pyocd/probe/pydapaccess/interface/interface.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 class Interface(object):

--- a/pyocd/target/builtin/target_K32W042S1M2xxx.py
+++ b/pyocd/target/builtin/target_K32W042S1M2xxx.py
@@ -154,7 +154,7 @@ FLASH_ALGO = {
     'analyzer_address' : 0x8000000,  # Analyzer 0x8000000..0x80000600
     'page_buffers' : [0x20003000, 0x20004000],   # Enable double buffering
     'min_program_length' : 8,
-};
+}
 
 class K32W042S(Kinetis):
 

--- a/pyocd/target/builtin/target_LPC1114FN28_102.py
+++ b/pyocd/target/builtin/target_LPC1114FN28_102.py
@@ -50,7 +50,7 @@ FLASH_ALGO = {
     'page_size' : 0x00001000,
     'min_program_length' : 1024,
     'analyzer_supported' : False,
-};
+}
 
 class Flash_lpc11xx_32(Flash):
     def __init__(self, target):

--- a/pyocd/target/builtin/target_LPC11U24FBD64_401.py
+++ b/pyocd/target/builtin/target_LPC11U24FBD64_401.py
@@ -45,7 +45,7 @@ FLASH_ALGO = { 'load_address' : 0x10000000,
                'static_base' : 0x1000019c,
                'min_program_length' : 256,
                'analyzer_supported' : False
-              };
+              }
 
 class Flash_lpc11u24(Flash):
 

--- a/pyocd/target/builtin/target_LPC1768.py
+++ b/pyocd/target/builtin/target_LPC1768.py
@@ -55,7 +55,7 @@ FLASH_ALGO = { 'load_address' : 0x10000000,
                'min_program_length' : 256,
                'analyzer_supported' : True,
                'analyzer_address' : 0x10002000  # Analyzer 0x10002000..0x10002600
-              };
+              }
 
 class Flash_lpc1768(Flash):
 

--- a/pyocd/target/builtin/target_LPC4330.py
+++ b/pyocd/target/builtin/target_LPC4330.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2015,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2015,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ...core.coresight_target import (SVDFile, CoreSightTarget)
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)

--- a/pyocd/target/builtin/target_LPC4330.py
+++ b/pyocd/target/builtin/target_LPC4330.py
@@ -310,7 +310,7 @@ FLASH_ALGO = { 'load_address' : 0x10000000,
                'min_program_length' : 512,
                'analyzer_supported' : False,    # Analyzer works, but would fail if a full ROM analysis was performed since there is not enough ram
                'analyzer_address' : 0x10005000  # Analyzer 0x10005000..0x10005600
-              };
+              }
 
 class LPC4330(CoreSightTarget):
 

--- a/pyocd/target/builtin/target_LPC54114J256BD64.py
+++ b/pyocd/target/builtin/target_LPC54114J256BD64.py
@@ -55,7 +55,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'page_size' : 0x00000100,
     'min_program_length' : 256,
     'analyzer_supported' : False
-};
+}
 
 class Flash_lpc54114(Flash):
     def __init__(self, target):

--- a/pyocd/target/builtin/target_LPC54608J512ET180.py
+++ b/pyocd/target/builtin/target_LPC54608J512ET180.py
@@ -51,7 +51,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'page_size' : 0x00000100,
     'min_program_length' : 256,
     'analyzer_supported' : False
-};
+}
 
 class Flash_lpc54608(Flash):
     def __init__(self, target):

--- a/pyocd/target/builtin/target_MAX32600.py
+++ b/pyocd/target/builtin/target_MAX32600.py
@@ -50,7 +50,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'min_program_length' : 4,
                'analyzer_supported' : True,
                'analyzer_address' : 0x20004000  # Analyzer 0x20004000..0x20004600
-              };
+              }
 
 class MAX32600(CoreSightTarget):
 

--- a/pyocd/target/builtin/target_MAX32600.py
+++ b/pyocd/target/builtin/target_MAX32600.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget

--- a/pyocd/target/builtin/target_MAX32620.py
+++ b/pyocd/target/builtin/target_MAX32620.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget

--- a/pyocd/target/builtin/target_MAX32620.py
+++ b/pyocd/target/builtin/target_MAX32620.py
@@ -55,7 +55,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'min_program_length' : 4,
                'analyzer_supported' : True,
                'analyzer_address'   : 0x2000A000                  # Analyzer 0x2000A000..0x2000A600
-              };
+              }
 
 class MAX32620(CoreSightTarget):
 

--- a/pyocd/target/builtin/target_MAX32625.py
+++ b/pyocd/target/builtin/target_MAX32625.py
@@ -55,7 +55,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'min_program_length' : 4,
                'analyzer_supported' : True,
                'analyzer_address'   : 0x2000A000                  # Analyzer 0x2000A000..0x2000A600
-              };
+              }
 
 class MAX32625(CoreSightTarget):
 

--- a/pyocd/target/builtin/target_MAX32625.py
+++ b/pyocd/target/builtin/target_MAX32625.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget

--- a/pyocd/target/builtin/target_MAX32630.py
+++ b/pyocd/target/builtin/target_MAX32630.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget

--- a/pyocd/target/builtin/target_MAX32630.py
+++ b/pyocd/target/builtin/target_MAX32630.py
@@ -55,7 +55,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'min_program_length' : 4,
                'analyzer_supported' : True,
                'analyzer_address'   : 0x2000A000                  # Analyzer 0x2000A000..0x2000A600
-              };
+              }
 
 class MAX32630(CoreSightTarget):
 

--- a/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
@@ -1,20 +1,19 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2017 NXP
- Copyright (c) 2018 Arm Ltd
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2017 NXP
+# Copyright (c) 2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget

--- a/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
+++ b/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
@@ -1,20 +1,19 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2017 NXP
- Copyright (c) 2018 Arm Ltd
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2017 NXP
+# Copyright (c) 2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget

--- a/pyocd/target/builtin/target_MK20DX128xxx5.py
+++ b/pyocd/target/builtin/target_MK20DX128xxx5.py
@@ -71,7 +71,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'min_program_length' : 8,
                'analyzer_supported' : True,
                'analyzer_address' : 0x1fffe000  # Analyzer 0x1fffe000..0x1fffe600
-              };
+              }
 
 class K20D50M(Kinetis):
 

--- a/pyocd/target/builtin/target_MK22FN1M0Axxx12.py
+++ b/pyocd/target/builtin/target_MK22FN1M0Axxx12.py
@@ -87,7 +87,7 @@ FLASH_ALGO = {
     'analyzer_address' : 0x1ffff000,  # Analyzer 0x1ffff000..0x1ffff600
     'page_buffers' : [0x20003000, 0x20004000],   # Enable double buffering
     'min_program_length' : 8,
-};
+}
 
 class K22FA12(Kinetis):
 

--- a/pyocd/target/builtin/target_MK22FN512xxx12.py
+++ b/pyocd/target/builtin/target_MK22FN512xxx12.py
@@ -72,7 +72,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'min_program_length' : 8,
                'analyzer_supported' : True,
                'analyzer_address' : 0x1ffff000  # Analyzer 0x1ffff000..0x1ffff600
-              };
+              }
 
 class K22F(Kinetis):
 

--- a/pyocd/target/builtin/target_MK22FN512xxx12.py
+++ b/pyocd/target/builtin/target_MK22FN512xxx12.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MK28FN2M0xxx15.py
+++ b/pyocd/target/builtin/target_MK28FN2M0xxx15.py
@@ -72,7 +72,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'analyzer_address' : 0x1ffff000,  # Analyzer 0x1ffff000..0x1ffff600
     'page_buffers' : [0x20003000, 0x20004000],   # Enable double buffering
     'min_program_length' : 8,
-  };
+  }
 
 class K28F15(Kinetis):
 

--- a/pyocd/target/builtin/target_MK28FN2M0xxx15.py
+++ b/pyocd/target/builtin/target_MK28FN2M0xxx15.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2016,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2016,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MK64FN1M0xxx12.py
+++ b/pyocd/target/builtin/target_MK64FN1M0xxx12.py
@@ -71,7 +71,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'min_program_length' : 8,
                'analyzer_supported' : True,
                'analyzer_address' : 0x1ffff000  # Analyzer 0x1ffff000..0x1ffff600
-              };
+              }
 
 class K64F(Kinetis):
 

--- a/pyocd/target/builtin/target_MK66FN2M0xxx18.py
+++ b/pyocd/target/builtin/target_MK66FN2M0xxx18.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2016,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2016,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MK66FN2M0xxx18.py
+++ b/pyocd/target/builtin/target_MK66FN2M0xxx18.py
@@ -72,7 +72,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'analyzer_address' : 0x1ffff000,  # Analyzer 0x1ffff000..0x1ffff600
     'page_buffers' : [0x20003000, 0x20004000],   # Enable double buffering
     'min_program_length' : 8,
-  };
+  }
 
 class K66F18(Kinetis):
 

--- a/pyocd/target/builtin/target_MK82FN256xxx15.py
+++ b/pyocd/target/builtin/target_MK82FN256xxx15.py
@@ -1,19 +1,18 @@
-"""
- Flash OS Routines (Automagically Generated)
- Copyright (c) 2009-2015,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2009-2015,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MK82FN256xxx15.py
+++ b/pyocd/target/builtin/target_MK82FN256xxx15.py
@@ -81,7 +81,7 @@ FLASH_ALGO = {
     'analyzer_address' : 0x1ffff000,  # Analyzer 0x1ffff000..0x1ffff600
     'page_buffers' : [0x20003000, 0x20004000],   # Enable double buffering
     'min_program_length' : 8,
-  };
+  }
 
 class K82F25615(Kinetis):
 

--- a/pyocd/target/builtin/target_MKE15Z256xxx7.py
+++ b/pyocd/target/builtin/target_MKE15Z256xxx7.py
@@ -1,19 +1,20 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2016,2018 Freescale Semiconductor, Inc.
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2017 NXP
+# Copyright (c) 2016 Freescale Semiconductor, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKE15Z256xxx7.py
+++ b/pyocd/target/builtin/target_MKE15Z256xxx7.py
@@ -83,7 +83,7 @@ FLASH_ALGO = {
     'analyzer_address' : 0x1ffff000,  # Analyzer 0x1ffff000..0x1ffff600
     'page_buffers' : [0x20003000, 0x20004000],   # Enable double buffering
     'min_program_length' : 8,
-};
+}
 
 class KE15Z7(Kinetis):
 

--- a/pyocd/target/builtin/target_MKE18F256xxx16.py
+++ b/pyocd/target/builtin/target_MKE18F256xxx16.py
@@ -84,7 +84,7 @@ FLASH_ALGO = {
     'analyzer_address' : 0x1ffff000,  # Analyzer 0x1ffff000..0x1ffff600
     'page_buffers' : [0x20003000, 0x20004000],   # Enable double buffering
     'min_program_length' : 8,
-};
+}
 
 class KE18F16(Kinetis):
 

--- a/pyocd/target/builtin/target_MKE18F256xxx16.py
+++ b/pyocd/target/builtin/target_MKE18F256xxx16.py
@@ -1,19 +1,20 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2016,2018 Freescale Semiconductor, Inc.
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2017 NXP
+# Copyright (c) 2016 Freescale Semiconductor, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKL02Z32xxx4.py
+++ b/pyocd/target/builtin/target_MKL02Z32xxx4.py
@@ -82,7 +82,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'static_base' : 0x20000000 + 0x20 + 0x5E8,
                'min_program_length' : 4,
                'analyzer_supported' : False     # Not enough space on KL02 and KL05
-              };
+              }
 
 class KL02Z(Kinetis):
 

--- a/pyocd/target/builtin/target_MKL02Z32xxx4.py
+++ b/pyocd/target/builtin/target_MKL02Z32xxx4.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKL05Z32xxx4.py
+++ b/pyocd/target/builtin/target_MKL05Z32xxx4.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKL05Z32xxx4.py
+++ b/pyocd/target/builtin/target_MKL05Z32xxx4.py
@@ -82,7 +82,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'static_base' : 0x20000000 + 0x20 + 0x5E8,
                'min_program_length' : 4,
                'analyzer_supported' : False     # Not enough space on KL02 and KL05
-              };
+              }
 
 class KL05Z(Kinetis):
 

--- a/pyocd/target/builtin/target_MKL25Z128xxx4.py
+++ b/pyocd/target/builtin/target_MKL25Z128xxx4.py
@@ -84,7 +84,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'page_buffers' : [0x20000800, 0x20000c00], # Enable double buffering
                'analyzer_supported' : True,
                'analyzer_address' : 0x1ffff000  # Analyzer 0x1ffff000..0x1ffff600
-              };
+              }
 
 class KL25Z(Kinetis):
 

--- a/pyocd/target/builtin/target_MKL25Z128xxx4.py
+++ b/pyocd/target/builtin/target_MKL25Z128xxx4.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKL26Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL26Z256xxx4.py
@@ -84,7 +84,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'page_buffers' : [0x20000800, 0x20000c00], # Enable double buffering
                'analyzer_supported' : True,
                'analyzer_address' : 0x1ffff000  # Analyzer 0x1ffff000..0x1ffff600
-              };
+              }
 
 class KL26Z(Kinetis):
 

--- a/pyocd/target/builtin/target_MKL26Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL26Z256xxx4.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKL27Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL27Z256xxx4.py
@@ -86,7 +86,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'min_program_length' : 4,
     'analyzer_supported' : True,
     'analyzer_address' : 0x20002000
-  };
+  }
 
 class KL27Z4(Kinetis):
 

--- a/pyocd/target/builtin/target_MKL27Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL27Z256xxx4.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKL28Z512xxx7.py
+++ b/pyocd/target/builtin/target_MKL28Z512xxx7.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKL28Z512xxx7.py
+++ b/pyocd/target/builtin/target_MKL28Z512xxx7.py
@@ -122,7 +122,7 @@ FLASH_ALGO = {
     'analyzer_address' : 0x1fffa000,             # [modified] default is zero. Use 8K block before flash algo. Can be any unused SRAM.
     'page_buffers' : [0x20000a00, 0x20001200],   # [added] Use areas above algo. Note 'begin_data' is unused if double buffering. Can be any unused SRAM.
     'min_program_length' : 4                     # [added] See FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE in KSDK features header file
-};
+}
 
 class Flash_kl28z(Flash_Kinetis):
     def __init__(self, target):

--- a/pyocd/target/builtin/target_MKL43Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL43Z256xxx4.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKL43Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL43Z256xxx4.py
@@ -87,7 +87,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'min_program_length' : 4,
     'analyzer_supported' : True,
     'analyzer_address' : 0x20002000
-  };
+  }
 
 class KL43Z4(Kinetis):
 

--- a/pyocd/target/builtin/target_MKL46Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL46Z256xxx4.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKL46Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL46Z256xxx4.py
@@ -84,7 +84,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'page_buffers' : [0x20000800, 0x20000c00], # Enable double buffering
                'analyzer_supported' : True,
                'analyzer_address' : 0x1ffff000  # Analyzer 0x1ffff000..0x1ffff600
-              };
+              }
 
 class KL46Z(Kinetis):
 

--- a/pyocd/target/builtin/target_MKL82Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKL82Z128xxx7.py
@@ -82,7 +82,7 @@ FLASH_ALGO = {
     'analyzer_address' : 0x1fffa000,             # [modified] default is zero. Use 8K block before flash algo. Can be any unused SRAM.
     'page_buffers' : [0x20000a00, 0x20001200],   # [added] Use areas above algo. Note 'begin_data' is unused if double buffering. Can be any unused SRAM.
     'min_program_length' : 4                     # [added] See FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE in KSDK features header file
-};
+}
 
 class KL82Z7(Kinetis):
 

--- a/pyocd/target/builtin/target_MKL82Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKL82Z128xxx7.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKV10Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKV10Z128xxx7.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013, ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013, Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKV10Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKV10Z128xxx7.py
@@ -88,7 +88,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'min_program_length' : 4,
     'analyzer_supported' : True,
     'analyzer_address' : 0x1ffff800
-  };
+  }
 
 class KV10Z7(Kinetis):
 

--- a/pyocd/target/builtin/target_MKV11Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKV11Z128xxx7.py
@@ -89,7 +89,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'min_program_length' : 4,
     'analyzer_supported' : True,
     'analyzer_address' : 0x1ffff800
-  };
+  }
 
 class KV11Z7(Kinetis):
 

--- a/pyocd/target/builtin/target_MKV11Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKV11Z128xxx7.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKW01Z128xxx4.py
+++ b/pyocd/target/builtin/target_MKW01Z128xxx4.py
@@ -87,7 +87,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'min_program_length' : 4,
     'analyzer_supported' : True,
     'analyzer_address' : 0x1ffff800
-  };
+  }
 
 class KW01Z4(Kinetis):
 

--- a/pyocd/target/builtin/target_MKW01Z128xxx4.py
+++ b/pyocd/target/builtin/target_MKW01Z128xxx4.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKW24D512xxx5.py
+++ b/pyocd/target/builtin/target_MKW24D512xxx5.py
@@ -79,7 +79,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'min_program_length' : 4,
     'analyzer_supported' : True,
     'analyzer_address' : 0x1ffff800
-  };
+  }
 
 class KW24D5(Kinetis):
 

--- a/pyocd/target/builtin/target_MKW36Z512xxx4.py
+++ b/pyocd/target/builtin/target_MKW36Z512xxx4.py
@@ -150,7 +150,7 @@ FLASH_ALGO = {
     'min_program_length' : 8,
     'analyzer_supported' : True,
     'analyzer_address' : 0x1fffc000
-};
+}
 
 class KW36Z4(Kinetis):
 

--- a/pyocd/target/builtin/target_MKW40Z160xxx4.py
+++ b/pyocd/target/builtin/target_MKW40Z160xxx4.py
@@ -88,7 +88,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'min_program_length' : 4,
     'analyzer_supported' : True,
     'analyzer_address' : 0x1ffff800
-  };
+  }
 
 class KW40Z4(Kinetis):
 

--- a/pyocd/target/builtin/target_MKW40Z160xxx4.py
+++ b/pyocd/target/builtin/target_MKW40Z160xxx4.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_MKW41Z512xxx4.py
+++ b/pyocd/target/builtin/target_MKW41Z512xxx4.py
@@ -78,7 +78,7 @@ FLASH_ALGO = {
     'page_size' : 0x00000200,
     'analyzer_supported' : False,
     'analyzer_address' : 0x00000000  # ITCM, Analyzer 0x00000000..0x000000600
-};
+}
 
 class KW41Z4(Kinetis):
 

--- a/pyocd/target/builtin/target_MKW41Z512xxx4.py
+++ b/pyocd/target/builtin/target_MKW41Z512xxx4.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2013,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2013,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis

--- a/pyocd/target/builtin/target_STM32F051T8.py
+++ b/pyocd/target/builtin/target_STM32F051T8.py
@@ -63,7 +63,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'min_program_length' : 2,
                'analyzer_supported' : True,
                'analyzer_address' : 0x20001400 # Analyzer 0x20001400..0x20001A00
-              };
+              }
 
 
 class STM32F051(CoreSightTarget):

--- a/pyocd/target/builtin/target_STM32F103RC.py
+++ b/pyocd/target/builtin/target_STM32F103RC.py
@@ -46,7 +46,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'min_program_length' : 2,
                'analyzer_supported' : True,
                'analyzer_address' : 0x20003000 # Analyzer 0x20003000..0x20003600
-              };
+              }
 
 
 class STM32F103RC(CoreSightTarget):

--- a/pyocd/target/builtin/target_STM32F412xx.py
+++ b/pyocd/target/builtin/target_STM32F412xx.py
@@ -59,7 +59,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'min_program_length' : 2,
     'analyzer_supported' : True,
     'analyzer_address' : 0x20002000
-  };
+  }
 
 class STM32F412xE(CoreSightTarget):
 

--- a/pyocd/target/builtin/target_STM32F429xx.py
+++ b/pyocd/target/builtin/target_STM32F429xx.py
@@ -59,7 +59,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'min_program_length' : 1,
     'analyzer_supported' : True,
     'analyzer_address' : 0x20002000
-  };
+  }
 
 # @brief Flash algorithm for STM32F429xx device.
 class Flash_stm32f429xx(Flash):

--- a/pyocd/target/builtin/target_STM32F439xx.py
+++ b/pyocd/target/builtin/target_STM32F439xx.py
@@ -59,7 +59,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'min_program_length' : 1,
     'analyzer_supported' : True,
     'analyzer_address' : 0x20002000
-  };
+  }
 
 # @brief Flash algorithm for STM32F439xx device.
 class Flash_stm32f439xx(Flash):

--- a/pyocd/target/builtin/target_STM32L475xx.py
+++ b/pyocd/target/builtin/target_STM32L475xx.py
@@ -63,7 +63,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
     'min_program_length' : 8,
     'analyzer_supported' : True,
     'analyzer_address' : 0x20002000
-  };
+  }
 
 class STM32L475xx(CoreSightTarget):
         

--- a/pyocd/target/builtin/target_lpc800.py
+++ b/pyocd/target/builtin/target_lpc800.py
@@ -45,7 +45,7 @@ FLASH_ALGO = { 'load_address' : 0x10000000,
                'min_program_length' : 64,
                'analyzer_supported' : True,
                'analyzer_address' : 0x10000800  # Analyzer 0x10000800..0x10000e00
-              };
+              }
 
 class LPC800(CoreSightTarget):
 

--- a/pyocd/target/builtin/target_w7500.py
+++ b/pyocd/target/builtin/target_w7500.py
@@ -35,7 +35,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'page_size'        : 256,
                'analyzer_supported' : True,
                'analyzer_address' : 0x20001000 # Analyzer 0x20001000..0x20001600
-              };
+              }
 
 
 class W7500(CoreSightTarget):

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -1,20 +1,19 @@
 #!/usr/bin/env python
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from __future__ import print_function
 import sys

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2006-2015,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2006-2015,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from __future__ import print_function
 
 import argparse, os, sys

--- a/test/unit/test_cmdline.py
+++ b/test/unit/test_cmdline.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2015,2018 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2015,2018 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from pyocd.utility.cmdline import (
     split_command_line,


### PR DESCRIPTION
Missed a number of license headers in the conversion process for #568.

This PR also includes a change to remove an unnecessary semicolon that made its way onto the end of the flash algo dicts, seemingly very early on in pyOCD's life, and repeatedly got copied as new targets were created.