### PR TITLE
Commander additions and some fixes

### DIFF
--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -317,10 +317,14 @@ class PyOCDTool(object):
     def show_options_help(self):
         for infoName in sorted(options.OPTIONS_INFO.keys()):
             info = options.OPTIONS_INFO[infoName]
+            if isinstance(info.type, tuple):
+                typename = ", ".join(t.__name__ for t in info.type)
+            else:
+                typename = info.type.__name__
             print((colorama.Fore.BLUE + "{name}"
                 + colorama.Style.RESET_ALL + colorama.Fore.GREEN + " ({typename})"
                 + colorama.Style.RESET_ALL + " {help}").format(
-                name=info.name, typename=info.type.__name__, help=info.help))
+                name=info.name, typename=typename, help=info.help))
     
     def do_list(self):
         # Default to listing probes.

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -476,7 +476,7 @@ class PyOCDTool(object):
                 gdb = gdbs[0]
                 while gdb.isAlive():
                     gdb.join(timeout=0.5)
-        except Exception as e:
+        except (KeyboardInterrupt, Exception):
             for gdb in gdbs:
                 gdb.stop()
             raise

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -226,7 +226,7 @@ class DebugPort(object):
             try:
                 result = result_cb()
                 if LOG_DAP:
-                    self.logger.info("read_dp:%06d %s(addr=0x%08x) -> 0x%08x", num, "" if now else "...", addr.value, result)
+                    self.logger.info("read_dp:%06d %s(addr=0x%08x) -> 0x%08x", num, "" if now else "...", addr, result)
                 return result
             except exceptions.ProbeError as error:
                 self._handle_error(error, num)
@@ -236,7 +236,7 @@ class DebugPort(object):
             return read_dp_cb()
         else:
             if LOG_DAP:
-                self.logger.info("read_dp:%06d (addr=0x%08x) -> ...", num, addr.value)
+                self.logger.info("read_dp:%06d (addr=0x%08x) -> ...", num, addr)
             return read_dp_cb
 
     def write_dp(self, addr, data):
@@ -245,7 +245,7 @@ class DebugPort(object):
         # Write the DP register.
         try:
             if LOG_DAP:
-                self.logger.info("write_dp:%06d (addr=0x%08x) = 0x%08x", num, addr.value, data)
+                self.logger.info("write_dp:%06d (addr=0x%08x) = 0x%08x", num, addr, data)
             self.link.write_dp(addr, data)
         except exceptions.ProbeError as error:
             self._handle_error(error, num)

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -272,7 +272,7 @@ class GDBServer(threading.Thread):
         self.telnet_port = session.options.get('telnet_port', 4444)
         if self.telnet_port != 0:
             self.telnet_port += self.core
-        self.vector_catch = session.options.get('vector_catch', Target.CATCH_HARD_FAULT)
+        self.vector_catch = session.options.get('vector_catch', "h")
         self.target.set_vector_catch(convert_vector_catch(self.vector_catch))
         self.step_into_interrupt = session.options.get('step_into_interrupt', False)
         self.persist = session.options.get('persist', False)

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -398,7 +398,6 @@ class GDBServer(threading.Thread):
             while self.isAlive():
                 pass
             self.log.info("GDB server thread killed")
-        self.board.uninit()
 
     def _cleanup(self):
         self.log.debug("GDB server cleaning up")

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -1047,6 +1047,7 @@ class PyOCDCommander(object):
 
     def handle_python(self, args):
         try:
+            import pyocd
             env = {
                     'session' : self.session,
                     'board' : self.board,
@@ -1057,6 +1058,7 @@ class PyOCDCommander(object):
                     'aps' : self.target.dp.aps,
                     'elf' : self.elf,
                     'map' : self.target.memory_map,
+                    'pyocd' : pyocd,
                 }
             result = eval(args, globals(), env)
             if result is not None:

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -1556,10 +1556,14 @@ Prefix line with ! to execute a shell command.""")
 
     def print_disasm(self, code, startAddr, maxInstructions=None):
         if not isCapstoneAvailable:
-            print("Warning: Disassembly is not available because the Capstone library is not installed")
+            print("Warning: Disassembly is not available because the Capstone library is not installed. "
+                  "To install Capstone, run 'pip install capstone'.")
             return
 
-        pc = self.target.read_core_register('pc') & ~1
+        if self.target.is_halted():
+            pc = self.target.read_core_register('pc') & ~1
+        else:
+            pc = -1
         md = capstone.Cs(capstone.CS_ARCH_ARM, capstone.CS_MODE_THUMB)
 
         addrLine = 0

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -630,8 +630,7 @@ class PyOCDCommander(object):
             return False
         self.board = self.session.board
         try:
-            if not self.args.no_init:
-                self.session.open()
+            self.session.open(init_board=not self.args.no_init)
         except exceptions.TransferFaultError as e:
             if not self.board.target.is_locked():
                 print("Transfer fault while initing board: %s" % e)

--- a/pyocd/utility/graph.py
+++ b/pyocd/utility/graph.py
@@ -84,8 +84,7 @@ def dump_graph(node):
     """! @brief Draw the object graph."""
     
     def _dump(node, level):
-        name = node.__class__.__name__
-        print("  " * level + "- " + name)
+        print("  " * level + "- " + str(node))
         for child in node.children:
             _dump(child, level + 1)
     


### PR DESCRIPTION
The primary change in this PR is the addition of some commands to `pyocd commander`.
- `gdbserver (start|stop)`: Allows you to run the gdbserver from within commander. The gdbserver runs in the background, so you can still use commander to examine the target even with gdb connected.
- `show option <name>…`: Print the value of one or more user options.
- `set option <name>=<value>…`: Change the value of one or more user options.
- `pyocd` symbol added to the namespace used for '$'-prefixed Python expression commands. This lets you access the entire pyOCD package.

Additionally, several fixes are included.
- Fixed the default value for 'vector_catch' option in GDBServer.
- GDBServer.stop() no longer uninits the board.
- The gdbserver subcommand handler for pyocd tool catches KeyboardInterrupt exceptions to stop the gdbserver.
- If the target is running, the `disasm` command doesn't try to read the PC.
- Fixed `--help-options` for options with multiple types.
- Fixed issue with `LOG_DAP` in `pyocd.coresight.ap`.