### PR TITLE
Debug probe fixes

### DIFF
--- a/pyocd/probe/common.py
+++ b/pyocd/probe/common.py
@@ -1,0 +1,32 @@
+# pyOCD debugger
+# Copyright (c) 2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+LOG = logging.getLogger(__name__)
+
+## Whether the warning about no libusb was printed already.
+#
+# Used to prevent warning spewage if repeatedly scanning for probes, such as when ConnectHelper
+# is used in blocking mode and no probes are connected.
+did_show_no_libusb_warning = False
+
+def show_no_libusb_warning():
+    global did_show_no_libusb_warning
+    if not did_show_no_libusb_warning:
+        LOG.warning("STLink and CMSIS-DAPv2 probes are not supported because no libusb library was found.")
+        did_show_no_libusb_warning = True
+    

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -159,5 +159,8 @@ class DebugProbe(object):
         @eturn Bytearray of the received data.
         """
         raise NotImplementedError()
+    
+    def __repr__(self):
+        return "<{}@{:x} {}>".format(self.__class__.__name__, id(self), self.description)
   
 

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -50,12 +50,19 @@ LOG_PACKET_BUILDS = False
 def _get_interfaces():
     """Get the connected USB devices"""
     # Get CMSIS-DAPv1 interfaces.
-    interfaces = INTERFACE[USB_BACKEND].get_all_connected_interfaces()
+    v1_interfaces = INTERFACE[USB_BACKEND].get_all_connected_interfaces()
     
-    # Add in CMSIS-DAPv2 interfaces.
-    interfaces += INTERFACE[USB_BACKEND_V2].get_all_connected_interfaces()
+    # Get CMSIS-DAPv2 interfaces.
+    v2_interfaces = INTERFACE[USB_BACKEND_V2].get_all_connected_interfaces()
     
-    return interfaces
+    # Prefer v2 over v1 if a device provides both.
+    devices_in_both = [v1 for v1 in v1_interfaces for v2 in v2_interfaces
+                        if _get_unique_id(v1) == _get_unique_id(v2)]
+    for dev in devices_in_both:
+        v1_interfaces.remove(dev)
+        
+    # Return the combined list.
+    return v1_interfaces + v2_interfaces
 
 
 def _get_unique_id(interface):

--- a/pyocd/probe/pydapaccess/interface/common.py
+++ b/pyocd/probe/pydapaccess/interface/common.py
@@ -24,13 +24,23 @@ CMSIS_DAP_USB_CLASSES = [
     USB_CLASS_MISCELLANEOUS,
     ]
 
-NXP_VID = 0x1fc9
-NXP_LPCLINK2_PID = 0x0090
-
-ARM_VID = 0x0d28
-DAPLINK_PID = 0x0204
-
 CMSIS_DAP_HID_USAGE_PAGE = 0xff00
+
+# Various known USB VID/PID values.
+ARM_DAPLINK_ID = (0x0d28, 0x0204)
+KEIL_ULINKPLUS_ID = (0xc251, 0x2750)
+NXP_LPCLINK2_ID = (0x1fc9, 0x0090)
+
+## List of VID/PID pairs for known CMSIS-DAP USB devices.
+KNOWN_CMSIS_DAP_IDS = [
+    ARM_DAPLINK_ID,
+    KEIL_ULINKPLUS_ID,
+    NXP_LPCLINK2_ID,
+    ]
+
+def is_known_cmsis_dap_vid_pid(vid, pid):
+    """! @brief Test whether a VID/PID pair belong to a known CMSIS-DAP device."""
+    return (vid, pid) in KNOWN_CMSIS_DAP_IDS
 
 def filter_device_by_class(vid, pid, device_class):
     """! @brief Test whether the device should be ignored by comparing bDeviceClass.
@@ -45,7 +55,7 @@ def filter_device_by_class(vid, pid, device_class):
     if device_class in CMSIS_DAP_USB_CLASSES:
         return False
     # Old "Mbed CMSIS-DAP" firmware has an incorrect bDeviceClass.
-    if (vid == ARM_VID) and (pid == DAPLINK_PID) and (device_class == USB_CLASS_COMMUNICATIONS):
+    if ((vid, pid) == ARM_DAPLINK_ID) and (device_class == USB_CLASS_COMMUNICATIONS):
         return False
     # Any other class indicates the device is not CMSIS-DAP.
     return True
