### PR TITLE
cmsis-pack-manager integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,14 @@ Requirements
 - macOS, Linux, or Windows 7 or newer
 - Microcontroller with an Arm Cortex-M CPU
 - Supported debug probe
-  - [CMSIS-DAP](http://www.keil.com/pack/doc/CMSIS/DAP/html/index.html) v1 (HID) and v2 (WinUSB),
-    such as an on-board debug probe using [DAPLink](https://os.mbed.com/handbook/DAPLink) firmware.
+  - [CMSIS-DAP](http://www.keil.com/pack/doc/CMSIS/DAP/html/index.html) v1 (HID),
+    such as:
+    - An on-board debug probe using [DAPLink](https://os.mbed.com/handbook/DAPLink) firmware.
+    - NXP LPC-LinkII
+  - [CMSIS-DAP](http://www.keil.com/pack/doc/CMSIS/DAP/html/index.html) v2 (WinUSB),
+    such as:
+    - Cypress KitProg3
+    - Keil ULINKplus
   - STLinkV2, either on-board or the standalone version.
 
 
@@ -58,8 +64,8 @@ Status
 
 PyOCD is functionally reliable and fully useable.
 
-The Python API is considered unstable as we are restructuring and cleaning it up prior to releasing
-version 1.0.
+The Python API is considered partially unstable as we are restructuring and cleaning it up prior to
+releasing version 1.0.
 
 
 Documentation
@@ -68,7 +74,7 @@ Documentation
 The pyOCD documentation is located in [the docs directory](docs/).
 
 In addition to user guides, you can generate reference documentation using Doxygen with the
-supplied config file in the `docs/` directory.
+supplied [config file](docs/Doxyfile).
 
 
 Installing
@@ -110,7 +116,7 @@ You have a few options here:
 
 [pyusb](https://github.com/pyusb/pyusb) and its backend library [libusb](https://libusb.info/) are
 dependencies on all supported operating systems. pyusb is a regular Python package and will be
-installed along with pyOCD. However, libusb is binary shared library that does not get installed
+installed along with pyOCD. However, libusb is a binary shared library that does not get installed
 automatically via pip dependency management.
 
 How to install libusb depends on your OS:
@@ -118,7 +124,8 @@ How to install libusb depends on your OS:
 - macOS: use Homebrew: `brew install libusb`
 - Linux: should already be installed.
 - Windows: download libusb from [libusb.info](https://libusb.info/) and place the DLL in your Python
-  installation folder next to python.exe.
+  installation folder next to python.exe. Make sure to use the same 32- or 64-bit architecture as
+  your Python installation.
 
 ### udev rules on Linux
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,17 @@ A command line tool is provided that covers most use cases, or you can make use 
 API to enable low-level target control. A common use for the Python API is to run and control CI
 tests.
 
+Upwards of 70 popular MCUs are supported built-in. In addition, through the use of CMSIS-Packs,
+nearly every Cortex-M device on the market is supported.
+
 The `pyocd` command line tool gives you total control over your device with these subcommands:
 
 - `gdbserver`: GDB remote server allows you to debug using gdb via either
     [GNU MCU Eclipse plug-in](https://gnu-mcu-eclipse.github.io/) or the console.
 - `flash`: Program files of various formats into flash memory.
 - `erase`: Erase part or all of an MCU's flash memory.
+- `pack`: Manage [CMSIS Device Family Packs](http://arm-software.github.io/CMSIS_5/Pack/html/index.html)
+    that provide additional target device support.
 - `commander`: Interactive REPL control and inspection of the MCU.
 - `list`: Show connected devices.
 
@@ -125,6 +130,12 @@ To help with this, example udev rules files are included with pyOCD in the
 [udev](https://github.com/mbedmicro/pyOCD/tree/master/udev) folder. The
 [readme](https://github.com/mbedmicro/pyOCD/tree/master/udev/README.md) in this folder has detailed
 instructions.
+
+### Target support
+
+See the [target support documentation](docs/target_support.md) for information on how to check if
+the MCU(s) you are using have built-in support, and how to install support for additional MCUs via
+CMSIS-Packs.
 
 
 Standalone GDB server

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 
 ### User documentation
 
+- [Target support](target_support.md)
 - [Configuration](configuration.md)
 - [User scripts](user_scripts.md)
 - [Debugging multicore devices](multicore_debug.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@
 - [Configuration](configuration.md)
 - [User scripts](user_scripts.md)
 - [Debugging multicore devices](multicore_debug.md)
-- [Introduction to pyOCD API](python_api.md)
-- [Python API Examples](api_examples.md)
+- [Introduction to the pyOCD Python API](python_api.md)
+- [Python API examples](api_examples.md)
 
 ### Developer documentation
 

--- a/docs/multicore_debug.md
+++ b/docs/multicore_debug.md
@@ -6,9 +6,12 @@ you connect independant gdb instances. This is the most reliable method of debug
 embedded devices using gdb.
 
 `pyocd gdbserver` automatically creates one `GDBServer` instance per core. The first core is given the
-user-specified port number. Additional cores have port numbers incremented from there. To prevent
-reset requests from multiple connected gdb instances causing havoc, the reset monitor commands are
-only honoured for core 0.
+user-specified port number. Additional cores have port numbers incremented from there.
+
+To prevent reset requests from multiple connected gdb instances causing havoc, secondary cores have
+their default reset type set to core-only reset (VECTRESET), which will fall back to an emulated
+reset for non-v7-M architectures. This feature can be disabled by setting the
+`enable_multicore_debug` user option to false.
 
 To debug a multicore device, run `pyocd gdbserver` as usual. This will connect to the device, detect
 the cores, and create the gdb server instances on separate ports. Next, start up two gdb instances

--- a/docs/target_support.md
+++ b/docs/target_support.md
@@ -1,0 +1,87 @@
+Target support
+==============
+
+Through both built-in support and CMSIS-Packs, pyOCD supports nearly every Cortex-M MCU that is
+available on the market.
+
+In addition, because pyOCD dynamically inspects the target's debug infrastructure, basic
+debug functionality is enabled for any target that correctly implement the CoreSight architecture.
+
+
+## Built-in
+
+PyOCD has built-in support for over 70 popular MCUs from various vendors.
+
+Because new targets are addded fairly often, the best way to see the available built-in targets is
+by running `pyocd list --targets`. This command will print a table of supported targets, including
+the target name, vendor, and part number.
+
+
+## CMSIS-Packs
+
+The [CMSIS](http://arm-software.github.io/CMSIS_5/General/html/index.html) specification defines the
+[Device Family Pack](http://arm-software.github.io/CMSIS_5/Pack/html/index.html) (DFP) standard for
+distributing device support files. PyOCD uses DFPs as a means to add support for devices that do
+not have support built in. This allows pyOCD to support nearly every Cortex-M MCU on the market.
+
+The [CMSIS-Pack list](http://www.keil.com/dd2/pack/) web page shows all available packs. You can
+choose to download individual packs.
+
+There are two methods to use a DFP within pyOCD. First, you can let pyOCD fully manage packs for
+you, where all you have to do is tell it the part number(s) for which you wish to install support.
+Alternatively, you can manually download packs and tell pyOCD which pack files to use.
+
+
+### Managed
+
+The `pyocd` tool's `pack` subcommand provides completely automated management of CMSIS-Packs. It
+allows you to install new device support with a single command line invocation.
+
+As part of the pack management, pyOCD keeps an index of all available DFPs. The pack index is a two-
+level hierarchy of pack lists, with the top level pointing to individual vendor indexes. Once the
+index is downloaded, pyOCD can very quickly locate the DFP that provides support for a given
+MCU part number. To learn more about the index, see the [CMSIS-Pack index
+files](http://arm-software.github.io/CMSIS_5/Pack/html/packIndexFile.html) documentation.
+
+The two most useful options for the `pack` subcommand are `--find` and `--install`. The options
+accept a glob-style pattern that is matched against MCU part numbers in the index. If the index
+has not been downloaded yet, that will be done first. `--find` will print out which DFPs provide
+support for matching part numbers. `--install` performs the same match, but downloads and installs
+the matching DFPs. The patterns are matched case-insensitively and as a starts-with comparison.
+
+For instance, if you know the specific part number of the device you are using, say STM32L073, you
+can run this command to install support:
+
+    # pyocd pack --install stm32l073
+
+This will download the index if required, then download the STM32L0xx_DFP pack.
+
+As another example, to find which pack(s) support the NXP MK26F family, you could run:
+
+    $ pyocd pack --find mk26
+
+This will print a table similar to:
+
+     PART            VENDOR  PACK         VERSION
+     MK26FN2M0CAC18  NXP     MK26F18_DFP  11.0.0
+     MK26FN2M0VLQ18  NXP     MK26F18_DFP  11.0.0
+     MK26FN2M0VMD18  NXP     MK26F18_DFP  11.0.0
+     MK26FN2M0VMI18  NXP     MK26F18_DFP  11.0.0
+
+Once a DFP is installed, the `pyocd list --targets` command will show the new targets in its output,
+and you can immediately begin using the target support with the other `pyocd` subcommands.
+
+
+### Manual
+
+If you prefer to manually manage packs, you can download them yourself from the [CMSIS-Pack
+list](http://www.keil.com/dd2/pack/). To use a downloaded pack, just pass the `--pack` option to
+the `pyocd` tool, specifying the pack to the .pack file. You may also set the `pack` user option
+to either a single .pack file path or a list of paths in the [configuration file](configuration.md).
+
+To see the targets provided by a .pack file, run `pyocd list --targets` and pass the approprate
+`--pack` option or use the config file, as above.
+
+_Note:_ .pack files are simply zip archives with a different extension. To examine the contents of
+a pack, change the extension to .zip and extract.
+

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -23,7 +23,10 @@ import argparse
 import json
 import colorama
 import os
+import fnmatch
+import re
 import prettytable
+import cmsis_pack_manager
 
 from . import __version__
 from .core.session import Session
@@ -60,6 +63,7 @@ DEFAULT_CMD_LOG_LEVEL = {
     'gdb':          logging.INFO,
     'commander':    logging.WARNING,
     'cmd':          logging.WARNING,
+    'pack':         logging.INFO,
     }
 
 ## @brief map to convert erase mode to chip_erase option for gdbserver.
@@ -112,6 +116,13 @@ class PyOCDTool(object):
         parser.add_argument('--help-options', action='store_true',
             help="Display available session options.")
         
+        # Define logging related options.
+        loggingOptions = argparse.ArgumentParser(description='logging', add_help=False)
+        loggingOptions.add_argument('-v', '--verbose', action='count', default=0,
+            help="More logging. Can be specified multiple times.")
+        loggingOptions.add_argument('-q', '--quiet', action='count', default=0,
+            help="Less logging. Can be specified multiple times.")
+        
         # Define common options for all subcommands, excluding --verbose and --quiet.
         commonOptionsNoLogging = argparse.ArgumentParser(description='common', add_help=False)
         commonOptionsNoLogging.add_argument('-j', '--dir', metavar="PATH", dest="project_dir", default=os.getcwd(),
@@ -130,11 +141,8 @@ class PyOCDTool(object):
             help="Path to a CMSIS Device Family Pack.")
         
         # Define common options for all subcommands with --verbose and --quiet.
-        commonOptions = argparse.ArgumentParser(description='common', parents=[commonOptionsNoLogging], add_help=False)
-        commonOptions.add_argument('-v', '--verbose', action='count', default=0,
-            help="More logging. Can be specified multiple times.")
-        commonOptions.add_argument('-q', '--quiet', action='count', default=0,
-            help="Less logging. Can be specified multiple times.")
+        commonOptions = argparse.ArgumentParser(description='common',
+            parents=[loggingOptions, commonOptionsNoLogging], add_help=False)
         
         # Common connection related options.
         connectOptions = argparse.ArgumentParser(description='common', add_help=False)
@@ -256,6 +264,26 @@ class PyOCDTool(object):
             help="List all known targets.")
         group.add_argument('-b', '--boards', action='store_true',
             help="List all known boards.")
+        listParser.add_argument('-n', '--name',
+            help="Restrict listing to items matching the given name.")
+
+        # Create *pack* subcommand parser.
+        packParser = subparsers.add_parser('pack', parents=[loggingOptions],
+            help="Manage CMSIS-Packs for target support.")
+        packParser.add_argument("-c", "--clean", action='store_true',
+            help="Erase all stored pack information.")
+        packParser.add_argument("-u", "--update", action='store_true',
+            help="Update the pack index.")
+        packParser.add_argument("-s", "--show", action='store_true',
+            help="Show the list of installed devices and packs.")
+        packParser.add_argument("-f", "--find", dest="find_devices", metavar="GLOB", action='append',
+            help="Look up a device part number in the index using a glob pattern. The pattern is "
+                "suffixed with '*'. Can be specified multiple times.")
+        packParser.add_argument("-i", "--install", dest="install_devices", metavar="GLOB", action='append',
+            help="Download and install pack(s) to support targets matching the glob pattern. "
+                "The pattern is suffixed with '*'. Can be specified multiple times.")
+        packParser.add_argument("-n", "--no-download", action='store_true',
+            help="Just list the pack(s) that would be downloaded, don't actually download anything.")
         
         self._parser = parser
         return parser
@@ -294,7 +322,8 @@ class PyOCDTool(object):
             self._setup_logging()
             
             # Pass any options to DAPAccess.
-            DAPAccess.set_args(self._args.daparg)
+            if hasattr(self._args, 'daparg'):
+                DAPAccess.set_args(self._args.daparg)
 
             # Invoke subcommand.
             self._COMMANDS[self._args.cmd](self)
@@ -546,6 +575,75 @@ class PyOCDTool(object):
 
         # Enter REPL.
         PyOCDCommander(self._args, cmds).run()
+    
+    def do_pack(self):
+        """! @brief Handle 'pack' subcommand."""
+        verbosity = self._args.verbose - self._args.quiet
+        cache = cmsis_pack_manager.Cache(verbosity < 0, False)
+        
+        if self._args.clean:
+            LOG.info("Removing all pack data...")
+            cache.cache_clean()
+        
+        if self._args.update:
+            LOG.info("Updating pack index...")
+            cache.cache_descriptors()
+        
+        if self._args.show:
+            devices = pack_target.get_supported_targets()
+            pt = self._get_pretty_table(["Part", "Vendor", "Pack", "Version"])
+            for info in devices:
+                ref, = cache.packs_for_devices([info])
+                pt.add_row([
+                            info['name'],
+                            ref.vendor,
+                            ref.pack,
+                            ref.version,
+                            ])
+            print(pt)
+
+        if self._args.find_devices or self._args.install_devices:
+            if not cache.index:
+                LOG.info("No pack index present, downloading now...")
+                cache.cache_descriptors()
+            
+            patterns = self._args.find_devices or self._args.install_devices
+            
+            # Find matching part numbers.
+            matches = set()
+            for pattern in patterns:
+                # Using fnmatch.fnmatch() was failing to match correctly.
+                pat = re.compile(fnmatch.translate(pattern + "*"), re.IGNORECASE)
+                results = {name for name in cache.index.keys() if pat.match(name)}
+                matches.update(results)
+            
+            if not matches:
+                LOG.warning("No matching devices. Please make sure the pack index is up to date.")
+                return
+            
+            if self._args.find_devices:
+                pt = self._get_pretty_table(["Part", "Vendor", "Pack", "Version"])
+                for name in sorted(matches):
+                    info = cache.index[name]
+                    ref, = cache.packs_for_devices([info])
+                    pt.add_row([
+                                info['name'],
+                                ref.vendor,
+                                ref.pack,
+                                ref.version,
+                                ])
+                print(pt)
+            elif self._args.install_devices:
+                devices = [cache.index[dev] for dev in matches]
+                packs = cache.packs_for_devices(devices)
+                if not self._args.no_download:
+                    print("Downloading packs (press Control-C to cancel):")
+                else:
+                    print("Would download packs:")
+                for pack in packs:
+                    print("    " + str(pack))
+                if not self._args.no_download:
+                    cache.download_pack_list(packs)
 
     ## @brief Table of handler methods for subcommands.
     _COMMANDS = {
@@ -557,6 +655,7 @@ class PyOCDTool(object):
         'gdb':          do_gdbserver,
         'commander':    do_commander,
         'cmd':          do_commander,
+        'pack':         do_pack,
         }
 
 def main():

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -41,7 +41,11 @@ class Board(GraphNode):
         if ('pack' in session.options) and (session.options['pack'] is not None):
             pack_target.populate_targets_from_pack(session.options['pack'])
 
-        # Create Target and Flash instances.
+        # Create targets from the cmsis-pack-manager cache.
+        if self._target_type not in TARGET:
+            pack_target.populate_target_from_cache(target)
+        
+        # Create Target instance.
         try:
             log.info("Target type is %s", self._target_type)
             self.target = TARGET[self._target_type](session)

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -104,24 +104,24 @@ class Session(object):
         else:
             self._project_dir = os.path.abspath(os.path.expanduser(self._options['project_dir']))
         LOG.debug("Project directory: %s", self.project_dir)
-        
-        # Bail early if we weren't provided a probe.
-        if probe is None:
-            self._board = None
-            return
             
         # Apply common configuration settings from the config file.
         config = self._get_config()
         probesConfig = config.pop('probes', None)
         self._options.update(config)
 
-        # Pick up any config file options for this probe.
-        if probesConfig is not None:
+        # Pick up any config file options for this board.
+        if (probe is not None) and (probesConfig is not None):
             for uid, settings in probesConfig.items():
                 if str(uid).lower() in probe.unique_id.lower():
                     LOG.info("Using config settings for board %s" % (probe.unique_id))
                     self._options.update(settings)
         
+        # Bail early if we weren't provided a probe.
+        if probe is None:
+            self._board = None
+            return
+            
         # Ask the probe if it has an associated board, and if not then we create a generic one.
         self._board = probe.create_associated_board(self) \
                         or Board(self, self._options.get('target_override', None))

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -382,7 +382,7 @@ class CmsisPackDevice(object):
                 if i + 1 >= len(packAlgo.sector_sizes):
                     nextStart = region.length
                 else:
-                    nextStart = packAlgo.sector_sizes[i + 1]
+                    nextStart, _ = packAlgo.sector_sizes[i + 1]
                 
                 length = nextStart - start
                 start += region.start

--- a/pyocd/tools/lists.py
+++ b/pyocd/tools/lists.py
@@ -28,6 +28,11 @@ from ..target.pack import pack_target
 class ListGenerator(object):
     @staticmethod
     def list_probes():
+        """! @brief Generate dictionary with info about the connected debug probes.
+        
+        Output version history:
+        - 1.0, initial version
+        """
         try:
             all_mbeds = ConnectHelper.get_sessions_for_all_connected_probes(blocking=False)
             status = 0
@@ -65,6 +70,11 @@ class ListGenerator(object):
 
     @staticmethod
     def list_boards():
+        """! @brief Generate dictionary with info about supported boards.
+        
+        Output version history:
+        - 1.0, initial version
+        """
         boards = []
         obj = {
             'pyocd_version' : __version__,
@@ -85,18 +95,21 @@ class ListGenerator(object):
         return obj
 
     @staticmethod
-    def list_targets(pack):
+    def list_targets():
+        """! @brief Generate dictionary with info about all supported targets.
+        
+        Output version history:
+        - 1.0, initial version
+        - 1.1, added part_families
+        - 1.2, added source
+        """
         targets = []
         obj = {
             'pyocd_version' : __version__,
-            'version' : { 'major' : 1, 'minor' : 1 },
+            'version' : { 'major' : 1, 'minor' : 2 },
             'status' : 0,
             'targets' : targets
             }
-
-        # Load CMSIS-Pack.
-        if pack is not None:
-            pack_target.populate_targets_from_pack(pack)
 
         for name in TARGET.keys():
             s = Session(None) # Create empty session
@@ -106,6 +119,7 @@ class ListGenerator(object):
                 'vendor' : t.vendor,
                 'part_families' : t.part_families,
                 'part_number' : t.part_number,
+                'source': 'pack' if hasattr(t, '_pack_device') else 'builtin',
                 }
             if t._svd_location is not None and IS_CMSIS_SVD_AVAILABLE:
                 if t._svd_location.is_local:

--- a/pyocd/tools/lists.py
+++ b/pyocd/tools/lists.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018 Arm Limited
+# Copyright (c) 2018-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,5 +133,23 @@ class ListGenerator(object):
                 if isinstance(svdPath, six.string_types) and os.path.exists(svdPath):
                     d['svd_path'] = svdPath
             targets.append(d)
+        
+        # Add targets from cmsis-pack-manager cache.
+        for dev in pack_target.get_supported_targets():
+            try:
+                if 'vendor' in dev:
+                    vendor = dev['vendor'].split(':')[0]
+                else:
+                    vendor = dev['from_pack']['vendor']
+            
+                targets.append({
+                    'name' : dev['name'].lower(),
+                    'part_families' : [],
+                    'part_number' : dev['name'],
+                    'vendor' : vendor,
+                    'source' : 'pack',
+                    })
+            except KeyError:
+                pass
 
         return obj

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     # Allow installation on 2.7.9+, and 3.4+ even though we officially only support 3.6+.
     python_requires=">=2.7.9, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires = [
+        'cmsis-pack-manager>=0.2.6',
         'colorama',
         'enum34>=1.0,<2.0;python_version<"3.4"',
         'hidapi;platform_system=="Darwin"',

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'hidapi;platform_system=="Darwin"',
         'intelhex>=2.0,<3.0',
         'intervaltree>=3.0.2,<4.0',
+        'prettytable',
         'pyelftools',
         'pyusb>=1.0.0b2,<2.0',
         'pywinusb>=0.4.0;platform_system=="Windows"',

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,18 @@
-"""
- mbed CMSIS-DAP debugger
- Copyright (c) 2012-2019 ARM Limited
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# pyOCD debugger
+# Copyright (c) 2012-2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys
 from setuptools import setup, find_packages
@@ -48,16 +47,16 @@ setup(
     # Allow installation on 2.7.9+, and 3.4+ even though we officially only support 3.6+.
     python_requires=">=2.7.9, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires = [
-        'intelhex>=2.0,<3.0',
-        'six>=1.0,<2.0',
-        'enum34>=1.0,<2.0;python_version<"3.4"',
-        'intervaltree>=3.0.2,<4.0',
         'colorama',
+        'enum34>=1.0,<2.0;python_version<"3.4"',
+        'hidapi;platform_system=="Darwin"',
+        'intelhex>=2.0,<3.0',
+        'intervaltree>=3.0.2,<4.0',
         'pyelftools',
         'pyusb>=1.0.0b2,<2.0',
         'pywinusb>=0.4.0;platform_system=="Windows"',
-        'hidapi;platform_system=="Darwin"',
         'pyyaml>=5.1,<6.0',
+        'six>=1.0,<2.0',
         ],
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -72,7 +71,7 @@ setup(
         "Topic :: Software Development :: Embedded Systems",
     ],
     extras_require={
-        'dissassembler': ['capstone']
+        'dissassembler': ['capstone'],
     },
     entry_points={
         'console_scripts': [

--- a/test/gdb_server_json_test.py
+++ b/test/gdb_server_json_test.py
@@ -198,7 +198,7 @@ def gdb_server_json_test(board_id, testing_standalone=False):
     out = subprocess.check_output(['pyocd', 'json', '--targets'])
     data = json.loads(out)
     test_count += 2
-    if validate_basic_keys(data, minor_version=1):
+    if validate_basic_keys(data, minor_version=2):
         test_pass_count += 1
     if validate_targets(data):
         test_pass_count += 1


### PR DESCRIPTION
The cmsis-pack-manager project is made use of by pyOCD to make it substantially easier for users to manage CMSIS-Packs.

A new `pack` subcommand for the `pyocd` tool has been added. This subcommand can be used to refresh the global pack index, list installed packs, find device part numbers in available packs, and add target support by downloading select packs.

All a user needs to do now to add support for a new target is run a command like this:

```
pyocd pack --install da1458
```

This will first download the global pack index if it is missing, concurrently downloading all vendor indexes. Then it will install all packs that provide device part numbers matching the glob pattern 'da1458*'.

Complete usage of the `pack` subcommand:

```
usage: pyocd pack [-h] [-v] [-q] [-c] [-u] [-s] [-f GLOB] [-i GLOB] [-n]

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         More logging. Can be specified multiple times.
  -q, --quiet           Less logging. Can be specified multiple times.
  -c, --clean           Erase all stored pack information.
  -u, --update          Update the pack index.
  -s, --show            Show the list of installed devices and packs.
  -f GLOB, --find GLOB  Look up a device part number in the index using a glob
                        pattern. The pattern is suffixed with '*'. Can be
                        specified multiple times.
  -i GLOB, --install GLOB
                        Download and install pack(s) to support targets
                        matching the glob pattern. The pattern is suffixed
                        with '*'. Can be specified multiple times.
  -n, --no-download     Just list the pack(s) that would be downloaded, don't
                        actually download anything.
```

When the target type set by the user doesn't match an builtin target or one of the packs explicitly listed with the `--pack` argument or `pack` user option, pyOCD will check the cmsis-pack-manager installed packs.

`pyocd list --targets` and `pyocd json --targets` will include any targets supported via installed cmsis-pack-manager packs.

Closes #563 
