### PR TITLE
Fix ArgumentError definition

### DIFF
--- a/pyocd/flash/loader.py
+++ b/pyocd/flash/loader.py
@@ -29,6 +29,11 @@ from ..debug.elf.elf import (ELFBinaryFile, SH_FLAGS)
 
 LOG = logging.getLogger(__name__)
 
+
+class ArgumentError(Exception):
+    pass
+
+
 def ranges(i):
     """!
     Accepts a sorted list of byte addresses. Breaks the addresses into contiguous ranges.

--- a/pyocd/flash/loader.py
+++ b/pyocd/flash/loader.py
@@ -30,10 +30,6 @@ from ..debug.elf.elf import (ELFBinaryFile, SH_FLAGS)
 LOG = logging.getLogger(__name__)
 
 
-class ArgumentError(Exception):
-    pass
-
-
 def ranges(i):
     """!
     Accepts a sorted list of byte addresses. Breaks the addresses into contiguous ranges.
@@ -102,11 +98,11 @@ class FileProgrammer(object):
         - `skip`: Number of bytes to skip at the start of the binary file. Does not affect the
             base address.
         
-        @exception ArgumentError Invalid argument value, for instance providing a file object but
+        @exception ValueError Invalid argument value, for instance providing a file object but
             not setting file_format.
         """
         if not file_or_path:
-            raise ArgumentError("No file provided")
+            raise ValueError("No file provided")
         
         # If no format provided, use the file's extension.
         isPath = isinstance(file_or_path, six.string_types)
@@ -114,11 +110,11 @@ class FileProgrammer(object):
             if isPath:
                 file_format = os.path.splitext(file_or_path)[1][1:]
             else:
-                raise ArgumentError("file object provided but no format is set")
+                raise ValueError("file object provided but no format is set")
         
         # Check the format is one we understand.
         if file_format not in self._format_handlers:
-            raise ArgumentError("unknown file format '%s'" % file_format)
+            raise ValueError("unknown file format '%s'" % file_format)
             
         self._loader = FlashLoader(self._session,
                                     progress=self._progress,


### PR DESCRIPTION
ArgumentError is thrown in many places in ```FileProgrammer``` class but it is not defined anywhere. Use `ValueError` instead.

```
$ pyocd flash blaa -b 066CFF494849887767174337 -t stm32l073rz --pack /home/systest/nucleo-l073rz/Keil.STM32L0xx_DFP.2.0.1.pack0000255:WARNING:pyusb_v2_backend:Exception getting product string: [Errno 13] Access denied (insufficient permissions)
0000261:INFO:pack_target:Loading CMSIS-Pack: /home/systest/nucleo-l073rz/Keil.STM32L0xx_DFP.2.0.1.pack
0000435:ERROR:__main__:uncaught exception: global name 'ArgumentError' is not defined
Traceback (most recent call last):
  File "/home/systest/workspace/mbed-flasher/py2/local/lib/python2.7/site-packages/pyocd/__main__.py", line 304, in run
    self._commands[self._args.cmd]()
  File "/home/systest/workspace/mbed-flasher/py2/local/lib/python2.7/site-packages/pyocd/__main__.py", line 379, in do_flash
    file_format=self._args.format)
  File "/home/systest/workspace/mbed-flasher/py2/local/lib/python2.7/site-packages/pyocd/flash/loader.py", line 116, in program
    raise ArgumentError("unknown file format '%s'" % file_format)
NameError: global name 'ArgumentError' is not defined
```

After the change:

```
$ pyocd flash blaa -b 066CFF494849887767174337 -t stm32l073rz --pack /home/systest/nucleo-l073rz/Keil.STM32L0xx_DFP.2.0.1.pack
0000258:WARNING:pyusb_v2_backend:Exception getting product string: [Errno 13] Access denied (insufficient permissions)
0000264:INFO:pack_target:Loading CMSIS-Pack: /home/systest/nucleo-l073rz/Keil.STM32L0xx_DFP.2.0.1.pack
0000440:ERROR:__main__:uncaught exception: unknown file format ''
Traceback (most recent call last):
  File "/home/systest/workspace/pyOCD/pyocd/__main__.py", line 304, in run
    self._commands[self._args.cmd]()
  File "/home/systest/workspace/pyOCD/pyocd/__main__.py", line 383, in do_flash
    file_format=self._args.format)
  File "/home/systest/workspace/pyOCD/pyocd/flash/loader.py", line 116, in program
    raise ValueError("unknown file format '%s'" % file_format)
ValueError: unknown file format ''
```