@@ -61,6 +71,6 @@ def filter_device_by_usage_page(vid, pid, usage_page):
     @retval True Skip the device.
     @retval False The device is valid.
     """
-    return (vid == NXP_VID) and (pid == NXP_LPCLINK2_PID) \
+    return ((vid, pid) == NXP_LPCLINK2_ID) \
         and (usage_page != CMSIS_DAP_HID_USAGE_PAGE)
 

--- a/pyocd/probe/pydapaccess/interface/common.py
+++ b/pyocd/probe/pydapaccess/interface/common.py
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# USB class codes.
 USB_CLASS_COMPOSITE = 0x00
+USB_CLASS_COMMUNICATIONS = 0x02
 USB_CLASS_MISCELLANEOUS = 0xef
 
 CMSIS_DAP_USB_CLASSES = [
@@ -25,14 +27,36 @@ CMSIS_DAP_USB_CLASSES = [
 NXP_VID = 0x1fc9
 NXP_LPCLINK2_PID = 0x0090
 
+ARM_VID = 0x0d28
+DAPLINK_PID = 0x0204
+
 CMSIS_DAP_HID_USAGE_PAGE = 0xff00
 
-def filter_device(vid, pid, usage_page):
-    """! @brief Test whether the device should be ignored.
+def filter_device_by_class(vid, pid, device_class):
+    """! @brief Test whether the device should be ignored by comparing bDeviceClass.
     
-    This function performs device-specific tests to determine whether the device is
-    a CMSIS-DAP interface. An example is the NXP LPC-Link2, which has extra HID interfaces
-    with usage pages other than 0xff00.
+    This function checks the device's bDeviceClass to determine whether the it is likely to be
+    a CMSIS-DAP device. It uses the vid and pid for device-specific quirks.
+    
+    @retval True Skip the device.
+    @retval False The device is valid.
+    """
+    # Check valid classes for CMSIS-DAP firmware.
+    if device_class in CMSIS_DAP_USB_CLASSES:
+        return False
+    # Old "Mbed CMSIS-DAP" firmware has an incorrect bDeviceClass.
+    if (vid == ARM_VID) and (pid == DAPLINK_PID) and (device_class == USB_CLASS_COMMUNICATIONS):
+        return False
+    # Any other class indicates the device is not CMSIS-DAP.
+    return True
+
+def filter_device_by_usage_page(vid, pid, usage_page):
+    """! @brief Test whether the device should be ignored by comparing the HID usage page.
+    
+    This function performs device-specific tests to determine whether the device is a CMSIS-DAP
+    interface. The only current test is for the NXP LPC-Link2, which has extra HID interfaces with
+    usage pages other than 0xff00. No generic tests are done regardless of VID/PID, because it is
+    not clear whether all CMSIS-DAP devices have the usage page set to the same value.
     
     @retval True Skip the device.
     @retval False The device is valid.

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -39,8 +39,6 @@ class HidApiUSB(Interface):
     a USB HID device using cython-hidapi:
         - write/read an endpoint
     """
-    vid = 0
-    pid = 0
 
     isAvailable = IS_AVAILABLE
 
@@ -48,13 +46,12 @@ class HidApiUSB(Interface):
         super(HidApiUSB, self).__init__()
         # Vendor page and usage_id = 2
         self.device = None
-        self.packet_size = 64
 
     def open(self):
         try:
             self.device.open_path(self.device_info['path'])
         except IOError as exc:
-            raise six.raise_from(DAPAccessIntf.DeviceError("Unable to open device"), exc)
+            raise six.raise_from(DAPAccessIntf.DeviceError("Unable to open device: " + str(exc)), exc)
 
     @staticmethod
     def get_all_connected_interfaces():
@@ -76,15 +73,18 @@ class HidApiUSB(Interface):
             if (product_name.find("CMSIS-DAP") < 0):
                 # Skip non cmsis-dap devices
                 continue
+            
+            vid = deviceInfo['vendor_id']
+            pid = deviceInfo['product_id']
+            
             # Perform device-specific filtering.
-            if filter_device(deviceInfo['vendor_id'], deviceInfo['product_id'], deviceInfo['usage_page']):
+            if filter_device(vid, pid, deviceInfo['usage_page']):
                 continue
 
             try:
-                dev = hid.device(vendor_id=deviceInfo['vendor_id'], product_id=deviceInfo['product_id'],
-                    path=deviceInfo['path'])
-            except IOError:
-                log.debug("Failed to open Mbed device")
+                dev = hid.device(vendor_id=vid, product_id=pid, path=deviceInfo['path'])
+            except IOError as exc:
+                log.debug("Failed to open USB device: %s", exc)
                 continue
 
             # Create the USB interface object for this device.
@@ -92,8 +92,8 @@ class HidApiUSB(Interface):
             new_board.vendor_name = deviceInfo['manufacturer_string']
             new_board.product_name = deviceInfo['product_string']
             new_board.serial_number = deviceInfo['serial_number']
