### PR TITLE
Fix some docs issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,20 +4,33 @@ Contributing
 We appreciate your contributions! Because this is an open source project, we want to keep it as easy
 as possible to contribute changes. However, we need contributors to follow a few guidelines.
 
-## Contributor agreement
 
-For us to accept your pull request, we need you to agree to our
-[contributor agreement](http://developer.mbed.org/contributor_agreement/)
-to give us the necessary rights to use and distribute your contributions. (To click through the agreement, create an account on mbed.com, and log in.)
+## Coding style
+
+Contributed source code must follow [PEP8](https://www.python.org/dev/peps/pep-0008/) style
+conventions.
+
+Other formatting requirements:
+- 4 space indents, no tabs are allowed.
+- No trailing whitespace.
+- All source files must end with a newline (an empty line at the end).
+- Lines should generally not be longer than 120 characters, though this is not a hard rule.
+
 
 ## Process
 
-Please create a pull request in GitHub with your
-contribution. Before creating the pull request, please ensure that all tests pass. We also run the
-tests on a wide range of boards for every pull request using our CI setup. Changes must pass on
-all tested boards before the the pull request can be merged.
+Please create a pull request in GitHub with your contribution. Before creating the pull request,
+please ensure that all tests pass. We also run the tests on a wide range of boards for every pull
+request using our CI setup. Changes must pass on all tested boards before the the pull request can
+be merged.
 
-The [developers' guide](docs/DEVELOPERS_GUIDE.md) describes how to create your development environment.
-The [automated tests guide](docs/AUTOMATED_TESTS.md) provides information about the available types
-of tests and describes how to run the tests.
+The [developers' guide](docs/developers_guide.md) describes how to create your development
+environment. The [automated tests guide](docs/automated_tests.md) provides information about the
+available types of tests and describes how to run the tests.
 
+
+## More
+
+For more information about contributing, see the Mbed OS [contributor
+documentation](http://os.mbed.com/contributing). Although this documentation is written primarily
+with Mbed OS in mind, much of it applies directly to pyOCD, as well.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ existing setups. The primary difference is the set of gdb monitor commands.
 Recommended GDB and IDE setup
 -----------------------------
 
+The recommended toolchain for embedded Arm Cortex-M development is [GNU Arm
+Embedded](https://developer.arm.com/tools-and-software/open-source-software/gnu-toolchain/gnu-rm),
+provided by Arm. GDB is included with this toolchain.
+
 The GDB server works well with [Eclipse](https://www.eclipse.org/) and the [GNU MCU Eclipse
 plug-ins](https://gnu-mcu-eclipse.github.io/). GNU MCU Eclipse fully supports pyOCD with an included
 pyOCD debugging plugin.
@@ -185,7 +189,7 @@ Contributions
 -------------
 
 We welcome contributions to pyOCD in any area. Please see the [contribution
-guidelines](CONTRIBUTING.md) for details.
+guidelines](CONTRIBUTING.md) for detailed requirements for contributions.
 
 To report bugs, please [create an issue](https://github.com/mbedmicro/pyOCD/issues/new) in the
 GitHub project.
@@ -194,6 +198,7 @@ GitHub project.
 License
 -------
 
-PyOCD is licensed with Apache 2.0. See the [LICENSE](LICENSE) file for the full text of the license.
+PyOCD is licensed with the permissive Apache 2.0 license. See the [LICENSE](LICENSE) file for the
+full text of the license.
 
-Copyright © 2006-2018 Arm Ltd
+Copyright © 2006-2019 Arm Ltd

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,19 +8,23 @@ that a user of the Python API will interact with. The connections in the diagram
 composition, not inheritance.
 
 ```
-          Session
-             |
-             |-----> DebugProbe
-             |
-           Board
-             |
-       CoreSightTarget
-             |
-   /---------|-----------\
-   |         |           |
- Flash   CortexM[]   DebugPort
-             |           |
-         MemoryMap  AccessPort[]
+              Session
+                 |
+                 |----------------\
+                 |                |
+               Board          DebugProbe
+                 |
+           CoreSightTarget
+                 |
+                 |----------------\
+                 |                |
+             CortexM[]        DebugPort
+                 |                |
+             MemoryMap       AccessPort[]
+                 |
+           MemoryRegion[]
+                 |
+               Flash
 ```
 
 The root of the runtime object graph is a `Session` object. This object holds references to the debug
@@ -28,10 +32,11 @@ probe and the board. It is also responsible for managing per-session user option
 various features and settings.
 
 Attached to the board is a `CoreSightTarget` instance, which represents an MCU. This owns the
-CoreSight related objects for communicating with the DP and APs, the flash programming interface,
-and a `CortexM` object for each CPU core on the device. Both `CoreSightTarget` and `CortexM` are
-subclasses of the abstract `Target` class, which is referenced below, and share most of the same
-APIs.
+CoreSight related objects for communicating with the DP and APs and a `CortexM` object for each CPU
+core on the device. Both `CoreSightTarget` and `CortexM` are subclasses of the abstract `Target`
+class, which is referenced below, and share most of the same APIs. `CortexM` has a memory map
+comprised of `MemoryRegion` objects. The flash memory regions have a `Flash` object to control flash
+programming.
 
 ## Targets and boards
 

--- a/docs/automated_tests.md
+++ b/docs/automated_tests.md
@@ -38,10 +38,13 @@ Functional tests:
 - `blank_test.py`: tests ability to connect to devices with with blank flash. (Not run by `automated_test.py`.)
 - `connect_test.py`: tests all combinations of the halt on connect and disconnect resume options.
 - `cortex_test.py`: validates CPU control operations and memory accesses.
+- `debug_context_test.py`: tests some `DebugContext` classes.
 - `flash_test.py`: comprehensive test of flash programming.
 - `flash_loader_test.py`: test the classes in the `pyocd.flash.loader` module.
 - `gdb_server_json_test.py`: validates the JSON output from pyocd-gdbserver used by tools like the GNU MCU Eclipse pyOCD plugin.
-- `gdb_test.py`: tests the gdbserver by running a script in a gdb process.
+- `gdb_test.py`: tests the gdbserver by running a script in a gdb process. Note that on Windows,
+    the 32-bit Python 2.7 must be installed for the Python-enabled gdb to work properly and for
+    this test to pass.
 - `parallel_test.py`: checks for issues with accessing debug probes from multiple processes and threads simultaneously. (Not run by `automated_test.py`.)
 - `speed_test.py`: performance test for memory reads and writes.
 

--- a/docs/developers_guide.md
+++ b/docs/developers_guide.md
@@ -10,9 +10,15 @@ dependencies for the current platform by following the detailed steps below.
 
 Install the necessary tools listed below. Skip any step where a compatible tool already exists.
 
-* [Install Python](https://www.python.org/downloads/). Version 3.6.0 or above is preferred, while version 2.7.9 or above is also supported. Add to PATH.
+* [Install Python](https://www.python.org/downloads/). It is recommended that you install both
+    Python 3.7.0 or above and Python 2.7.15 or above, in order to test under both versions. Add to
+    PATH.
+    *  Note that on Windows, the 32-bit Python 2.7 must be installed for the Python-enabled gdb to
+        work properly and for the `test/gdb_test.py` functional test to pass.
 * [Install Git](https://git-scm.com/downloads). Add to PATH.
-* [Install virtualenv](https://virtualenv.pypa.io/en/latest/) in your global Python installation, eg: `pip install virtualenv`
+* [Install virtualenv](https://virtualenv.pypa.io/en/latest/) in your global Python installation, eg: `pip install virtualenv`.
+* [Install GNU Arm Embedded toolchain](https://developer.arm.com/tools-and-software/open-source-software/gnu-toolchain/gnu-rm).
+    This provides `arm-none-eabi-gdb` used for testing the gdbserver. Add to PATH.
 
 ## Steps
 
@@ -33,7 +39,7 @@ $ python3 -mvirtualenv venv3
 
 **Step 2.** Activate virtual environment
 
-Activate your virtualenv and install the PyOCD dependencies for the current platform by doing
+Activate your virtualenv and install the pyOCD dependencies for the current platform by doing
 the following.
 
 Linux or Mac:


### PR DESCRIPTION
- Removed reference to contributor agreement that is no longer required.
- Fixed architecture block diagram in `docs/architecture.md`.
- Added `debug_context_test.py` to list of functional tests in `docs/automated_tests.py`.
- Incremented copyright year in `README.md`.
- Some more minor adjustments.