### PR TITLE
Fix get_probe_with_id() for CMSIS-DAP

### DIFF
--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -77,7 +77,11 @@ class CMSISDAPProbe(DebugProbe):
     @classmethod
     def get_probe_with_id(cls, unique_id):
         try:
-            return cls(DAPAccess(unique_id))
+            dap_access = DAPAccess.get_device(unique_id)
+            if dap_access is not None:
+                return cls(dap_access)
+            else:
+                return None
         except DAPAccess.Error as exc:
             six.raise_from(cls._convert_exception(exc), exc)
 

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -466,7 +466,11 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     @staticmethod
     def get_device(device_id):
         assert isinstance(device_id, six.string_types)
-        return DAPAccessCMSISDAP(device_id)
+        iface = DAPAccessCMSISDAP._lookup_interface_for_unique_id(device_id)
+        if iface is not None:
+            return DAPAccessCMSISDAP(device_id, iface)
+        else:
+            return None
 
     @staticmethod
     def set_args(arg_list):
@@ -515,6 +519,8 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         # Search for a matching interface if one wasn't provided.
         if interface is None:
             interface = DAPAccessCMSISDAP._lookup_interface_for_unique_id(unique_id)
+            if interface is None:
+                raise self.DeviceError("no device with ID %s" % unique_id)
 
         if interface is not None:
             self._unique_id = _get_unique_id(interface)

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -34,7 +34,7 @@ class StlinkProbe(DebugProbe):
     def get_probe_with_id(cls, unique_id):
         for dev in STLinkUSBInterface.get_all_connected_devices():
             if dev.serial_number == unique_id:
-                return cls(STLinkUSBInterface(unique_id))
+                return cls(dev)
         else:
             return None
 


### PR DESCRIPTION
Calling `CMSISDAPProbe.get_probe_with_id()` would always return an object even if there was no matching probe. This also caused the same method on `DebugProbeAggregator` to always return a `CMSISDAPProbe` even if the ID only matched an STLink.

Underlying this was original behaviour of `DAPAccessCMSISDAP`, where you could create an instance with any unique ID. It would only fail when you called `open()`. This patch changes this behaviour so it fails early. Attempting to construct a `DAPAccessCMSISDAP` with an unique ID that does not match a CMSIS-DAP interface will cause a `DAPAccessIntf.DeviceError` to be raised.

Another problem was in `CMSISDAPProbe.get_probe_with_id()`, where it always returned an instance even for invalid IDs. This specific behaviour broke `DebugProbeAggregator`.

Closes #617 