### PR TITLE
Flash, test, and other fixes

### DIFF
--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -69,9 +69,9 @@ class CoreSightTarget(Target, GraphNode):
     
     @selected_core.setter
     def selected_core(self, core_number):
-        if num not in self.cores:
-            raise ValueError("invalid core number")
-        logging.debug("selected core #%d" % num)
+        if core_number not in self.cores:
+            raise ValueError("invalid core number %d" % core_number)
+        logging.debug("selected core #%d" % core_number)
         self._selected_core = core_number
 
     @property

--- a/pyocd/flash/flash_builder.py
+++ b/pyocd/flash/flash_builder.py
@@ -770,7 +770,7 @@ class FlashBuilder(object):
             for page in unknown_pages:
                 if page.cached_estimate_data is not None:
                     data = page.cached_estimate_data
-                    offset = len(cached_data)
+                    offset = len(data)
                 else:
                     data = []
                     offset = 0

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -190,31 +190,59 @@ def basic_test(board_id, file):
 
         print("\n\n------ TEST PROGRAM/ERASE PAGE ------")
         # Fill 3 pages with 0x55
+        sector_size = flash.get_sector_info(addr_flash).size
         page_size = flash.get_page_info(addr_flash).size
         fill = [0x55] * page_size
         for i in range(0, 3):
-            address = addr_flash + page_size * i
+            address = addr_flash + sector_size * i
             # Test only supports a location with 3 aligned
             # pages of the same size
             current_page_size = flash.get_page_info(addr_flash).size
             assert page_size == current_page_size
             assert address % current_page_size == 0
 
+            print("Erasing sector @ 0x%x (%d bytes)" % (address, sector_size))
             flash.init(flash.Operation.ERASE)
             flash.erase_sector(address)
-            flash.uninit()
 
-            flash.init(flash.Operation.PROGRAM)
-            flash.program_page(address, fill)
-            flash.uninit()
-        # Erase the middle page
+            print("Verifying erased sector @ 0x%x (%d bytes)" % (address, sector_size))
+            data = target.read_memory_block8(address, sector_size)
+            if data != [flash.region.erased_byte_value] * sector_size:
+                print("FAILED to erase sector @ 0x%x (%d bytes)" % (address, sector_size))
+            else:
+                print("Programming page @ 0x%x (%d bytes)" % (address, page_size))
+                flash.init(flash.Operation.PROGRAM)
+                flash.program_page(address, fill)
+
+                print("Verifying programmed page @ 0x%x (%d bytes)" % (address, page_size))
+                data = target.read_memory_block8(address, page_size)
+                if data != fill:
+                    print("FAILED to program page @ 0x%x (%d bytes)" % (address, page_size))
+
+        # Erase the middle sector
+        address = addr_flash + sector_size
+        print("Erasing sector @ 0x%x (%d bytes)" % (address, sector_size))
         flash.init(flash.Operation.ERASE)
-        flash.erase_sector(addr_flash + page_size)
+        flash.erase_sector(address)
         flash.cleanup()
-        # Verify the 1st and 3rd page were not erased, and that the 2nd page is fully erased
-        data = target.read_memory_block8(addr_flash, page_size * 3)
-        expected = fill + [0xFF] * page_size + fill
-        if data == expected:
+
+        print("Verifying erased sector @ 0x%x (%d bytes)" % (address, sector_size))
+        data = target.read_memory_block8(address, sector_size)
+        if data != [flash.region.erased_byte_value] * sector_size:
+            print("FAILED to erase sector @ 0x%x (%d bytes)" % (address, sector_size))
+       
+        # Re-verify the 1st and 3rd page were not erased, and that the 2nd page is fully erased
+        did_pass = False
+        for i in range(0, 3):
+            address = addr_flash + sector_size * i
+            print("Verifying page @ 0x%x (%d bytes)" % (address, page_size))
+            data = target.read_memory_block8(address, page_size)
+            expected = ([flash.region.erased_byte_value] * page_size) if (i == 1) else fill
+            did_pass = (data == expected)
+            if not did_pass:
+                print("FAILED verify for page @ 0x%x (%d bytes)" % (address, page_size))
+                break
+        if did_pass:
             print("TEST PASSED")
         else:
             print("TEST FAILED")

--- a/test/speed_test.py
+++ b/test/speed_test.py
@@ -31,6 +31,8 @@ from pyocd.core.memory_map import MemoryType
 from pyocd.utility import conversion
 from test_util import (Test, TestResult, get_session_options, get_target_test_params)
 
+_1MB = (1 * 1024 * 1024)
+
 class SpeedTestResult(TestResult):
     def __init__(self):
         super(SpeedTestResult, self).__init__(None, None, None)
@@ -86,10 +88,12 @@ def speed_test(board_id):
         ram_region = memory_map.get_first_region_of_type(MemoryType.RAM)
         rom_region = memory_map.get_boot_memory()
 
+        # Limit region sizes used for performance testing to 1 MB. We don't really need to
+        # be reading all 32 MB of a QSPI!
         ram_start = ram_region.start
-        ram_size = ram_region.length
+        ram_size = min(ram_region.length, _1MB)
         rom_start = rom_region.start
-        rom_size = rom_region.length
+        rom_size = min(rom_region.length, _1MB)
 
         target = board.target
 


### PR DESCRIPTION
- Fixed invalid symbol name in `FlashBuilder`. This would only happen if the target does not support the CRC analyzer and sector erase was used.
- Rewrote the `basic_test.py` flash tests to support different sector and page sizes.
- Limiting `speed_test.py` to a max of 1 MB r/w for any region.
- Fixed the `selector_core` property setter for `CoreSightTarget`.