### PR TITLE
savemem: call flash algo's init() for flash regions which are not powered on boot

### DIFF
--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -905,7 +905,15 @@ class PyOCDCommander(object):
         count = self.convert_value(args[1])
         filename = args[2]
 
+        region = self.session.target.memory_map.get_region_for_address(addr)
+        flash_init_required =  region is not None and region.is_flash and not region.is_powered_on_boot and region.flash is not None
+        if flash_init_required:
+            region.flash.init(region.flash.Operation.VERIFY)
+
         data = bytearray(self.target.aps[self.selected_ap].read_memory_block8(addr, count))
+
+        if flash_init_required:
+            region.flash.cleanup()
 
         with open(filename, 'wb') as f:
             f.write(data)


### PR DESCRIPTION
Some flash regions may represent external memory which is not mapped to CPU
address space by default. Reading these regions will lead to FAULT response
on the bus.

Use is_powered_on_boot attribute to indicate that initialization of the flash algo
is required to map flash region to CPU address space thus making it accessible.
Initialize flash algo in 'savemem' command, if required.