-            new_board.vid = deviceInfo['vendor_id']
-            new_board.pid = deviceInfo['product_id']
+            new_board.vid = vid
+            new_board.pid = pid
             new_board.device_info = deviceInfo
             new_board.device = dev
             boards.append(new_board)

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from .interface import Interface
-from .common import filter_device
+from .common import filter_device_by_usage_page
 from ..dap_access_api import DAPAccessIntf
 from ....utility.compatibility import to_str_safe
 import logging
@@ -78,7 +78,7 @@ class HidApiUSB(Interface):
             pid = deviceInfo['product_id']
             
             # Perform device-specific filtering.
-            if filter_device(vid, pid, deviceInfo['usage_page']):
+            if filter_device_by_usage_page(vid, pid, deviceInfo['usage_page']):
                 continue
 
             try:

--- a/pyocd/probe/pydapaccess/interface/interface.py
+++ b/pyocd/probe/pydapaccess/interface/interface.py
@@ -23,6 +23,7 @@ class Interface(object):
         self.vendor_name = ""
         self.product_name = ""
         self.packet_count = 1
+        self.packet_size = 64
     
     @property
     def has_swo_ep(self):

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -15,13 +15,15 @@
 # limitations under the License.
 
 from .interface import Interface
-from .common import filter_device_by_class
+from .common import (filter_device_by_class, is_known_cmsis_dap_vid_pid)
 from ..dap_access_api import DAPAccessIntf
 import logging
 import os
 import threading
 import six
 from time import sleep
+import platform
+import errno
 
 log = logging.getLogger('pyusb')
 
@@ -261,19 +263,32 @@ class FindDap(object):
             return False
         
         try:
+            # First attempt to get the active config. This produces a more direct error
+            # when you don't have device permissions on Linux
+            dev.get_active_configuration()
+            
+            # Now read the product name string.
             device_string = dev.product
-        except ValueError as error:
-            # Permission denied error gets reported as ValueError (langid)
-            log.debug(("ValueError \"{}\" while trying to access dev.product "
-                           "for idManufacturer=0x{:04x} idProduct=0x{:04x}. "
-                           "This is probably a permission issue.").format(error, dev.idVendor, dev.idProduct))
-            return False
         except usb.core.USBError as error:
-            log.warning("Exception getting product string: %s", error)
+            if error.errno == errno.EACCES and platform.system() == "Linux":
+                msg = ("%s while trying to interrogate a USB device "
+                   "(VID=%04x PID=%04x). This can probably be remedied with a udev rule. "
+                   "See <https://github.com/mbedmicro/pyOCD/tree/master/udev> for help." %
+                   (error, dev.idVendor, dev.idProduct))
+                # If we recognize this device as one that should be CMSIS-DAP, we can raise
+                # the level of the log message since it's almost certainly a permissions issue.
+                if is_known_cmsis_dap_vid_pid(dev.idVendor, dev.idProduct):
+                    log.warning(msg)
+                else:
+                    log.debug(msg)
+            else:
+                log.debug("Error accessing USB device (VID=%04x PID=%04x): %s",
+                    dev.idVendor, dev.idProduct, error)
             return False
-        except IndexError as error:
-            log.warning("Internal pyusb error: %s", error)
+        except (IndexError, NotImplementedError) as error:
+            log.debug("Error accessing USB device (VID=%04x PID=%04x): %s", dev.idVendor, dev.idProduct, error)
             return False
+
         if device_string is None:
             return False
         if device_string.find("CMSIS-DAP") < 0:

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from .interface import Interface
-from .common import CMSIS_DAP_USB_CLASSES
+from .common import filter_device_by_class
 from ..dap_access_api import DAPAccessIntf
 import logging
 import os
@@ -257,7 +257,7 @@ class FindDap(object):
     def __call__(self, dev):
         """Return True if this is a DAP device, False otherwise"""
         # Check if the device class is a valid one for CMSIS-DAP.
-        if dev.bDeviceClass not in CMSIS_DAP_USB_CLASSES:
+        if filter_device_by_class(dev.idVendor, dev.idProduct, dev.bDeviceClass):
             return False
         
         try:

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from .interface import Interface
-from .common import CMSIS_DAP_USB_CLASSES
+from .common import filter_device_by_class
 from ..dap_access_api import DAPAccessIntf
 from ... import common
 import logging
@@ -266,7 +266,7 @@ class HasCmsisDapv2Interface(object):
     def __call__(self, dev):
         """! @brief Return True if this is a CMSIS-DAPv2 device, False otherwise"""
         # Check if the device class is a valid one for CMSIS-DAP.
