### PR TITLE
Add decoding of serial number from string to hexadecimal for ST-Link V2 probes

### DIFF
--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -26,7 +26,6 @@ from collections import namedtuple
 import platform
 import errno
 from binascii import hexlify
-from sys import hexversion
 
 # Set to True to enable debug logs of USB data transfers.
 LOG_USB_DATA = False
@@ -128,11 +127,11 @@ class STLinkUSBInterface(object):
         # reading the strings, everything is ok. This workaround doesn't cause any issues with
         # Linux or macOS.
         try:
-            if self._dev.idProduct == 0x3748:  # Workaround for unprintable characters in the ST-Link V2 probes
-                if hexversion >= 0x03020000:  # To align with libusb encoder
-                    self._serial_number = bytes(self._dev.serial_number, 'utf-16-le')[::2].hex().upper()
-                else:
-                    self._serial_number = hexlify(self._dev.serial_number.encode('utf-16-le')[::2]).upper()
+            if len(self._dev.serial_number) == 12:  # Workaround for unprintable characters in the ST-Link V2 probes
+                self._serial_number = hexlify(self._dev.serial_number.encode('utf-16-le')[::2])\
+                    .decode('utf-8', 'replace').upper()
+            else:
+                self._serial_number = self._dev.serial_number
             self._vendor_name = self._dev.manufacturer
             self._product_name = self._dev.product
         finally:

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -25,6 +25,8 @@ import threading
 from collections import namedtuple
 import platform
 import errno
+from binascii import hexlify
+from sys import hexversion
 
 # Set to True to enable debug logs of USB data transfers.
 LOG_USB_DATA = False
@@ -126,8 +128,12 @@ class STLinkUSBInterface(object):
         # reading the strings, everything is ok. This workaround doesn't cause any issues with
         # Linux or macOS.
         try:
-            self._serial_number = self._dev.serial_number
-            self._vendor_name =  self._dev.manufacturer
+            if self._dev.idProduct == 0x3748:  # Workaround for unprintable characters in the ST-Link V2 probes
+                if hexversion >= 0x03020000:  # To align with libusb encoder
+                    self._serial_number = bytes(self._dev.serial_number, 'utf-16-le')[::2].hex().upper()
+                else:
+                    self._serial_number = hexlify(self._dev.serial_number.encode('utf-16-le')[::2]).upper()
+            self._vendor_name = self._dev.manufacturer
             self._product_name = self._dev.product
         finally:
             usb.util.dispose_resources(self._dev)


### PR DESCRIPTION
 I could not find other solution for the ST-Link V2 probes serial numbers. Seems it's quite an old problem, for example, [here](http://wunderkis.de/stlink-serialno/).
 If there is some other planned fix for this, please, discard the PR.
