### PR TITLE
Check that at least one core was found

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,6 +66,8 @@ frequency: 8000000 # Set 8 MHz SWD default for all probes
 
 ## Options list
 
+- `allow_no_cores`: (bool) Prevents raising an error if no core were found after CoreSight discovery. Default is False.
+
 - `auto_unlock`: (bool) If the target is locked, it will by default be automatically mass erased in
     order to gain debug access. Set this option to False to disable auto unlock. Default is True.
 

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -20,6 +20,7 @@ OptionInfo = namedtuple('OptionInfo', 'name type help')
 
 OPTIONS_INFO = {
     # Common options
+    'allow_no_cores': OptionInfo('allow_no_cores', bool, "Prevents raising an error if no core were found after CoreSight discovery."),
     'auto_unlock': OptionInfo('auto_unlock', bool, "Whether to unlock secured target by erasing."),
     'chip_erase': OptionInfo('chip_erase', str, "Whether to perform a chip erase or sector erases when programming flash."),
     'config_file': OptionInfo('config_file', str, "Path to custom config file."),

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -549,9 +549,9 @@ class CortexM(Target, CoreSightComponent):
             self._supports_vectreset = True
         
         if self.core_type in CORE_TYPE_NAME:
-            logging.info("CPU core is %s r%dp%d", CORE_TYPE_NAME[self.core_type], self.cpu_revision, self.cpu_patch)
+            logging.info("CPU core #%d is %s r%dp%d", self.core_number, CORE_TYPE_NAME[self.core_type], self.cpu_revision, self.cpu_patch)
         else:
-            logging.info("CPU core is unknown")
+            logging.warning("CPU core #%d type is unrecognized", self.core_number)
 
     ## @brief Determine if a core has an FPU.
     #

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -544,7 +544,10 @@ class PyOCDCommander(object):
                         if self.target.is_locked():
                             status = "locked"
                         else:
-                            status = CORE_STATUS_DESC[self.target.get_state()]
+                            try:
+                                status = CORE_STATUS_DESC[self.target.get_state()]
+                            except KeyError:
+                                status = "<no core>"
 
                         # Say what we're connected to.
                         print("Connected to %s [%s]: %s" % (self.target.part_number,


### PR DESCRIPTION
A new init task is added that verifies that at least one core was created. If not, the default is to raise a `pyocd.core.exceptions.Error`. This can be changed to a warning log with the `allow_no_cores` user option, which could be useful if using pyOCD for chip bringup and debug. Also included is a change to print the core number in the core info log message.