### PR TITLE
Debug probe error handling in match classes

### DIFF
--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -293,7 +293,7 @@ class HasCmsisDapv2Interface(object):
                 LOG.debug("Error accessing USB device (VID=%04x PID=%04x): %s",
                     dev.idVendor, dev.idProduct, error)
             return False
-        except (IndexError, NotImplementedError) as error:
+        except (IndexError, NotImplementedError, ValueError) as error:
             LOG.debug("Error accessing USB device (VID=%04x PID=%04x): %s", dev.idVendor, dev.idProduct, error)
             return False
 

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -268,8 +268,15 @@ class HasCmsisDapv2Interface(object):
         
         try:
             def match_cmsis_dap_interface_name(desc):
-                interface_name = usb.util.get_string(desc.device, desc.iInterface)
-                return (interface_name is not None) and ("CMSIS-DAP" in interface_name)
+                try:
+                    interface_name = usb.util.get_string(desc.device, desc.iInterface)
+                    return (interface_name is not None) and ("CMSIS-DAP" in interface_name)
+                except UnicodeDecodeError:
+                    # This exception can be raised if the device has a corrupted interface name.
+                    # Certain versions of STLinkV2 are known to have this problem. If we can't
+                    # read the interface name, there's no way to tell if it's a CMSIS-DAPv2
+                    # interface.
+                    return False
 
             config = dev.get_active_configuration()
             cmsis_dap_interface = usb.util.find_descriptor(config, custom_match=match_cmsis_dap_interface_name)

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -85,7 +85,7 @@ class STLinkUSBInterface(object):
                 log.debug("Error accessing USB device (VID=%04x PID=%04x): %s",
                     dev.idVendor, dev.idProduct, error)
             return False
-        except (IndexError, NotImplementedError) as error:
+        except (IndexError, NotImplementedError, ValueError) as error:
             log.debug("Error accessing USB device (VID=%04x PID=%04x): %s", dev.idVendor, dev.idProduct, error)
             return False
 


### PR DESCRIPTION
These changes fix two issues by catching exceptions in the USB match classes used by CMSIS-DAPv2 and STLink debug probes.

1. `UnicodeDecodeError` caused by certain STLink firmware versions having an invalid interface name. See #613.
2. `ValueError` raised when certain non-debug probe devices that apparently don't have a langid are attached. See #614.