### PR TITLE
Remove websocket-client and future from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,6 @@ setup(
         'intelhex>=2.0,<3.0',
         'six>=1.0,<2.0',
         'enum34>=1.0,<2.0;python_version<"3.4"',
-        'future',
-        'websocket-client',
         'intervaltree>=3.0.2,<4.0',
         'colorama',
         'pyelftools',


### PR DESCRIPTION
These packages are no longer required now that websocket support has been removed.