### PR TITLE
Gracefully handle invalid CMSIS-Pack path with a warning

### DIFF
--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -25,6 +25,7 @@ from ..family import FAMILIES
 from .. import TARGET
 from ...core.coresight_target import CoreSightTarget
 from ...debug.svd.loader import SVDFile
+from ...utility.compatibility import FileNotFoundError_
 
 LOG = logging.getLogger(__name__)
 
@@ -127,7 +128,7 @@ def _create_targets_from_pack(pack_or_path):
                         "set_default_reset_type": _pack_target_set_default_reset_type,
                     })
             yield (dev.part_number, targetClass)
-    except MalformedCmsisPackError as err:
+    except (MalformedCmsisPackError, FileNotFoundError_) as err:
         LOG.warning(err)
         return
 

--- a/pyocd/utility/compatibility.py
+++ b/pyocd/utility/compatibility.py
@@ -62,8 +62,7 @@ else:
 
 # Make FileNotFoundError available to Python 2.x.
 if not PY3:
-    class FileNotFoundError(IOError):
-        pass
+    FileNotFoundError = IOError
 
 # Symbol to reference either the builtin FNF or our custom subclass.
 FileNotFoundError_ = FileNotFoundError


### PR DESCRIPTION
If you pass an invalid path to the `--pack` command line argument or `pack` user option, a warning will be logged but pyOCD won't exit.