### PR TITLE
Integrate SVD support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include pytest.ini
 include Doxyfile
 include dev-requirements.txt
+include pyocd/debug/svd/*.zip
 recursive-include docs *
 recursive-include udev *
 recursive-include binaries *

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -19,7 +19,7 @@ from .memory_map import MemoryType
 from . import exceptions
 from ..flash.loader import FlashEraser
 from ..coresight import (dap, cortex_m, cortex_m_v8m, rom_table)
-from ..debug.svd import (SVDFile, SVDLoader)
+from ..debug.svd.loader import (SVDFile, SVDLoader)
 from ..debug.context import DebugContext
 from ..debug.cache import CachingDebugContext
 from ..debug.elf.elf import ELFBinaryFile

--- a/pyocd/debug/svd/__init__.py
+++ b/pyocd/debug/svd/__init__.py
@@ -1,0 +1,15 @@
+# pyOCD debugger
+# Copyright (c) 2015-2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/pyocd/debug/svd/loader.py
+++ b/pyocd/debug/svd/loader.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2015 Arm Limited
+# Copyright (c) 2015-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,28 +16,17 @@
 
 import threading
 import logging
-# Make cmsis_svd optional.
-try:
-    from cmsis_svd.parser import SVDParser
-    IS_CMSIS_SVD_AVAILABLE = True
-except ImportError:
-    IS_CMSIS_SVD_AVAILABLE = False
+
+from .parser import SVDParser
 
 class SVDFile(object):
-    def __init__(self, filename=None, vendor=None, is_local=False):
+    def __init__(self, filename=None, vendor=None):
         self.filename = filename
         self.vendor = vendor
-        self.is_local = is_local
         self.device = None
 
     def load(self):
-        if not IS_CMSIS_SVD_AVAILABLE:
-            return
-
-        if self.is_local:
-            self.device = SVDParser.for_xml_file(self.filename).get_device()
-        else:
-            self.device = SVDParser.for_packaged_svd(self.vendor, self.filename).get_device()
+        self.device = SVDParser.for_xml_file(self.filename).get_device()
 
 ## @brief Thread to read an SVD file in the background.
 class SVDLoader(threading.Thread):

--- a/pyocd/debug/svd/loader.py
+++ b/pyocd/debug/svd/loader.py
@@ -16,13 +16,23 @@
 
 import threading
 import logging
+import pkg_resources
+from zipfile import ZipFile
 
 from .parser import SVDParser
 
+## Path within the pyocd package to the generated zip containing builting SVD files.
+BUILTIN_SVD_DATA_PATH = "debug/svd/svd_data.zip"
+
 class SVDFile(object):
-    def __init__(self, filename=None, vendor=None):
+    @classmethod
+    def from_builtin(cls, svd_name):
+        zip_stream = pkg_resources.resource_stream("pyocd", BUILTIN_SVD_DATA_PATH)
+        zip = ZipFile(zip_stream, 'r')
+        return SVDFile(zip.open(svd_name))
+    
+    def __init__(self, filename=None):
         self.filename = filename
-        self.vendor = vendor
         self.device = None
 
     def load(self):

--- a/pyocd/debug/svd/model.py
+++ b/pyocd/debug/svd/model.py
@@ -1,0 +1,570 @@
+#
+# Copyright 2015 Paul Osborne <osbpau@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+import six
+
+# Sentinel value for lookup where None might be a valid value
+NOT_PRESENT = object()
+TO_DICT_SKIP_KEYS = {"_register_arrays", "parent"}
+REGISTER_PROPERTY_KEYS = {"size", "access", "protection", "reset_value", "reset_mask"}
+LIST_TYPE_KEYS = {"register_arrays", "registers", "fields", "peripherals", "interrupts"}
+
+
+def _check_type(value, expected_type):
+    """Perform type checking on the provided value
+
+    This is a helper that will raise ``TypeError`` if the provided value is
+    not an instance of the provided type.  This method should be used sparingly
+    but can be good for preventing problems earlier when you want to restrict
+    duck typing to make the types of fields more obvious.
+
+    If the value passed the type check it will be returned from the call.
+    """
+    if not isinstance(value, expected_type):
+        raise TypeError("Value {value!r} has unexpected type {actual_type!r}, expected {expected_type!r}".format(
+            value=value,
+            expected_type=expected_type,
+            actual_type=type(value),
+        ))
+    return value
+
+
+def _none_as_empty(v):
+    if v is not None:
+        for e in v:
+            yield e
+
+
+class SVDJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, SVDElement):
+            eldict = {}
+            for k, v in six.iteritems(obj.__dict__):
+                if k in TO_DICT_SKIP_KEYS:
+                    continue
+                if k.startswith("_"):
+                    pubkey = k[1:]
+                    eldict[pubkey] = getattr(obj, pubkey)
+                else:
+                    eldict[k] = v
+            return eldict
+        else:
+            return json.JSONEncoder.default(self, obj)
+
+
+class SVDElement(object):
+    """Base class for all SVD Elements"""
+
+    def __init__(self):
+        self.parent = None
+
+    def _lookup_possibly_derived_attribute(self, attr):
+        derived_from = self.get_derived_from()
+
+        # see if there is an attribute with the same name and leading underscore
+        try:
+            value_self = object.__getattribute__(self, "_{}".format(attr))
+        except AttributeError:
+            value_self = NOT_PRESENT
+
+        # if not, then this is an attribute error
+        if value_self is NOT_PRESENT:
+            raise AttributeError("Requested missing key")
+
+        # if there is a non-None value, that is what we want to use
+        elif value_self is not None:
+            return value_self  # if there is a non-None value, use it
+
+        # if there is a derivedFrom, check there first
+        elif derived_from is not None:
+            derived_value = getattr(derived_from, "_{}".format(attr), NOT_PRESENT)
+            if derived_value is not NOT_PRESENT:
+                return derived_value
+
+        # for some attributes, try to grab from parent
+        if attr in REGISTER_PROPERTY_KEYS:
+            value = getattr(self.parent, attr, value_self)
+        else:
+            value = value_self
+
+        # if value is None and this is a list type, transform to empty list
+        if value is None and attr in LIST_TYPE_KEYS:
+            value = []
+
+        return value
+
+    def get_derived_from(self):
+        pass  # override in children
+
+    def to_dict(self):
+        # This is a little convoluted but it works and ensures a
+        # json-compatible dictionary representation (at the cost of
+        # some computational overhead)
+        encoder = SVDJSONEncoder()
+        return json.loads(encoder.encode(self))
+
+
+class SVDEnumeratedValue(SVDElement):
+    def __init__(self, name, description, value, is_default):
+        SVDElement.__init__(self)
+        self.name = name
+        self.description = description
+        self.value = value
+        self.is_default = is_default
+
+
+class SVDField(SVDElement):
+    def __init__(self, name, derived_from, description, bit_offset, bit_width, access, enumerated_values, modified_write_values, read_action):
+        SVDElement.__init__(self)
+        self.name = name
+        self.derived_from = derived_from
+        self.description = description
+        self.bit_offset = bit_offset
+        self.bit_width = bit_width
+        self.access = access
+        self.enumerated_values = enumerated_values
+        self.modified_write_values = modified_write_values
+        self.read_action = read_action
+
+    def __getattr__(self, attr):
+        return self._lookup_possibly_derived_attribute(attr)
+
+    def get_derived_from(self):
+        # TODO: add support for dot notation derivedFrom
+        if self.derived_from is None:
+            return None
+
+        for field in self.parent.fields:
+            if field.name == self.derived_from:
+                return field
+
+        raise KeyError("Unable to find derived_from: %r" % self.derived_from)
+
+    @property
+    def is_enumerated_type(self):
+        """Return True if the field is an enumerated type"""
+        return self.enumerated_values is not None
+
+    @property
+    def is_reserved(self):
+        return self.name.lower() == "reserved"
+
+
+class SVDRegisterArray(SVDElement):
+    """Represent a register array in the tree"""
+
+    def __init__(self, name, derived_from, description, address_offset, size,
+                 access, protection, reset_value, reset_mask, fields,
+                 display_name, alternate_group, modified_write_values,
+                 read_action, dim, dim_indices, dim_increment):
+        SVDElement.__init__(self)
+
+        # When deriving a register, it is mandatory to specify at least the name, the description,
+        # and the addressOffset
+        self.derived_from = derived_from
+        self.name = name
+        self.description = description
+        self.address_offset = address_offset
+        self.dim = dim
+        self.dim_indices = dim_indices
+        self.dim_increment = dim_increment
+
+        self._read_action = read_action
+        self._modified_write_values = modified_write_values
+        self._display_name = display_name
+        self._alternate_group = alternate_group
+        self._size = size
+        self._access = access
+        self._protection = protection
+        self._reset_value = reset_value
+        self._reset_mask = reset_mask
+        self._fields = fields
+
+        # make parent association
+        for field in self._fields:
+            field.parent = self
+
+    def __getattr__(self, attr):
+        return self._lookup_possibly_derived_attribute(attr)
+
+    @property
+    def registers(self):
+        for i in six.moves.range(self.dim):
+            reg = SVDRegister(
+                name=self.name % self.dim_indices[i],
+                fields=self._fields,
+                derived_from=self.derived_from,
+                description=self.description,
+                address_offset=self.address_offset + self.dim_increment * i,
+                size=self._size,
+                access=self._access,
+                protection=self._protection,
+                reset_value=self._reset_value,
+                reset_mask=self._reset_mask,
+                display_name=self._display_name,
+                alternate_group=self._alternate_group,
+                modified_write_values=self._modified_write_values,
+                read_action=self._read_action,
+            )
+            reg.parent = self.parent
+            yield reg
+
+    def get_derived_from(self):
+        # TODO: add support for dot notation derivedFrom
+        if self.derived_from is None:
+            return None
+
+        for register in self.parent.registers:
+            if register.name == self.derived_from:
+                return register
+
+        raise KeyError("Unable to find derived_from: %r" % self.derived_from)
+
+    def is_reserved(self):
+        return 'reserved' in self.name.lower()
+
+
+class SVDRegister(SVDElement):
+    def __init__(self, name, derived_from, description, address_offset, size, access, protection, reset_value, reset_mask,
+                 fields, display_name, alternate_group, modified_write_values, read_action):
+        SVDElement.__init__(self)
+
+        # When deriving a register, it is mandatory to specify at least the name, the description,
+        # and the addressOffset
+        self.derived_from = derived_from
+        self.name = name
+        self.description = description
+        self.address_offset = address_offset
+
+        self._read_action = read_action
+        self._modified_write_values = modified_write_values
+        self._display_name = display_name
+        self._alternate_group = alternate_group
+        self._size = size
+        self._access = access
+        self._protection = protection
+        self._reset_value = reset_value
+        self._reset_mask = reset_mask
+        self._fields = fields
+
+        # make parent association
+        for field in self._fields:
+            field.parent = self
+
+    def __getattr__(self, attr):
+        return self._lookup_possibly_derived_attribute(attr)
+
+    def get_derived_from(self):
+        # TODO: add support for dot notation derivedFrom
+        if self.derived_from is None:
+            return None
+
+        for register in self.parent.registers:
+            if register.name == self.derived_from:
+                return register
+
+        raise KeyError("Unable to find derived_from: %r" % self.derived_from)
+
+    def is_reserved(self):
+        return 'reserved' in self.name.lower()
+
+
+class SVDRegisterCluster(SVDElement):
+    """Represent a register cluster in the tree"""
+
+    def __init__(self, name, derived_from, description, address_offset, size,
+                 alternate_cluster, header_struct_name,
+                 access, protection, reset_value, reset_mask, register,
+                 cluster):
+        SVDElement.__init__(self)
+
+        # When deriving a register, it is mandatory to specify at least the name, the description,
+        # and the addressOffset
+        self.derived_from = derived_from
+        self.name = name
+        self.description = description
+        self.address_offset = address_offset
+
+        self._alternate_cluster = alternate_cluster
+        self._header_struct_name = header_struct_name
+        self._size = size
+        self._access = access
+        self._protection = protection
+        self._reset_value = reset_value
+        self._reset_mask = reset_mask
+        self._register = register
+        self._cluster = cluster
+
+        # make parent association
+        for cluster in self._cluster:
+            cluster.parent = self
+
+    def __getattr__(self, attr):
+        return self._lookup_possibly_derived_attribute(attr)
+
+    def updated_register(self, reg, clu):
+        new_reg = SVDRegister(
+            name="{}_{}".format(clu.name, reg.name),
+            fields=reg.fields,
+            derived_from=reg.derived_from,
+            description=reg.description,
+            address_offset=clu.address_offset + reg.address_offset,
+            size=reg.size,
+            access=reg.access,
+            protection=reg.protection,
+            reset_value=reg.reset_value,
+            reset_mask=reg.reset_mask,
+            display_name=reg.display_name,
+            alternate_group=reg.alternate_group,
+            modified_write_values=reg.modified_write_values,
+            read_action=reg.read_action,
+        )
+        new_reg.parent = self
+        return new_reg
+
+    @property
+    def registers(self):
+        for reg in self._register:
+            yield self.updated_register(reg, self)
+        for cluster in self._cluster:
+            for reg in cluster.registers:
+                yield self.updated_register(reg, self)
+
+    def get_derived_from(self):
+        # TODO: add support for dot notation derivedFrom
+        if self.derived_from is None:
+            return None
+
+        for register in self.parent.registers:
+            if register.name == self.derived_from:
+                return register
+
+        raise KeyError("Unable to find derived_from: %r" % self.derived_from)
+
+    def is_reserved(self):
+        return 'reserved' in self.name.lower()
+
+
+class SVDRegisterClusterArray(SVDElement):
+    """Represent a register cluster in the tree"""
+
+    def __init__(self, name, derived_from, description, address_offset, size,
+                 alternate_cluster, header_struct_name,
+                 dim, dim_indices, dim_increment,
+                 access, protection, reset_value, reset_mask, register,
+                 cluster):
+        SVDElement.__init__(self)
+
+        # When deriving a register, it is mandatory to specify at least the name, the description,
+        # and the addressOffset
+        self.derived_from = derived_from
+        self.name = name
+        self.description = description
+        self.address_offset = address_offset
+        self.dim = dim
+        self.dim_indices = dim_indices
+        self.dim_increment = dim_increment
+
+        self._alternate_cluster = alternate_cluster
+        self._header_struct_name = header_struct_name
+        self._size = size
+        self._access = access
+        self._protection = protection
+        self._reset_value = reset_value
+        self._reset_mask = reset_mask
+        self._register = register
+        self._cluster = cluster
+
+        # make parent association
+        for register in self._register:
+            register.parent = self
+        for cluster in self._cluster:
+            cluster.parent = self
+
+    def __getattr__(self, attr):
+        return self._lookup_possibly_derived_attribute(attr)
+
+    def updated_register(self, reg, clu, i):
+        new_reg = SVDRegister(
+            name="{}_{}".format(clu.name % i, reg.name),
+            fields=reg.fields,
+            derived_from=reg.derived_from,
+            description=reg.description,
+            address_offset=clu.address_offset + reg.address_offset + i*clu.dim_increment,
+            size=reg.size,
+            access=reg.access,
+            protection=reg.protection,
+            reset_value=reg.reset_value,
+            reset_mask=reg.reset_mask,
+            display_name=reg.display_name,
+            alternate_group=reg.alternate_group,
+            modified_write_values=reg.modified_write_values,
+            read_action=reg.read_action,
+        )
+        new_reg.parent = self
+        return new_reg
+
+    @property
+    def registers(self):
+        for i in six.moves.range(self.dim):
+            for reg in self._register:
+                yield self.updated_register(reg, self, i)
+            for cluster in self._cluster:
+                for reg in cluster.registers:
+                    yield self.updated_register(reg, cluster, i)
+
+    def get_derived_from(self):
+        # TODO: add support for dot notation derivedFrom
+        if self.derived_from is None:
+            return None
+
+        for register in self.parent.registers:
+            if register.name == self.derived_from:
+                return register
+
+        raise KeyError("Unable to find derived_from: %r" % self.derived_from)
+
+    def is_reserved(self):
+        return 'reserved' in self.name.lower()
+
+
+class SVDAddressBlock(SVDElement):
+    def __init__(self, offset, size, usage):
+        SVDElement.__init__(self)
+        self.offset = offset
+        self.size = size
+        self.usage = usage
+
+
+class SVDInterrupt(SVDElement):
+    def __init__(self, name, value, description):
+        SVDElement.__init__(self)
+        self.name = name
+        self.value = _check_type(value, six.integer_types)
+        self.description = description
+
+
+class SVDPeripheral(SVDElement):
+    def __init__(self, name, version, derived_from, description,
+                 prepend_to_name, base_address, address_block,
+                 interrupts, registers, register_arrays, size, access,
+                 protection, reset_value, reset_mask,
+                 group_name, append_to_name, disable_condition,
+                 clusters):
+        SVDElement.__init__(self)
+
+        # items with underscore are potentially derived
+        self.name = name
+        self._version = version
+        self._derived_from = derived_from
+        self._description = description
+        self._prepend_to_name = prepend_to_name
+        self._base_address = base_address
+        self._address_block = address_block
+        self._interrupts = interrupts
+        self._registers = registers
+        self._register_arrays = register_arrays
+        self._size = size  # Defines the default bit-width of any register contained in the device (implicit inheritance).
+        self._access = access  # Defines the default access rights for all registers.
+        self._protection = protection  # Defines extended access protection for all registers.
+        self._reset_value = reset_value  # Defines the default value for all registers at RESET.
+        self._reset_mask = reset_mask  # Identifies which register bits have a defined reset value.
+        self._group_name = group_name
+        self._append_to_name = append_to_name
+        self._disable_condition = disable_condition
+        self._clusters = clusters
+
+        # make parent association for complex node types
+        for i in _none_as_empty(self._interrupts):
+            i.parent = self
+        for r in _none_as_empty(self._registers):
+            r.parent = self
+
+    def __getattr__(self, attr):
+        return self._lookup_possibly_derived_attribute(attr)
+
+    @property
+    def registers(self):
+        regs = []
+        for reg in self._lookup_possibly_derived_attribute('registers'):
+            regs.append(reg)
+        for arr in self._lookup_possibly_derived_attribute('register_arrays'):
+            regs.extend(arr.registers)
+        for cluster in self._lookup_possibly_derived_attribute('clusters'):
+            regs.extend(cluster.registers)
+        return regs
+
+    def get_derived_from(self):
+        if self._derived_from is None:
+            return None
+
+        # find the peripheral with this name in the tree
+        try:
+            return [p for p in self.parent.peripherals if p.name == self._derived_from][0]
+        except IndexError:
+            return None
+
+
+class SVDCpu(SVDElement):
+    def __init__(self, name, revision, endian, mpu_present, fpu_present, fpu_dp, icache_present,
+                 dcache_present, itcm_present, dtcm_present, vtor_present, nvic_prio_bits,
+                 vendor_systick_config, device_num_interrupts, sau_num_regions, sau_regions_config):
+        SVDElement.__init__(self)
+
+        self.name = name
+        self.revision = revision
+        self.endian = endian
+        self.mpu_present = mpu_present
+        self.fpu_present = fpu_present
+        self.fpu_dp = fpu_dp
+        self.icache_present = icache_present,
+        self.dcache_present = dcache_present,
+        self.itcm_present = itcm_present,
+        self.dtcm_present = dtcm_present,
+        self.vtor_present = vtor_present
+        self.nvic_prio_bits = nvic_prio_bits
+        self.vendor_systick_config = vendor_systick_config
+        self.device_num_interrupts = device_num_interrupts
+        self.sau_num_regions = sau_num_regions
+        self.sau_regions_config = sau_regions_config
+
+
+class SVDDevice(SVDElement):
+    def __init__(self, vendor, vendor_id, name, version, description, cpu, address_unit_bits, width,
+                 peripherals, size, access, protection, reset_value, reset_mask):
+        SVDElement.__init__(self)
+
+        self.vendor = vendor
+        self.vendor_id = vendor_id
+        self.name = name
+        self.version = version
+        self.description = description
+        self.cpu = cpu
+        self.address_unit_bits = _check_type(address_unit_bits, six.integer_types)
+        self.width = _check_type(width, six.integer_types)
+        self.peripherals = peripherals
+        self.size = size  # Defines the default bit-width of any register contained in the device (implicit inheritance).
+        self.access = access  # Defines the default access rights for all registers.
+        self.protection = protection  # Defines extended access protection for all registers.
+        self.reset_value = reset_value  # Defines the default value for all registers at RESET.
+        self.reset_mask = reset_mask  # Identifies which register bits have a defined reset value.
+
+        # set up parent relationship
+        if self.cpu:
+            self.cpu.parent = self
+
+        for p in _none_as_empty(self.peripherals):
+            p.parent = self

--- a/pyocd/debug/svd/parser.py
+++ b/pyocd/debug/svd/parser.py
@@ -1,0 +1,416 @@
+#
+# Copyright 2015 Paul Osborne <osbpau@gmail.com>
+# Copyright (c) 2019 Arm Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from xml.etree import ElementTree as ET
+
+import six
+
+from .model import SVDDevice
+from .model import SVDPeripheral
+from .model import SVDInterrupt
+from .model import SVDAddressBlock
+from .model import SVDRegister, SVDRegisterArray
+from .model import SVDRegisterCluster, SVDRegisterClusterArray
+from .model import SVDField
+from .model import SVDEnumeratedValue
+from .model import SVDCpu
+import re
+
+
+def _get_text(node, tag, default=None):
+    """Get the text for the provided tag from the provided node"""
+    try:
+        return node.find(tag).text
+    except AttributeError:
+        return default
+
+
+def _get_int(node, tag, default=None):
+    text_value = _get_text(node, tag, default)
+    try:
+        if text_value != default:
+            text_value = text_value.strip().lower()
+            if text_value.startswith('0x'):
+                return int(text_value[2:], 16)  # hexadecimal
+            elif text_value.startswith('#'):
+                # TODO(posborne): Deal with strange #1xx case better
+                #
+                # Freescale will sometimes provide values that look like this:
+                #   #1xx
+                # In this case, there are a number of values which all mean the
+                # same thing as the field is a "don't care".  For now, we just
+                # replace those bits with zeros.
+                text_value = text_value.replace('x', '0')[1:]
+                is_bin = all(x in '01' for x in text_value)
+                return int(text_value, 2) if is_bin else int(text_value)  # binary
+            elif text_value.startswith('true'):
+                return 1
+            elif text_value.startswith('false'):
+                return 0
+            else:
+                return int(text_value)  # decimal
+    except ValueError:
+        return default
+    return default
+
+
+class SVDParser(object):
+    """The SVDParser is responsible for mapping the SVD XML to Python Objects"""
+
+    @classmethod
+    def for_xml_file(cls, path, remove_reserved=False):
+        return cls(ET.parse(path), remove_reserved)
+
+    def __init__(self, tree, remove_reserved=False):
+        self.remove_reserved = remove_reserved
+        self._tree = tree
+        self._root = self._tree.getroot()
+
+    def _parse_enumerated_value(self, enumerated_value_node):
+        return SVDEnumeratedValue(
+            name=_get_text(enumerated_value_node, 'name'),
+            description=_get_text(enumerated_value_node, 'description'),
+            value=_get_int(enumerated_value_node, 'value'),
+            is_default=_get_int(enumerated_value_node, 'isDefault')
+        )
+
+    def _parse_field(self, field_node):
+        enumerated_values = []
+        for enumerated_value_node in field_node.findall("./enumeratedValues/enumeratedValue"):
+            enumerated_values.append(self._parse_enumerated_value(enumerated_value_node))
+
+        modified_write_values=_get_text(field_node, 'modifiedWriteValues')
+        read_action=_get_text(field_node, 'readAction')
+        bit_range = _get_text(field_node, 'bitRange')
+        bit_offset = _get_int(field_node, 'bitOffset')
+        bit_width = _get_int(field_node, 'bitWidth')
+        msb = _get_int(field_node, 'msb')
+        lsb = _get_int(field_node, 'lsb')
+        if bit_range is not None:
+            m = re.search('\[([0-9]+):([0-9]+)\]', bit_range)
+            bit_offset = int(m.group(2))
+            bit_width = 1 + (int(m.group(1)) - int(m.group(2)))
+        elif msb is not None:
+            bit_offset = lsb
+            bit_width = 1 + (msb - lsb)
+
+        return SVDField(
+            name=_get_text(field_node, 'name'),
+            derived_from=_get_text(field_node, 'derivedFrom'),
+            description=_get_text(field_node, 'description'),
+            bit_offset=bit_offset,
+            bit_width=bit_width,
+            access=_get_text(field_node, 'access'),
+            enumerated_values=enumerated_values or None,
+            modified_write_values=modified_write_values,
+            read_action=read_action,
+        )
+
+    def _parse_registers(self, register_node):
+        fields = []
+        for field_node in register_node.findall('.//field'):
+            node = self._parse_field(field_node)
+            if self.remove_reserved or 'reserved' not in node.name.lower():
+                fields.append(node)
+
+        dim = _get_int(register_node, 'dim')
+        name = _get_text(register_node, 'name')
+        derived_from = _get_text(register_node, 'derivedFrom')
+        description = _get_text(register_node, 'description')
+        address_offset = _get_int(register_node, 'addressOffset')
+        size = _get_int(register_node, 'size')
+        access = _get_text(register_node, 'access')
+        protection = _get_text(register_node, 'protection')
+        reset_value = _get_int(register_node, 'resetValue')
+        reset_mask = _get_int(register_node, 'resetMask')
+        dim_increment = _get_int(register_node, 'dimIncrement')
+        dim_index_text = _get_text(register_node, 'dimIndex')
+        display_name = _get_text(register_node, 'displayName')
+        alternate_group = _get_text(register_node, 'alternateGroup')
+        modified_write_values = _get_text(register_node, 'modifiedWriteValues')
+        read_action = _get_text(register_node, 'readAction')
+
+        if dim is None:
+            return SVDRegister(
+                name=name,
+                fields=fields,
+                derived_from=derived_from,
+                description=description,
+                address_offset=address_offset,
+                size=size,
+                access=access,
+                protection=protection,
+                reset_value=reset_value,
+                reset_mask=reset_mask,
+                display_name=display_name,
+                alternate_group=alternate_group,
+                modified_write_values=modified_write_values,
+                read_action=read_action,
+            )
+        else:
+            # the node represents a register array
+            if dim_index_text is None:
+                dim_indices = range(0, dim)  # some files omit dimIndex
+            elif ',' in dim_index_text:
+                dim_indices = dim_index_text.split(',')
+            elif '-' in dim_index_text:  # some files use <dimIndex>0-3</dimIndex> as an inclusive inclusive range
+                m = re.search(r'([0-9]+)-([0-9]+)', dim_index_text)
+                dim_indices = range(int(m.group(1)), int(m.group(2)) + 1)
+            else:
+                raise ValueError("Unexpected dim_index_text: %r" % dim_index_text)
+
+            # yield `SVDRegisterArray` (caller will differentiate on type)
+            return SVDRegisterArray(
+                name=name,
+                fields=fields,
+                derived_from=derived_from,
+                description=description,
+                address_offset=address_offset,
+                size=size,
+                access=access,
+                protection=protection,
+                reset_value=reset_value,
+                reset_mask=reset_mask,
+                display_name=display_name,
+                alternate_group=alternate_group,
+                modified_write_values=modified_write_values,
+                read_action=read_action,
+                dim=dim,
+                dim_indices=dim_indices,
+                dim_increment=dim_increment,
+            )
+
+    def _parse_cluster(self, cluster_node):
+        dim = _get_int(cluster_node, 'dim')
+        name = _get_text(cluster_node, 'name')
+        derived_from = _get_text(cluster_node, 'derivedFrom')
+        description = _get_text(cluster_node, 'description')
+        address_offset = _get_int(cluster_node, 'addressOffset')
+        size = _get_int(cluster_node, 'size')
+        access = _get_text(cluster_node, 'access')
+        protection = _get_text(cluster_node, 'protection')
+        reset_value = _get_int(cluster_node, 'resetValue')
+        reset_mask = _get_int(cluster_node, 'resetMask')
+        dim_increment = _get_int(cluster_node, 'dimIncrement')
+        dim_index_text = _get_text(cluster_node, 'dimIndex')
+        alternate_cluster = _get_text(cluster_node, 'alternateGluster')
+        header_struct_name = _get_text(cluster_node, 'headerStructName')
+        cluster = []
+        for sub_cluster_node in cluster_node.findall("./cluster"):
+            cluster.append(self._parse_cluster(sub_cluster_node))
+        register = []
+        for reg_node in cluster_node.findall("./register"):
+            register.append(self._parse_registers(reg_node))
+
+        if dim is None:
+            return SVDRegisterCluster(
+                name=name,
+                derived_from=derived_from,
+                description=description,
+                address_offset=address_offset,
+                size=size,
+                access=access,
+                protection=protection,
+                reset_value=reset_value,
+                reset_mask=reset_mask,
+                alternate_cluster=alternate_cluster,
+                header_struct_name=header_struct_name,
+                register=register,
+                cluster=cluster,
+            )
+        else:
+            # the node represents a register array
+            if dim_index_text is None:
+                dim_indices = range(0, dim)  # some files omit dimIndex
+            elif ',' in dim_index_text:
+                dim_indices = dim_index_text.split(',')
+            elif '-' in dim_index_text:  # some files use <dimIndex>0-3</dimIndex> as an inclusive inclusive range
+                m = re.search(r'([0-9]+)-([0-9]+)', dim_index_text)
+                dim_indices = range(int(m.group(1)), int(m.group(2)) + 1)
+            else:
+                raise ValueError("Unexpected dim_index_text: %r" % dim_index_text)
+
+            # yield `SVDRegisterArray` (caller will differentiate on type)
+            return SVDRegisterClusterArray(
+                name=name,
+                derived_from=derived_from,
+                description=description,
+                address_offset=address_offset,
+                size=size,
+                access=access,
+                protection=protection,
+                reset_value=reset_value,
+                reset_mask=reset_mask,
+                alternate_cluster=alternate_cluster,
+                header_struct_name=header_struct_name,
+                register=register,
+                cluster=cluster,
+                dim=dim,
+                dim_increment=dim_increment,
+                dim_indices=dim_indices,
+            )
+
+    def _parse_address_block(self, address_block_node):
+        return SVDAddressBlock(
+            _get_int(address_block_node, 'offset'),
+            _get_int(address_block_node, 'size'),
+            _get_text(address_block_node, 'usage')
+        )
+
+    def _parse_interrupt(self, interrupt_node):
+        return SVDInterrupt(
+            name=_get_text(interrupt_node, 'name'),
+            value=_get_int(interrupt_node, 'value'),
+            description=_get_text(interrupt_node, 'description')
+        )
+
+    def _parse_peripheral(self, peripheral_node):
+        # parse registers
+        registers = None if peripheral_node.find('registers') is None else []
+        register_arrays = None if peripheral_node.find('registers') is None else []
+        for register_node in peripheral_node.findall('./registers/register'):
+            reg = self._parse_registers(register_node)
+            if isinstance(reg, SVDRegisterArray):
+                register_arrays.append(reg)
+            else:
+                registers.append(reg)
+
+        clusters = []
+        for cluster_node in peripheral_node.findall('./registers/cluster'):
+            reg = self._parse_cluster(cluster_node)
+            clusters.append(reg)
+
+        # parse all interrupts for the peripheral
+        interrupts = []
+        for interrupt_node in peripheral_node.findall('./interrupt'):
+            interrupts.append(self._parse_interrupt(interrupt_node))
+        interrupts = interrupts if interrupts else None
+
+        # parse address block if any
+        address_block_nodes = peripheral_node.findall('./addressBlock')
+        if address_block_nodes:
+            address_block = self._parse_address_block(address_block_nodes[0])
+        else:
+            address_block = None
+
+        return SVDPeripheral(
+            # <name>identifierType</name>
+            # <version>xs:string</version>
+            # <description>xs:string</description>
+            name=_get_text(peripheral_node, 'name'),
+            version=_get_text(peripheral_node, 'version'),
+            derived_from=peripheral_node.get('derivedFrom'),
+            description=_get_text(peripheral_node, 'description'),
+
+            # <groupName>identifierType</groupName>
+            # <prependToName>identifierType</prependToName>
+            # <appendToName>identifierType</appendToName>
+            # <disableCondition>xs:string</disableCondition>
+            # <baseAddress>scaledNonNegativeInteger</baseAddress>
+            group_name=_get_text(peripheral_node, 'groupName'),
+            prepend_to_name=_get_text(peripheral_node, 'prependToName'),
+            append_to_name=_get_text(peripheral_node, 'appendToName'),
+            disable_condition=_get_text(peripheral_node, 'disableCondition'),
+            base_address=_get_int(peripheral_node, 'baseAddress'),
+
+            # <!-- registerPropertiesGroup -->
+            # <size>scaledNonNegativeInteger</size>
+            # <access>accessType</access>
+            # <resetValue>scaledNonNegativeInteger</resetValue>
+            # <resetMask>scaledNonNegativeInteger</resetMask>
+            size=_get_int(peripheral_node, "size"),
+            access=_get_text(peripheral_node, 'access'),
+            reset_value=_get_int(peripheral_node, "resetValue"),
+            reset_mask=_get_int(peripheral_node, "resetMask"),
+
+            # <addressBlock>
+            #     <offset>scaledNonNegativeInteger</offset>
+            #     <size>scaledNonNegativeInteger</size>
+            #     <usage>usageType</usage>
+            #     <protection>protectionStringType</protection>
+            # </addressBlock>
+            address_block=address_block,
+
+            # <interrupt>
+            #     <name>identifierType</name>
+            #     <value>scaledNonNegativeInteger</value>
+            #     <description>xs:string</description>
+            # </interrupt>
+            interrupts=interrupts,
+
+            # <registers>
+            #     ...
+            # </registers>
+            register_arrays=register_arrays,
+            registers=registers,
+
+            # <cluster>
+            #    ...
+            # </cluster>
+            clusters=clusters,
+
+            # (not mentioned in docs -- applies to all registers)
+            protection=_get_text(peripheral_node, 'protection'),
+        )
+
+    def _parse_device(self, device_node):
+        peripherals = []
+        for peripheral_node in device_node.findall('.//peripheral'):
+            peripherals.append(self._parse_peripheral(peripheral_node))
+        cpu_node = device_node.find('./cpu')
+        cpu = SVDCpu(
+            name=_get_text(cpu_node, 'name'),
+            revision=_get_text(cpu_node, 'revision'),
+            endian=_get_text(cpu_node, 'endian'),
+            mpu_present=_get_int(cpu_node, 'mpuPresent'),
+            fpu_present=_get_int(cpu_node, 'fpuPresent'),
+            fpu_dp=_get_int(cpu_node, 'fpuDP'),
+            icache_present=_get_int(cpu_node, 'icachePresent'),
+            dcache_present=_get_int(cpu_node, 'dcachePresent'),
+            itcm_present=_get_int(cpu_node, 'itcmPresent'),
+            dtcm_present=_get_int(cpu_node, 'dtcmPresent'),
+            vtor_present=_get_int(cpu_node, 'vtorPresent'),
+            nvic_prio_bits=_get_int(cpu_node, 'nvicPrioBits'),
+            vendor_systick_config=_get_int(cpu_node, 'vendorSystickConfig'),
+            device_num_interrupts=_get_int(cpu_node, 'vendorSystickConfig'),
+            sau_num_regions=_get_int(cpu_node, 'vendorSystickConfig'),
+            sau_regions_config=_get_text(cpu_node, 'sauRegionsConfig')
+        )
+
+        return SVDDevice(
+            vendor=_get_text(device_node, 'vendor'),
+            vendor_id=_get_text(device_node, 'vendorID'),
+            name=_get_text(device_node, 'name'),
+            version=_get_text(device_node, 'version'),
+            description=_get_text(device_node, 'description'),
+            cpu=cpu,
+            address_unit_bits=_get_int(device_node, 'addressUnitBits'),
+            width=_get_int(device_node, 'width'),
+            peripherals=peripherals,
+            size=_get_int(device_node, "size"),
+            access=_get_text(device_node, 'access'),
+            protection=_get_text(device_node, 'protection'),
+            reset_value=_get_int(device_node, "resetValue"),
+            reset_mask=_get_int(device_node, "resetMask")
+        )
+
+    def get_device(self):
+        """Get the device described by this SVD"""
+        return self._parse_device(self._root)
+
+
+def duplicate_array_of_registers(svdreg):  # expects a SVDRegister which is an array of registers
+    assert (svdreg.dim == len(svdreg.dim_index))

--- a/pyocd/target/builtin/target_CC3220SF.py
+++ b/pyocd/target/builtin/target_CC3220SF.py
@@ -16,9 +16,9 @@
 
 from ...flash.flash import Flash
 from ...core import exceptions
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
-from ...coresight.cortex_m import (CortexM)
-from ...coresight import(ap, dap)
+from ...core.coresight_target import CoreSightTarget
+from ...coresight.cortex_m import CortexM
+from ...coresight import (ap, dap)
 from ...core.memory_map import (RomRegion, FlashRegion, RamRegion, MemoryMap)
 import logging
 import time

--- a/pyocd/target/builtin/target_K32W042S1M2xxx.py
+++ b/pyocd/target/builtin/target_K32W042S1M2xxx.py
@@ -19,7 +19,7 @@ from ...flash.flash import Flash
 from ...core.target import Target
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 from ...coresight import ap
 from ...coresight.cortex_m import CortexM
 from ...utility.timeout import Timeout
@@ -173,10 +173,7 @@ class K32W042S(Kinetis):
 
     def __init__(self, link):
         super(K32W042S, self).__init__(link, self.memoryMap)
-
-        svdPath = os.path.join(os.path.dirname(__file__), "K32W042S1M2_M4.xml")
-        if os.path.exists(svdPath):
-            self._svd_location = SVDFile(vendor="NXP", filename=svdPath, is_local=True)
+        self._svd_location = SVDFile.from_builtin("K32W042S1M2_M4.xml")
 
     def create_init_sequence(self):
         seq = super(K32W042S, self).create_init_sequence()

--- a/pyocd/target/builtin/target_LPC11U24FBD64_401.py
+++ b/pyocd/target/builtin/target_LPC11U24FBD64_401.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 
 FLASH_ALGO = { 'load_address' : 0x10000000,
                'instructions' : [
@@ -61,7 +62,7 @@ class LPC11U24(CoreSightTarget):
 
     def __init__(self, link):
         super(LPC11U24, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="NXP", filename="LPC11Uxx_v7.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("LPC11Uxx_v7.svd")
 
     def reset_and_halt(self, reset_type=None, map_to_user=True):
         super(LPC11U24, self).reset_and_halt(reset_type)

--- a/pyocd/target/builtin/target_LPC1768.py
+++ b/pyocd/target/builtin/target_LPC1768.py
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap, DefaultFlashWeights)
+from ...debug.svd.loader import SVDFile
 
 LARGE_PAGE_START_ADDR = 0x10000
 SMALL_PAGE_SIZE = 0x1000
@@ -81,7 +82,7 @@ class LPC1768(CoreSightTarget):
 
     def __init__(self, link):
         super(LPC1768, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="NXP", filename="LPC176x5x_v0.2.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("LPC176x5x_v0.2.svd")
 
     def reset(self, reset_type=None):
         super(LPC1768, self).reset(self.ResetType.HW)

--- a/pyocd/target/builtin/target_LPC4088FBD144.py
+++ b/pyocd/target/builtin/target_LPC4088FBD144.py
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap, DefaultFlashWeights)
+from ...debug.svd.loader import SVDFile
 
 LARGE_PAGE_START_ADDR = 0x10000
 SMALL_PAGE_SIZE = 0x1000
@@ -82,7 +83,7 @@ class LPC4088(CoreSightTarget):
             mem_map = self.memoryMap
         super(LPC4088, self).__init__(link, mem_map)
         self.ignoreReset = False
-        self._svd_location = SVDFile(vendor="NXP", filename="LPC408x_7x_v0.7.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("LPC408x_7x_v0.7.svd")
 
     def reset(self, reset_type=None):
         # Use hardware reset since software reset cause a debug logic reset

--- a/pyocd/target/builtin/target_LPC4330.py
+++ b/pyocd/target/builtin/target_LPC4330.py
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 
 FLASH_ALGO = { 'load_address' : 0x10000000,
                'instructions' : [
@@ -328,7 +329,7 @@ class LPC4330(CoreSightTarget):
     def __init__(self, link):
         super(LPC4330, self).__init__(link, self.memoryMap)
         self.ignoreReset = False
-        self._svd_location = SVDFile(vendor="NXP", filename="LPC43xx_svd_v5.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("LPC43xx_svd_v5.svd")
 
     def reset(self, reset_type=None):
         # Always use software reset for LPC4330 since the hardware version

--- a/pyocd/target/builtin/target_LPC54114J256BD64.py
+++ b/pyocd/target/builtin/target_LPC54114J256BD64.py
@@ -13,10 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...coresight import ap
 from ...coresight.cortex_m import CortexM
+from ...debug.svd.loader import SVDFile
 
 SYSCON_DEVICE_ID0 = 0x400000FF8
 LPC54114J256 = 0x36454114
@@ -74,7 +75,7 @@ class LPC54114(CoreSightTarget):
     def __init__(self, link):
         super(LPC54114, self).__init__(link, self.memoryMap)
         self.ignoreReset = False
-        self._svd_location = SVDFile(vendor="NXP", filename="LPC54114_cm0plus.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("LPC54114_cm4.xml")
 
     def reset_and_halt(self, reset_type=None, map_to_user=True):
         super(LPC54114, self).reset_and_halt(reset_type)

--- a/pyocd/target/builtin/target_LPC54608J512ET180.py
+++ b/pyocd/target/builtin/target_LPC54608J512ET180.py
@@ -13,10 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...coresight import ap
 from ...coresight.cortex_m import CortexM
+from ...debug.svd.loader import SVDFile
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [
@@ -70,7 +71,7 @@ class LPC54608(CoreSightTarget):
     def __init__(self, link):
         super(LPC54608, self).__init__(link, self.memoryMap)
         self.ignoreReset = False
-        self._svd_location = SVDFile(vendor="NXP", filename="LPC54608.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("LPC54608.xml")
 
     def reset_and_halt(self, reset_type=None, map_to_user=True):
         super(LPC54608, self).reset_and_halt(reset_type)

--- a/pyocd/target/builtin/target_LPC55S69JBD100.py
+++ b/pyocd/target/builtin/target_LPC55S69JBD100.py
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 
 FLASH_ALGO = {
     'load_address' : 0x20000000,
@@ -121,6 +122,7 @@ class LPC55S69JBD100(CoreSightTarget):
 
     def __init__(self, link):
         super(LPC55S69JBD100, self).__init__(link, self.memoryMap)
+        self._svd_location = SVDFile.from_builtin("LPC55S69_cm33_core0.xml")
 
     def create_init_sequence(self):
         seq = super(LPC55S69JBD100, self).create_init_sequence()

--- a/pyocd/target/builtin/target_LPC824M201JHI33.py
+++ b/pyocd/target/builtin/target_LPC824M201JHI33.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 
 FLASH_ALGO = {
     'load_address' : 0x10000000,
@@ -61,6 +62,7 @@ class LPC824(CoreSightTarget):
 
     def __init__(self, link):
         super(LPC824, self).__init__(link, self.memoryMap)
+        self._svd_location = SVDFile.from_builtin("LPC824.xml")
 
     def reset_and_halt(self, reset_type=None, map_to_user=True):
         super(LPC824, self).reset_and_halt(reset_type)

--- a/pyocd/target/builtin/target_MAX32620.py
+++ b/pyocd/target/builtin/target_MAX32620.py
@@ -17,6 +17,7 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -68,3 +69,4 @@ class MAX32620(CoreSightTarget):
 
     def __init__(self, link):
         super(MAX32620, self).__init__(link, self.memoryMap)
+        self._svd_location = SVDFile.from_builtin("max32620.svd")

--- a/pyocd/target/builtin/target_MAX32625.py
+++ b/pyocd/target/builtin/target_MAX32625.py
@@ -17,6 +17,7 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -68,3 +69,4 @@ class MAX32625(CoreSightTarget):
 
     def __init__(self, link):
         super(MAX32625, self).__init__(link, self.memoryMap)
+        self._svd_location = SVDFile.from_builtin("max32625.svd")

--- a/pyocd/target/builtin/target_MAX32630.py
+++ b/pyocd/target/builtin/target_MAX32630.py
@@ -17,6 +17,7 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -68,3 +69,4 @@ class MAX32630(CoreSightTarget):
 
     def __init__(self, link):
         super(MAX32630, self).__init__(link, self.memoryMap)
+        self._svd_location = SVDFile.from_builtin("max32630.svd")

--- a/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
@@ -18,6 +18,7 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RomRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO_QUADSPI = {
@@ -647,3 +648,4 @@ class MIMXRT1021xxxxx(CoreSightTarget):
 
     def __init__(self, link):
         super(MIMXRT1021xxxxx, self).__init__(link, self.memoryMap)
+        self._svd_location = SVDFile.from_builtin("MIMXRT1021.xml")

--- a/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
+++ b/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
@@ -18,6 +18,7 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RomRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO_QUADSPI = {
@@ -929,6 +930,7 @@ class MIMXRT1052xxxxB_hyperflash(CoreSightTarget):
 
     def __init__(self, link):
         super(MIMXRT1052xxxxB_hyperflash, self).__init__(link, self.memoryMap)
+        self._svd_location = SVDFile.from_builtin("MIMXRT1052.xml")
 
 class MIMXRT1052xxxxB_quadspi(CoreSightTarget):
 
@@ -952,3 +954,4 @@ class MIMXRT1052xxxxB_quadspi(CoreSightTarget):
 
     def __init__(self, link):
         super(MIMXRT1052xxxxB_quadspi, self).__init__(link, self.memoryMap)
+        self._svd_location = SVDFile.from_builtin("MIMXRT1052.xml")

--- a/pyocd/target/builtin/target_MK20DX128xxx5.py
+++ b/pyocd/target/builtin/target_MK20DX128xxx5.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -83,5 +83,5 @@ class K20D50M(Kinetis):
 
     def __init__(self, link):
         super(K20D50M, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MK20D5.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("MK20D5.svd")
 

--- a/pyocd/target/builtin/target_MK22FN1M0Axxx12.py
+++ b/pyocd/target/builtin/target_MK22FN1M0Axxx12.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 SIM_FCFG1 = 0x4004804C
@@ -100,7 +100,7 @@ class K22FA12(Kinetis):
 
     def __init__(self, link):
         super(K22FA12, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MK22FA12.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("MK22FA12.svd")
 
     def create_init_sequence(self):
         seq = super(K22FA12, self).create_init_sequence()

--- a/pyocd/target/builtin/target_MK22FN512xxx12.py
+++ b/pyocd/target/builtin/target_MK22FN512xxx12.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -85,5 +85,5 @@ class K22F(Kinetis):
 
     def __init__(self, link):
         super(K22F, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MK22F51212.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("MK22F51212.svd")
 

--- a/pyocd/target/builtin/target_MK28FN2M0xxx15.py
+++ b/pyocd/target/builtin/target_MK28FN2M0xxx15.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -86,5 +86,5 @@ class K28F15(Kinetis):
 
     def __init__(self, transport):
         super(K28F15, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MK28F15.svd")
+        self._svd_location = SVDFile.from_builtin("MK28FA15.xml")
 

--- a/pyocd/target/builtin/target_MK64FN1M0xxx12.py
+++ b/pyocd/target/builtin/target_MK64FN1M0xxx12.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -83,5 +83,5 @@ class K64F(Kinetis):
 
     def __init__(self, link):
         super(K64F, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MK64F12.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("MK64F12.svd")
 

--- a/pyocd/target/builtin/target_MK66FN2M0xxx18.py
+++ b/pyocd/target/builtin/target_MK66FN2M0xxx18.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -85,5 +85,5 @@ class K66F18(Kinetis):
 
     def __init__(self, transport):
         super(K66F18, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MK66F18.svd")
+        self._svd_location = SVDFile.from_builtin("MK66F18.svd")
 

--- a/pyocd/target/builtin/target_MK82FN256xxx15.py
+++ b/pyocd/target/builtin/target_MK82FN256xxx15.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = {
@@ -92,5 +92,5 @@ class K82F25615(Kinetis):
         )
     def __init__(self, transport):
         super(K82F25615, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MK82F25615.svd")
+        self._svd_location = SVDFile.from_builtin("MK82F25615.svd")
 

--- a/pyocd/target/builtin/target_MKE15Z256xxx7.py
+++ b/pyocd/target/builtin/target_MKE15Z256xxx7.py
@@ -19,7 +19,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 RCM_MR = 0x4007f010
@@ -95,7 +95,7 @@ class KE15Z7(Kinetis):
 
     def __init__(self, link):
         super(KE15Z7, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKE15Z7.svd")
+        self._svd_location = SVDFile.from_builtin("MKE15Z7.svd")
 
     def create_init_sequence(self):
         seq = super(KE15Z7, self).create_init_sequence()

--- a/pyocd/target/builtin/target_MKE18F256xxx16.py
+++ b/pyocd/target/builtin/target_MKE18F256xxx16.py
@@ -19,7 +19,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 RCM_MR = 0x4007f010
@@ -96,7 +96,7 @@ class KE18F16(Kinetis):
 
     def __init__(self, link):
         super(KE18F16, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKE18F16.svd")
+        self._svd_location = SVDFile.from_builtin("MKE18F16.svd")
 
     def create_init_sequence(self):
         seq = super(KE18F16, self).create_init_sequence()

--- a/pyocd/target/builtin/target_MKL02Z32xxx4.py
+++ b/pyocd/target/builtin/target_MKL02Z32xxx4.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -94,5 +94,5 @@ class KL02Z(Kinetis):
 
     def __init__(self, link):
         super(KL02Z, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKL02Z4.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("MKL02Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL05Z32xxx4.py
+++ b/pyocd/target/builtin/target_MKL05Z32xxx4.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -94,5 +94,5 @@ class KL05Z(Kinetis):
 
     def __init__(self, link):
         super(KL05Z, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKL05Z4.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("MKL05Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL25Z128xxx4.py
+++ b/pyocd/target/builtin/target_MKL25Z128xxx4.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -96,5 +96,5 @@ class KL25Z(Kinetis):
 
     def __init__(self, link):
         super(KL25Z, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKL25Z4.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("MKL25Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL26Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL26Z256xxx4.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -96,5 +96,5 @@ class KL26Z(Kinetis):
 
     def __init__(self, link):
         super(KL26Z, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKL26Z4.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("MKL26Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL27Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL27Z256xxx4.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -98,5 +98,5 @@ class KL27Z4(Kinetis):
 
     def __init__(self, transport):
         super(KL27Z4, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKL27Z644.svd")
+        self._svd_location = SVDFile.from_builtin("MKL27Z644.svd")
 

--- a/pyocd/target/builtin/target_MKL28Z512xxx7.py
+++ b/pyocd/target/builtin/target_MKL28Z512xxx7.py
@@ -19,7 +19,7 @@ from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...coresight import ap
 from ...coresight.cortex_m import CortexM
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 import os.path
 from time import (time, sleep)
@@ -184,7 +184,7 @@ class KL28x(Kinetis):
         super(KL28x, self).__init__(link, self.singleMap)
         self.is_dual_core = False
 
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKL28T7_CORE0.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("MKL28T7_CORE0.svd")
 
     def create_init_sequence(self):
         seq = super(KL28x, self).create_init_sequence()

--- a/pyocd/target/builtin/target_MKL43Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL43Z256xxx4.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -99,5 +99,5 @@ class KL43Z4(Kinetis):
 
     def __init__(self, transport):
         super(KL43Z4, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKL43Z4.svd")
+        self._svd_location = SVDFile.from_builtin("MKL43Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL46Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL46Z256xxx4.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -96,5 +96,5 @@ class KL46Z(Kinetis):
 
     def __init__(self, link):
         super(KL46Z, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKL46Z4.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("MKL46Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL82Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKL82Z128xxx7.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = {
@@ -96,7 +96,7 @@ class KL82Z7(Kinetis):
 
     def __init__(self, link):
         super(KL82Z7, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKL82Z7.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("MKL82Z7.svd")
 
 
 

--- a/pyocd/target/builtin/target_MKV10Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKV10Z128xxx7.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -100,5 +100,5 @@ class KV10Z7(Kinetis):
 
     def __init__(self, transport):
         super(KV10Z7, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKV10Z7.svd")
+        self._svd_location = SVDFile.from_builtin("MKV10Z7.svd")
 

--- a/pyocd/target/builtin/target_MKV11Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKV11Z128xxx7.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -101,5 +101,5 @@ class KV11Z7(Kinetis):
 
     def __init__(self, transport):
         super(KV11Z7, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKV11Z7.svd")
+        self._svd_location = SVDFile.from_builtin("MKV11Z7.svd")
 

--- a/pyocd/target/builtin/target_MKW01Z128xxx4.py
+++ b/pyocd/target/builtin/target_MKW01Z128xxx4.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -99,5 +99,5 @@ class KW01Z4(Kinetis):
 
     def __init__(self, transport):
         super(KW01Z4, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKW01Z4.svd")
+        self._svd_location = SVDFile.from_builtin("MKW01Z4.svd")
 

--- a/pyocd/target/builtin/target_MKW24D512xxx5.py
+++ b/pyocd/target/builtin/target_MKW24D512xxx5.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -91,5 +91,5 @@ class KW24D5(Kinetis):
 
     def __init__(self, transport):
         super(KW24D5, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKW24D5.svd")
+        self._svd_location = SVDFile.from_builtin("MKW24D5.svd")
 

--- a/pyocd/target/builtin/target_MKW36Z512xxx4.py
+++ b/pyocd/target/builtin/target_MKW36Z512xxx4.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = {
@@ -166,5 +166,5 @@ class KW36Z4(Kinetis):
 
     def __init__(self, transport):
         super(KW36Z4, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKW36Z4.svd")
+        self._svd_location = SVDFile.from_builtin("MKW36Z4.svd")
 

--- a/pyocd/target/builtin/target_MKW40Z160xxx4.py
+++ b/pyocd/target/builtin/target_MKW40Z160xxx4.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -100,5 +100,5 @@ class KW40Z4(Kinetis):
 
     def __init__(self, transport):
         super(KW40Z4, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKW40Z4.svd")
+        self._svd_location = SVDFile.from_builtin("MKW40Z4.svd")
 

--- a/pyocd/target/builtin/target_MKW41Z512xxx4.py
+++ b/pyocd/target/builtin/target_MKW41Z512xxx4.py
@@ -17,7 +17,7 @@
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = {
@@ -90,5 +90,5 @@ class KW41Z4(Kinetis):
 
     def __init__(self, transport):
         super(KW41Z4, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Freescale", filename="MKW41Z4.svd")
+        self._svd_location = SVDFile.from_builtin("MKW41Z4.svd")
 

--- a/pyocd/target/builtin/target_STM32F051T8.py
+++ b/pyocd/target/builtin/target_STM32F051T8.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 import logging
 
 #DBGMCU clock
@@ -78,7 +79,7 @@ class STM32F051(CoreSightTarget):
 
     def __init__(self, link):
         super(STM32F051, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="STMicro", filename="STM32F0xx.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("STM32F0xx.svd")
 
     def create_init_sequence(self):
         seq = super(STM32F051, self).create_init_sequence()

--- a/pyocd/target/builtin/target_STM32F103RC.py
+++ b/pyocd/target/builtin/target_STM32F103RC.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 import logging
 
 DBGMCU_CR = 0xE0042004
@@ -61,7 +62,7 @@ class STM32F103RC(CoreSightTarget):
 
     def __init__(self, link):
         super(STM32F103RC, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="STMicro", filename="STM32F103xx.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("STM32F103xx.svd")
 
     def create_init_sequence(self):
         seq = super(STM32F103RC, self).create_init_sequence()

--- a/pyocd/target/builtin/target_STM32F412xx.py
+++ b/pyocd/target/builtin/target_STM32F412xx.py
@@ -17,7 +17,7 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 
 class DBGMCU:
     CR = 0xE0042004
@@ -74,7 +74,7 @@ class STM32F412xE(CoreSightTarget):
 
     def __init__(self, transport):
         super(STM32F412xE, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="STMicro", filename="STM32F41x.svd")
+        self._svd_location = SVDFile.from_builtin("STM32F41x.svd")
         
     def create_init_sequence(self):
         seq = super(STM32F412xE, self).create_init_sequence()
@@ -103,7 +103,7 @@ class STM32F412xG(CoreSightTarget):
 
     def __init__(self, transport):
         super(STM32F412xG, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="STMicro", filename="STM32F41x.svd")
+        self._svd_location = SVDFile.from_builtin("STM32F41x.svd")
         
     def create_init_sequence(self):
         seq = super(STM32F412xG, self).create_init_sequence()

--- a/pyocd/target/builtin/target_STM32F429xx.py
+++ b/pyocd/target/builtin/target_STM32F429xx.py
@@ -17,7 +17,7 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 
 # Chip erase takes a really long time.
 CHIP_ERASE_WEIGHT = 15.0
@@ -84,7 +84,7 @@ class STM32F429xG(CoreSightTarget):
 
     def __init__(self, transport):
         super(STM32F429xG, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="STMicro", filename="STM32F429x.svd")
+        self._svd_location = SVDFile.from_builtin("STM32F429x.svd")
 
     def create_init_sequence(self):
         seq = super(STM32F429xG, self).create_init_sequence()
@@ -129,7 +129,7 @@ class STM32F429xI(CoreSightTarget):
 
     def __init__(self, transport):
         super(STM32F429xI, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="STMicro", filename="STM32F429x.svd")
+        self._svd_location = SVDFile.from_builtin("STM32F429x.svd")
 
     def create_init_sequence(self):
         seq = super(STM32F429xI, self).create_init_sequence()

--- a/pyocd/target/builtin/target_STM32F439xx.py
+++ b/pyocd/target/builtin/target_STM32F439xx.py
@@ -17,7 +17,7 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 
 # Chip erase takes a really long time.
 CHIP_ERASE_WEIGHT = 15.0
@@ -84,7 +84,7 @@ class STM32F439xG(CoreSightTarget):
 
     def __init__(self, transport):
         super(STM32F439xG, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="STMicro", filename="STM32F439x.svd")
+        self._svd_location = SVDFile.from_builtin("STM32F439x.svd")
         
     def create_init_sequence(self):
         seq = super(STM32F439xG, self).create_init_sequence()
@@ -129,7 +129,7 @@ class STM32F439xI(CoreSightTarget):
 
     def __init__(self, transport):
         super(STM32F439xI, self).__init__(transport, self.memoryMap)
-        self._svd_location = SVDFile(vendor="STMicro", filename="STM32F439x.svd")
+        self._svd_location = SVDFile.from_builtin("STM32F439x.svd")
         
     def create_init_sequence(self):
         seq = super(STM32F439xI, self).create_init_sequence()

--- a/pyocd/target/builtin/target_STM32L031x6.py
+++ b/pyocd/target/builtin/target_STM32L031x6.py
@@ -17,7 +17,7 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 
 class DBGMCU:
     # en.DM00108282.pdf (STM32L0x1 Reference manual)
@@ -89,6 +89,7 @@ class STM32L031x6(CoreSightTarget):
 
     def __init__(self, link):
         super(STM32L031x6, self).__init__(link, self.memoryMap)
+        self._svd_location = SVDFile.from_builtin("STM32L0x1.svd")
 
     def create_init_sequence(self):
         seq = super(STM32L031x6, self).create_init_sequence()

--- a/pyocd/target/builtin/target_STM32L475xx.py
+++ b/pyocd/target/builtin/target_STM32L475xx.py
@@ -17,7 +17,7 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...debug.svd import SVDFile
+from ...debug.svd.loader import SVDFile
 
 class DBGMCU:
     CR = 0xE0042004
@@ -95,7 +95,7 @@ class STM32L475xC(STM32L475xx):
 
     def __init__(self, transport):
         super(STM32L475xC, self).__init__(transport, self.memoryMap)
-        # cmsis-svd doesn't have this device's SVD file
+        self._svd_location = SVDFile.from_builtin("STM32L4x5.svd")
 
 class STM32L475xE(STM32L475xx):
 
@@ -108,7 +108,7 @@ class STM32L475xE(STM32L475xx):
 
     def __init__(self, transport):
         super(STM32L475xE, self).__init__(transport, self.memoryMap)
-        # cmsis-svd doesn't have this device's SVD file
+        self._svd_location = SVDFile.from_builtin("STM32L4x5.svd")
 
 class STM32L475xG(STM32L475xx):
 
@@ -121,6 +121,6 @@ class STM32L475xG(STM32L475xx):
 
     def __init__(self, transport):
         super(STM32L475xG, self).__init__(transport, self.memoryMap)
-        # cmsis-svd doesn't have this device's SVD file
+        self._svd_location = SVDFile.from_builtin("STM32L4x5.svd")
 
 

--- a/pyocd/target/builtin/target_lpc800.py
+++ b/pyocd/target/builtin/target_lpc800.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 
 FLASH_ALGO = { 'load_address' : 0x10000000,
                'instructions' : [
@@ -58,7 +59,7 @@ class LPC800(CoreSightTarget):
 
     def __init__(self, link):
         super(LPC800, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="NXP", filename="LPC800_v0.3.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("LPC800_v0.3.svd")
 
     def reset_and_halt(self, reset_type=None, map_to_user=True):
         super(LPC800, self).reset_and_halt(reset_type)

--- a/pyocd/target/builtin/target_musca_a1.py
+++ b/pyocd/target/builtin/target_musca_a1.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 
 FLASH_ALGO = {
     'load_address' : 0x20000000,
@@ -115,4 +116,5 @@ class MuscaA1(CoreSightTarget):
 
     def __init__(self, link):
         super(MuscaA1, self).__init__(link, self.memoryMap)
+        self._svd_location = SVDFile.from_builtin("Musca.svd")
 

--- a/pyocd/target/builtin/target_musca_b1.py
+++ b/pyocd/target/builtin/target_musca_b1.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 
 FLASH_ALGO_QSPI = {
     'load_address' : 0x20000000,
@@ -218,4 +219,4 @@ class MuscaB1(CoreSightTarget):
 
     def __init__(self, link):
         super(MuscaB1, self).__init__(link, self.memoryMap)
-
+        self._svd_location = SVDFile.from_builtin("Musca_B1.svd")

--- a/pyocd/target/builtin/target_nRF51822_xxAA.py
+++ b/pyocd/target/builtin/target_nRF51822_xxAA.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 import logging
 
 # NRF51 specific registers
@@ -61,7 +62,7 @@ class NRF51(CoreSightTarget):
 
     def __init__(self, link):
         super(NRF51, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Nordic", filename="nrf51.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("nrf51.svd")
 
     def resetn(self):
         """

--- a/pyocd/target/builtin/target_nRF52832_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52832_xxAA.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -57,7 +58,7 @@ class NRF52(CoreSightTarget):
 
     def __init__(self, link):
         super(NRF52, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Nordic", filename="nrf52.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("nrf52.svd")
 
     def resetn(self):
         """

--- a/pyocd/target/builtin/target_nRF52840_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52840_xxAA.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import (SVDFile, CoreSightTarget)
+from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
 import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
@@ -57,7 +58,7 @@ class NRF52840(CoreSightTarget):
 
     def __init__(self, link):
         super(NRF52840, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile(vendor="Nordic", filename="nrf52.svd", is_local=False)
+        self._svd_location = SVDFile.from_builtin("nrf52840.svd")
 
     def resetn(self):
         """

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -28,7 +28,6 @@ from .. import __version__
 from .. import target
 from ..core.session import Session
 from ..core.helpers import ConnectHelper
-from ..debug.svd import IS_CMSIS_SVD_AVAILABLE
 from ..gdbserver import GDBServer
 from ..utility.cmdline import (split_command_line, VECTOR_CATCH_CHAR_MAP, convert_vector_catch,
                                 convert_session_options)
@@ -240,15 +239,8 @@ class GDBServerTool(object):
                     'name' : name,
                     'part_number' : t.part_number,
                     }
-                if t._svd_location is not None and IS_CMSIS_SVD_AVAILABLE:
-                    if t._svd_location.is_local:
-                        svdPath = t._svd_location.filename
-                    else:
-                        resource = "data/{vendor}/{filename}".format(
-                            vendor=t._svd_location.vendor,
-                            filename=t._svd_location.filename
-                        )
-                        svdPath = pkg_resources.resource_filename("cmsis_svd", resource)
+                if t._svd_location is not None:
+                    svdPath = t._svd_location.filename
                     if os.path.exists(svdPath):
                         d['svd_path'] = svdPath
                 targets.append(d)

--- a/pyocd/tools/lists.py
+++ b/pyocd/tools/lists.py
@@ -21,7 +21,6 @@ from .. import __version__
 from ..core.session import Session
 from ..core.helpers import ConnectHelper
 from ..target import TARGET
-from ..debug.svd import IS_CMSIS_SVD_AVAILABLE
 from ..board.board_ids import BOARD_ID_TO_INFO
 from ..target.pack import pack_target
 
@@ -82,7 +81,7 @@ class ListGenerator(object):
             'status' : 0,
             'boards' : boards
             }
-    
+
         for board_id, info in BOARD_ID_TO_INFO.items():
             d = {
                 'id' : board_id,
@@ -91,7 +90,7 @@ class ListGenerator(object):
                 'binary' : info.binary,
                 }
             boards.append(d)
-    
+
         return obj
 
     @staticmethod
@@ -121,15 +120,8 @@ class ListGenerator(object):
                 'part_number' : t.part_number,
                 'source': 'pack' if hasattr(t, '_pack_device') else 'builtin',
                 }
-            if t._svd_location is not None and IS_CMSIS_SVD_AVAILABLE:
-                if t._svd_location.is_local:
-                    svdPath = t._svd_location.filename
-                else:
-                    resource = "data/{vendor}/{filename}".format(
-                        vendor=t._svd_location.vendor,
-                        filename=t._svd_location.filename
-                    )
-                    svdPath = pkg_resources.resource_filename("cmsis_svd", resource)
+            if t._svd_location is not None:
+                svdPath = t._svd_location.filename
                 if isinstance(svdPath, six.string_types) and os.path.exists(svdPath):
                     d['svd_path'] = svdPath
             targets.append(d)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@
 # limitations under the License.
 
 import sys
+import os
 from setuptools import setup, find_packages
+import zipfile
 
 open_args = { 'mode': 'r' }
 if sys.version_info[0] > 2:
@@ -87,5 +89,8 @@ setup(
     },
     packages=find_packages(),
     include_package_data=True,  # include files from MANIFEST.in
+    package_data={
+        'pyocd': ['debug/svd/svd_data.zip'],
+    },
     zip_safe=True,
 )


### PR DESCRIPTION
For quite a while, pyOCD has supported SVD files, if the cmsis-svd package was installed. The main feature this enables is the ability to read and write peripheral registers by name in pyocd commander. However, because cmsis-svd includes 823 MB of SVD data that most users wouldn't make use of, it was never made a standard requirement.

This PR brings the SVD parser and model classes from cmsis-svd directly into pyOCD so they are always available. It also includes the SVD data for most builtin targets as a single `pyocd/debug/svd/svd_data.zip` file. Thankfully, XML compresses so well that 136 MB of SVD files compresses at 95.9% to 5.6 MB. Of course, SVD is also supported for CMSIS-Pack targets.