### PR TITLE
gdbserver range step and a couple fixes

### DIFF
--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -241,8 +241,8 @@ class CoreSightTarget(Target, GraphNode):
     def halt(self):
         return self.selected_core.halt()
 
-    def step(self, disable_interrupts=True):
-        return self.selected_core.step(disable_interrupts)
+    def step(self, disable_interrupts=True, start=0, end=0):
+        return self.selected_core.step(disable_interrupts, start, end)
 
     def resume(self):
         return self.selected_core.resume()

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -147,7 +147,7 @@ class Target(MemoryInterface, Notifier):
     def halt(self):
         raise NotImplementedError()
 
-    def step(self, disable_interrupts=True):
+    def step(self, disable_interrupts=True, start=0, end=0):
         raise NotImplementedError()
 
     def resume(self):

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -760,7 +760,7 @@ class GDBServer(threading.Thread):
 
         # v_cont capabilities query.
         elif b'Cont?' == cmd:
-            return self.create_rsp_packet(b"v_cont;c;C;s;S;t")
+            return self.create_rsp_packet(b"vCont;c;C;s;S;t")
 
         # v_cont, thread action command.
         elif cmd.startswith(b'Cont'):

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -448,6 +448,7 @@ class GDBServer(threading.Thread):
                 self.log.info("One client connected!")
                 self._run_connection()
                 self.log.info("Client disconnected!")
+                self._cleanup_for_next_connection()
 
             except Exception as e:
                 self.log.error("Unexpected exception: %s", e)

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -736,10 +736,10 @@ class GDBServer(threading.Thread):
 
         return self.create_rsp_packet(val)
 
-    def step(self, data):
+    def step(self, data, start=0, end=0):
         addr = self._get_resume_step_addr(data)
-        self.log.debug("GDB step: %s", data)
-        self.target.step(not self.step_into_interrupt)
+        self.log.debug("GDB step: %s (start=0x%x, end=0x%x)", data, start, end)
+        self.target.step(not self.step_into_interrupt, start, end)
         return self.create_rsp_packet(self.get_t_response())
 
     def halt(self):
@@ -760,7 +760,7 @@ class GDBServer(threading.Thread):
 
         # v_cont capabilities query.
         elif b'Cont?' == cmd:
-            return self.create_rsp_packet(b"vCont;c;C;s;S;t")
+            return self.create_rsp_packet(b"vCont;c;C;s;S;r;t")
 
         # v_cont, thread action command.
         elif cmd.startswith(b'Cont'):
@@ -816,14 +816,19 @@ class GDBServer(threading.Thread):
                 return self.create_rsp_packet(b"OK")
             else:
                 return self.resume(None)
-        elif thread_actions[currentThread][0:1] in (b's', b'S'):
+        elif thread_actions[currentThread][0:1] in (b's', b'S', b'r'):
+            start = 0
+            end = 0
+            if thread_actions[currentThread][0:1] == b'r':
+                start, end = [int(addr, base=16) for addr in thread_actions[currentThread][1:].split(b',')]
+	
             if self.non_stop:
-                self.target.step(not self.step_into_interrupt)
+                self.target.step(not self.step_into_interrupt, start, end)
                 self.packet_io.send(self.create_rsp_packet(b"OK"))
                 self.send_stop_notification()
                 return None
             else:
-                return self.step(None)
+                return self.step(None, start, end)
         elif thread_actions[currentThread] == b't':
             # Must ignore t command in all-stop mode.
             if not self.non_stop:


### PR DESCRIPTION
This PR is an update of #329 that adds range step support to the gdbserver and Python API.

Also includes two fixes:
- Corrected response to the gdbserver `vCont?` command that was broken by search and replace back in the PEP8 rename. (Oddly, gdb still seemed to use `vCont` commands.)
- The gdbserver is cleaned up if the client disconnects (not detaches). The main impact is to detect the thread provider again on connect.