-        if dev.bDeviceClass not in CMSIS_DAP_USB_CLASSES:
+        if filter_device_by_class(dev.idVendor, dev.idProduct, dev.bDeviceClass):
             return False
         
         try:

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -17,6 +17,7 @@
 from .interface import Interface
 from .common import CMSIS_DAP_USB_CLASSES
 from ..dap_access_api import DAPAccessIntf
+from ... import common
 import logging
 import os
 import threading
@@ -169,8 +170,7 @@ class PyUSBv2(Interface):
         try:
             all_devices = usb.core.find(find_all=True, custom_match=HasCmsisDapv2Interface())
         except usb.core.NoBackendError:
-            # Print a warning if pyusb cannot find a backend, and return no probes.
-            LOG.warning("CMSIS-DAPv2 probes are not supported because no libusb library was found.")
+            common.show_no_libusb_warning()
             return []
 
         # iterate on all devices found

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -277,14 +277,18 @@ class HasCmsisDapv2Interface(object):
                 LOG.debug(("Error \"{}\" while trying to access the USB device configuration "
                    "for VID=0x{:04x} PID=0x{:04x}. This can probably be remedied with a udev rule.")
                    .format(error, dev.idVendor, dev.idProduct))
+            elif error.errno == errno.ENOENT:
+                # This error happens on devices that don't have an interface description string.
+                pass
             else:
-                LOG.warning("OS error getting USB interface string: %s", error)
+                LOG.debug("OS error getting USB interface string for VID=0x%x PID=0x%x: %s",
+                    dev.idVendor, dev.idProduct, error)
             return False
         except usb.core.USBError as error:
-            LOG.warning("Exception getting product string: %s", error)
+            LOG.debug("Exception getting product string: %s", error)
             return False
         except IndexError as error:
-            LOG.warning("Internal pyusb error: %s", error)
+            LOG.debug("Internal pyusb error: %s", error)
             return False
         except NotImplementedError as error:
             LOG.debug("Received USB unimplemented error (VID=%04x PID=%04x)", dev.idVendor, dev.idProduct)

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -43,8 +43,6 @@ class PyWinUSB(Interface):
     a USB HID device using pywinusb:
         - write/read an endpoint
     """
-    vid = 0
-    pid = 0
 
     isAvailable = IS_AVAILABLE
 
@@ -57,7 +55,6 @@ class PyWinUSB(Interface):
         # comprable to a based list implmentation.
         self.rcv_data = collections.deque()
         self.device = None
-        self.packet_size = 64
 
     # handler called when a report is received
     def rx_handler(self, data):

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from .interface import Interface
-from .common import filter_device
+from .common import filter_device_by_usage_page
 from ..dap_access_api import DAPAccessIntf
 from ....utility.timeout import Timeout
 import logging
@@ -114,7 +114,7 @@ class PyWinUSB(Interface):
                 dev.open(shared=True)
 
                 # Perform device-specific filtering.
-                if filter_device(dev.vendor_id, dev.product_id, dev.hid_caps.usage_page):
+                if filter_device_by_usage_page(dev.vendor_id, dev.product_id, dev.hid_caps.usage_page):
                     dev.close()
                     continue
 

--- a/pyocd/probe/stlink/__init__.py
+++ b/pyocd/probe/stlink/__init__.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018 Arm Limited
+# Copyright (c) 2018-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,5 @@
 # limitations under the License.
 
 
-class STLinkException(RuntimeError):
-    pass
 
 

--- a/pyocd/probe/stlink/constants.py
+++ b/pyocd/probe/stlink/constants.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018 Arm Limited
+# Copyright (c) 2018-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from . import STLinkException
-from ...core import exceptions
-import logging
-import struct
-import six
 
 class Commands:    
     """!

--- a/pyocd/probe/stlink/constants.py
+++ b/pyocd/probe/stlink/constants.py
@@ -78,7 +78,7 @@ class Commands:
     JTAG_STLINK_SWD_COM = 0x00
     JTAG_STLINK_JTAG_COM = 0x01
     
-class Status:
+class Status(object):
     """!
     @brief STLink status codes and messages.
     """
@@ -144,6 +144,10 @@ class Status:
         JTAG_FREQ_NOT_SUPPORTED : "Frequency not supported",
         JTAG_UNKNOWN_CMD : "Unknown command",
     }
