### PR TITLE
Fix pyocd flash error for invalid file

### DIFF
--- a/pyocd/utility/compatibility.py
+++ b/pyocd/utility/compatibility.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018 Arm Limited
+# Copyright (c) 2018-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,3 +60,10 @@ else:
         else:
             return v
 
+# Make FileNotFoundError available to Python 2.x.
+if not PY3:
+    class FileNotFoundError(IOError):
+        pass
+
+# Symbol to reference either the builtin FNF or our custom subclass.
+FileNotFoundError_ = FileNotFoundError


### PR DESCRIPTION
When calling `pyocd flash` with an invalid path you'd get a less than helpful exception about `file_obj` not being defined. This PR reworks `FileProgrammer` error checking so `FileNotFoundError` is raised if the given path is invalid. A couple other issues are also addressed, including the cause of the `file_obj` exception.

Closes #590 