### PR TITLE
Fix selection of pack targets in pyocd-gdbserver

### DIFF
--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -66,10 +66,6 @@ ERASE_OPTIONS = {
     'sector': False,
     }
 
-class InvalidArgumentError(RuntimeError):
-    """! @brief Exception class raised for invalid target names."""
-    pass
-
 def convert_frequency(value):
     """! @brief Applies scale suffix to frequency value string."""
     value = value.strip()
@@ -305,9 +301,6 @@ class PyOCDTool(object):
 
             # Successful exit.
             return 0
-        except InvalidArgumentError as e:
-            self._parser.error(e)
-            return 1
         except KeyboardInterrupt:
             return 0
         except Exception as e:


### PR DESCRIPTION
`pyocd-gdbserver` used an argparse type callable, `validate_target()`, to validate the target name passed to `--target`. This function raised `InvalidArgumentError` for an unknown target, and was not aware of pack targets. Thus, attempting to select a pack target would always fail even when it worked in the combined `pyocd` tool. This PR removes `validate_target()` and `InvalidArgumentError`. The combined `pyocd` tool also had a leftover vestige of `InvalidArgumentError` that was removed.

Closes #570 