+    
+    @staticmethod
+    def get_error_message(status):
+        return "STLink error ({}): {}".format(status, Status.MESSAGES.get(status, "Unknown error"))
 
 ## Map from SWD frequency in Hertz to delay loop count.
 SWD_FREQ_MAP = {

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -222,9 +222,11 @@ class STLink(object):
     def _clear_sticky_error(self):
         with self._lock:
             if self._protocol == self.Protocol.SWD:
-                self.write_dap_register(self.DP_PORT, dap.DP_ABORT, dap.ABORT_STKERRCLR)
+                self.write_dap_register(self.DP_PORT, dap.DP_ABORT,
+                    dap.ABORT_ORUNERRCLR | dap.ABORT_WDERRCLR | dap.ABORT_STKERRCLR | dap.ABORT_STKCMPCLR)
             elif self._protocol == self.Protocol.JTAG:
-                self.write_dap_register(self.DP_PORT, dap.DP_CTRL_STAT, dap.CTRLSTAT_STICKYERR)
+                self.write_dap_register(self.DP_PORT, dap.DP_CTRL_STAT,
+                    dap.CTRLSTAT_STICKYERR | dap.CTRLSTAT_STICKYCMP | dap.CTRLSTAT_STICKYORUN)
     
     def _read_mem(self, addr, size, memcmd, max, apsel):
         with self._lock:

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018 Arm Limited
+# Copyright (c) 2018-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from . import STLinkException
+from ...core import exceptions
 from .. import common
 import usb.core
 import usb.util
@@ -124,9 +124,9 @@ class STLinkUSBInterface(object):
                 self._ep_swv = endpoint
         
         if not self._ep_out:
-            raise STLinkException("Unable to find OUT endpoint")
+            raise exceptions.ProbeError("Unable to find OUT endpoint")
         if not self._ep_in:
-            raise STLinkException("Unable to find IN endpoint")
+            raise exceptions.ProbeError("Unable to find IN endpoint")
 
         self._max_packet_size = self._ep_in.wMaxPacketSize
         
@@ -208,7 +208,7 @@ class STLinkUSBInterface(object):
                     log.debug("  USB IN < %s" % ' '.join(['%02x' % i for i in data]))
                 return data
         except usb.core.USBError as exc:
-            six.raise_from(STLinkException("USB Error: %s" % exc), exc)
+            six.raise_from(exceptions.ProbeError("USB Error: %s" % exc), exc)
         return None
 
     def read_swv(self, size, timeout=1000):

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -72,13 +72,13 @@ class STLinkUSBInterface(object):
                         "This is probably a permission issue.", error, dev.idVendor, dev.idProduct)
             return False
         except usb.core.USBError as error:
-            log.warning("Exception getting device info (VID=%04x PID=%04x): %s", dev.idVendor, dev.idProduct, error)
+            log.debug("Exception getting device info (VID=%04x PID=%04x): %s", dev.idVendor, dev.idProduct, error)
             return False
         except IndexError as error:
-            log.warning("Internal pyusb error (VID=%04x PID=%04x): %s", dev.idVendor, dev.idProduct, error)
+            log.debug("Internal pyusb error (VID=%04x PID=%04x): %s", dev.idVendor, dev.idProduct, error)
             return False
         except NotImplementedError as error:
-            log.warning("Received USB unimplemented error (VID=%04x PID=%04x)", dev.idVendor, dev.idProduct)
+            log.debug("Received USB unimplemented error (VID=%04x PID=%04x)", dev.idVendor, dev.idProduct)
             return False
 
     @classmethod

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import
 from . import STLinkException
+from .. import common
 import usb.core
 import usb.util
 import logging
@@ -86,8 +87,7 @@ class STLinkUSBInterface(object):
         try:
             devices = usb.core.find(find_all=True, custom_match=cls._usb_match)
         except usb.core.NoBackendError:
-            # Print a warning if pyusb cannot find a backend, and return no probes.
-            log.warning("STLink probes are not supported because no libusb library was found.")
+            common.show_no_libusb_warning()
             return []
         
         intfList = []

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -17,36 +17,29 @@
 from .debug_probe import DebugProbe
 from ..core.memory_interface import MemoryInterface
 from ..core import exceptions
-from .stlink import (STLinkException, usb, stlink)
+from ..coresight.ap import (APSEL, APSEL_SHIFT)
+from .stlink.usb import STLinkUSBInterface
+from .stlink.stlink import STLink
 from ..utility import conversion
 import six
 
 class StlinkProbe(DebugProbe):
     """! @brief Wraps an STLink as a DebugProbe."""
         
-    APSEL = 0xff000000
-    APSEL_SHIFT = 24
-    
     @classmethod
     def get_all_connected_probes(cls):
-        try:
-            return [cls(dev) for dev in usb.STLinkUSBInterface.get_all_connected_devices()]
-        except STLinkException as exc:
-            six.raise_from(cls._convert_exception(exc), exc)
+        return [cls(dev) for dev in STLinkUSBInterface.get_all_connected_devices()]
     
     @classmethod
     def get_probe_with_id(cls, unique_id):
-        try:
-            for dev in usb.STLinkUSBInterface.get_all_connected_devices():
-                if dev.serial_number == unique_id:
-                    return cls(usb.STLinkUSBInterface(unique_id))
-            else:
-                return None
-        except STLinkException as exc:
-            six.raise_from(cls._convert_exception(exc), exc)
+        for dev in STLinkUSBInterface.get_all_connected_devices():
+            if dev.serial_number == unique_id:
+                return cls(STLinkUSBInterface(unique_id))
+        else:
+            return None
 
     def __init__(self, device):
-        self._link = stlink.STLink(device)
+        self._link = STLink(device)
         self._is_open = False
         self._is_connected = False
         self._nreset_state = False
@@ -82,29 +75,20 @@ class StlinkProbe(DebugProbe):
         return self._is_open
     
     def open(self):
-        try:
-            self._link.open()
-            self._is_open = True
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        self._link.open()
+        self._is_open = True
     
     def close(self):
-        try:
-            self._link.close()
-            self._is_open = False
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        self._link.close()
+        self._is_open = False
 
     # ------------------------------------------- #
     #          Target control functions
     # ------------------------------------------- #
     def connect(self, protocol=None):
         """! @brief Initialize DAP IO pins for JTAG or SWD"""
-        try:
-            self._link.enter_debug(stlink.STLink.Protocol.SWD)
-            self._is_connected = True
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        self._link.enter_debug(STLink.Protocol.SWD)
+        self._is_connected = True
 
     # TODO remove
     def swj_sequence(self):
@@ -113,40 +97,28 @@ class StlinkProbe(DebugProbe):
 
     def disconnect(self):
         """! @brief Deinitialize the DAP I/O pins"""
-        try:
-            # TODO Close the APs. When this is attempted, we get an undocumented 0x1d error. Doesn't
-            #      seem to be necessary, anyway.
-            self._memory_interfaces = {}
-            
-            self._link.enter_idle()
-            self._is_connected = False
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        # TODO Close the APs. When this is attempted, we get an undocumented 0x1d error. Doesn't
+        #      seem to be necessary, anyway.
+        self._memory_interfaces = {}
+        
+        self._link.enter_idle()
+        self._is_connected = False
 
     def set_clock(self, frequency):
         """! @brief Set the frequency for JTAG and SWD in Hz
 
         This function is safe to call before connect is called.
         """
-        try:
-            self._link.set_swd_frequency(frequency)
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        self._link.set_swd_frequency(frequency)
 
     def reset(self):
         """! @brief Reset the target"""
-        try:
-            self._link.target_reset()
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        self._link.target_reset()
 
     def assert_reset(self, asserted):
         """! @brief Assert or de-assert target reset line"""
-        try:
-            self._link.drive_nreset(asserted)
-            self._nreset_state = asserted
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        self._link.drive_nreset(asserted)
+        self._nreset_state = asserted
     
     def is_reset_asserted(self):
         """! @brief Returns True if the target reset line is asserted or False if de-asserted"""
@@ -161,10 +133,7 @@ class StlinkProbe(DebugProbe):
     # ------------------------------------------- #
     
     def read_dp(self, addr, now=True):
-        try:
-            result = self._link.read_dap_register(stlink.STLink.DP_PORT, addr)
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        result = self._link.read_dap_register(STLink.DP_PORT, addr)
         
         def read_dp_result_callback():
             return result
@@ -172,17 +141,11 @@ class StlinkProbe(DebugProbe):
         return result if now else read_dp_result_callback
 
     def write_dp(self, addr, data):
-        try:
-            result = self._link.write_dap_register(stlink.STLink.DP_PORT, addr, data)
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        result = self._link.write_dap_register(STLink.DP_PORT, addr, data)
 
     def read_ap(self, addr, now=True):
-        try:
-            apsel = (addr & self.APSEL) >> self.APSEL_SHIFT
-            result = self._link.read_dap_register(apsel, addr & 0xffff)
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        apsel = (addr & APSEL) >> APSEL_SHIFT
+        result = self._link.read_dap_register(apsel, addr & 0xffff)
         
         def read_ap_result_callback():
             return result
@@ -190,11 +153,8 @@ class StlinkProbe(DebugProbe):
         return result if now else read_ap_result_callback
 
     def write_ap(self, addr, data):
-        try:
-            apsel = (addr & self.APSEL) >> self.APSEL_SHIFT
-            result = self._link.write_dap_register(apsel, addr & 0xffff, data)
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        apsel = (addr & APSEL) >> APSEL_SHIFT
+        result = self._link.write_dap_register(apsel, addr & 0xffff, data)
 
     def read_ap_multiple(self, addr, count=1, now=True):
         results = [self.read_ap(addr, now=True) for n in range(count)]
@@ -214,13 +174,6 @@ class StlinkProbe(DebugProbe):
             self._link.open_ap(apsel)
             self._memory_interfaces[apsel] = STLinkMemoryInterface(self._link, apsel)
         return self._memory_interfaces[apsel]
-  
-    @staticmethod
-    def _convert_exception(exc):
-        if isinstance(exc, STLinkException):
-            return exceptions.ProbeError(str(exc))
-        else:
-            return exc
 
     def has_swo(self):
         """! @brief Returns bool indicating whether the link supports SWO."""
@@ -228,27 +181,18 @@ class StlinkProbe(DebugProbe):
 
     def swo_start(self, baudrate):
         """! @brief Start receiving SWO data at the given baudrate."""
-        try:
-            self._link.swo_start(baudrate)
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        self._link.swo_start(baudrate)
 
     def swo_stop(self):
         """! @brief Stop receiving SWO data."""
-        try:
-            self._link.swo_stop()
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        self._link.swo_stop()
 
     def swo_read(self):
         """! @brief Read as much buffered SWO data from the target as possible.
         
         @eturn Bytearray of the received data.
         """
-        try:
-            return self._link.swo_read()
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        return self._link.swo_read()
 
 class STLinkMemoryInterface(MemoryInterface):
     """! @brief Concrete memory interface for a single AP."""
@@ -263,15 +207,12 @@ class STLinkMemoryInterface(MemoryInterface):
         By default the transfer size is a word.
         """
         assert transfer_size in (8, 16, 32)
-        try:
-            if transfer_size == 32:
-                self._link.write_mem32(addr, conversion.u32le_list_to_byte_list([data]), self._apsel)
-            elif transfer_size == 16:
-                self._link.write_mem16(addr, conversion.u16le_list_to_byte_list([data]), self._apsel)
-            elif transfer_size == 8:
-                self._link.write_mem8(addr, [data], self._apsel)
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        if transfer_size == 32:
+            self._link.write_mem32(addr, conversion.u32le_list_to_byte_list([data]), self._apsel)
+        elif transfer_size == 16:
+            self._link.write_mem16(addr, conversion.u16le_list_to_byte_list([data]), self._apsel)
+        elif transfer_size == 8:
+            self._link.write_mem8(addr, [data], self._apsel)
         
     def read_memory(self, addr, transfer_size=32, now=True):
         """! @brief Read a memory location.
@@ -279,36 +220,20 @@ class STLinkMemoryInterface(MemoryInterface):
         By default, a word will be read.
         """
         assert transfer_size in (8, 16, 32)
-        try:
-            if transfer_size == 32:
-                result = conversion.byte_list_to_u32le_list(self._link.read_mem32(addr, 4, self._apsel))[0]
-            elif transfer_size == 16:
-                result = conversion.byte_list_to_u16le_list(self._link.read_mem16(addr, 2, self._apsel))[0]
-            elif transfer_size == 8:
-                result = self._link.read_mem8(addr, 1, self._apsel)[0]
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        if transfer_size == 32:
+            result = conversion.byte_list_to_u32le_list(self._link.read_mem32(addr, 4, self._apsel))[0]
+        elif transfer_size == 16:
+            result = conversion.byte_list_to_u16le_list(self._link.read_mem16(addr, 2, self._apsel))[0]
+        elif transfer_size == 8:
+            result = self._link.read_mem8(addr, 1, self._apsel)[0]
         
         def read_callback():
             return result
         return result if now else read_callback
 
     def write_memory_block32(self, addr, data):
-        try:
-            self._link.write_mem32(addr, conversion.u32le_list_to_byte_list(data), self._apsel)
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+        self._link.write_mem32(addr, conversion.u32le_list_to_byte_list(data), self._apsel)
 
     def read_memory_block32(self, addr, size):
-        try:
-            return conversion.byte_list_to_u32le_list(self._link.read_mem32(addr, size * 4, self._apsel))
-        except STLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
-  
-    @staticmethod
-    def _convert_exception(exc):
-        if isinstance(exc, STLinkException):
-            return exceptions.ProbeError(str(exc))
-        else:
-            return exc
+        return conversion.byte_list_to_u32le_list(self._link.read_mem32(addr, size * 4, self._apsel))
 

--- a/test/speed_test.py
+++ b/test/speed_test.py
@@ -28,6 +28,7 @@ sys.path.insert(0, parentdir)
 from pyocd.core.helpers import ConnectHelper
 from pyocd.probe.pydapaccess import DAPAccess
 from pyocd.core.memory_map import MemoryType
+from pyocd.utility import conversion
 from test_util import (Test, TestResult, get_session_options, get_target_test_params)
 
 class SpeedTestResult(TestResult):
@@ -99,15 +100,18 @@ def speed_test(board_id):
         test_params = get_target_test_params(session)
         session.probe.set_clock(test_params['test_clock'])
         
-        test_config = "uncached"
+        test_config = "uncached 8-bit"
 
-        def test_ram(record_speed=False):
+        def test_ram(record_speed=False, width=8):
             print("\n\n------ TEST RAM READ / WRITE SPEED [%s] ------" % test_config)
             test_addr = ram_start
             test_size = ram_size
             data = [randrange(1, 50) for x in range(test_size)]
             start = time()
-            target.write_memory_block8(test_addr, data)
+            if width == 8:
+                target.write_memory_block8(test_addr, data)
+            elif width == 32:
+                target.write_memory_block32(test_addr, conversion.byte_list_to_u32le_list(data))
             target.flush()
             stop = time()
             diff = stop - start
@@ -120,7 +124,10 @@ def speed_test(board_id):
                 result.write_speed = write_speed
             print("Writing %i byte took %.3f seconds: %.3f B/s" % (test_size, diff, write_speed))
             start = time()
-            block = target.read_memory_block8(test_addr, test_size)
+            if width == 8:
+                block = target.read_memory_block8(test_addr, test_size)
+            elif width == 32:
+                block = conversion.u32le_list_to_byte_list(target.read_memory_block32(test_addr, test_size // 4))
             target.flush()
             stop = time()
             diff = stop - start
@@ -147,12 +154,15 @@ def speed_test(board_id):
                 print("TEST PASSED")
             return not error
 
-        def test_rom(record_speed=False):
+        def test_rom(record_speed=False, width=8):
             print("\n\n------ TEST ROM READ SPEED [%s] ------" % test_config)
             test_addr = rom_start
             test_size = rom_size
             start = time()
-            block = target.read_memory_block8(test_addr, test_size)
+            if width == 8:
+                block = target.read_memory_block8(test_addr, test_size)
+            elif width == 32:
+                block = conversion.u32le_list_to_byte_list(target.read_memory_block32(test_addr, test_size // 4))
             target.flush()
             stop = time()
             diff = stop - start
@@ -167,18 +177,28 @@ def speed_test(board_id):
             print("TEST PASSED")
             return True
         
-        # Without memcache
-        passed = test_ram(True)
+        # 8-bit without memcache
+        passed = test_ram(True, 8)
         test_count += 1
         test_pass_count += int(passed)
         
-        passed = test_rom(True)
+        passed = test_rom(True, 8)
+        test_count += 1
+        test_pass_count += int(passed)
+        
+        # 32-bit without memcache
+        test_config = "uncached 32-bit"
+        passed = test_ram(False, 32)
+        test_count += 1
+        test_pass_count += int(passed)
+        
+        passed = test_rom(False, 32)
         test_count += 1
         test_pass_count += int(passed)
         
         # With memcache
         target = target.get_target_context()
-        test_config = "cached, pass 1"
+        test_config = "cached 8-bit, pass 1"
         
         passed = test_ram()
         test_count += 1
@@ -189,7 +209,7 @@ def speed_test(board_id):
         test_pass_count += int(passed)
         
         # Again with memcache
-        test_config = "cached, pass 2"
+        test_config = "cached 8-bit, pass 2"
         passed = test_ram()
         test_count += 1
         test_pass_count += int(passed)


### PR DESCRIPTION
This PR contains multiple bug fixes for both CMSIS-DAP and STLink debug probes.

- Workaround for apparent libusb issue on Windows that caused STLink devices to intermittently not be seen. Closes #575 
- Workaround for old "mbed CMSIS-DAP" firmware (the precursor to DAPLink) reporting an incorrect USB device class. Closes #588 
- The full range of STLink error responses to DP/AP transfers and high level memory accesses are now handled correctly. This change also addresses failures introduced by the latest STLink firmware (V2J33M25) returning more accurate errors. Closes #581
- If a debug probe provides both CMSIS-DAP v1 and v2 interfaces, the v2 interface will take precedence instead of showing both (with no way to know which is which).
- When clearing DP sticky errors, all sticky errors are cleared.
- An SWD timeout error is handled by aborting the DP transfer (writing `DP_ABORT.DAPABORT`).

Major improvements to error logging for probes:
- If libusb is not installed, pyOCD will only log a single warning per process lifetime about STLink and CMSIS-DAPv2 probes not being available.
- Much better handling of libusb permissions errors on Linux. For USB devices that are known to be debug probes by VID/PID, a warning is logged that contains a link to the [udev folder](https://github.com/mbedmicro/pyOCD/tree/master/udev).
- Normalized libusb error handling and error messages between all probe interface classes that use libusb.

And a little cleanup.