### PR TITLE
CMSIS-Pack target code refactoring

### DIFF
--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -275,7 +275,7 @@ class PyOCDTool(object):
         packParser.add_argument("-u", "--update", action='store_true',
             help="Update the pack index.")
         packParser.add_argument("-s", "--show", action='store_true',
-            help="Show the list of installed devices and packs.")
+            help="Show the list of installed packs.")
         packParser.add_argument("-f", "--find", dest="find_devices", metavar="GLOB", action='append',
             help="Look up a device part number in the index using a glob pattern. The pattern is "
                 "suffixed with '*'. Can be specified multiple times.")
@@ -590,12 +590,10 @@ class PyOCDTool(object):
             cache.cache_descriptors()
         
         if self._args.show:
-            devices = pack_target.get_supported_targets()
-            pt = self._get_pretty_table(["Part", "Vendor", "Pack", "Version"])
-            for info in devices:
-                ref, = cache.packs_for_devices([info])
+            packs = pack_target.ManagedPacks.get_installed_packs()
+            pt = self._get_pretty_table(["Vendor", "Pack", "Version"])
+            for ref in packs:
                 pt.add_row([
-                            info['name'],
                             ref.vendor,
                             ref.pack,
                             ref.version,

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -377,7 +377,7 @@ class PyOCDTool(object):
         elif self._args.targets:
             # Create targets from provided CMSIS pack.
             if ('pack' in session.options) and (session.options['pack'] is not None):
-                pack_target.populate_targets_from_pack(session.options['pack'])
+                pack_target.PackTargets.populate_targets_from_pack(session.options['pack'])
 
             obj = ListGenerator.list_targets()
             pt = self._get_pretty_table(["Name", "Vendor", "Part Number", "Families", "Source"])
@@ -423,7 +423,7 @@ class PyOCDTool(object):
         elif self._args.targets:
             # Create targets from provided CMSIS pack.
             if ('pack' in session.options) and (session.options['pack'] is not None):
-                pack_target.populate_targets_from_pack(session.options['pack'])
+                pack_target.PackTargets.populate_targets_from_pack(session.options['pack'])
 
             obj = ListGenerator.list_targets()
             print(json.dumps(obj, indent=4))

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -39,7 +39,7 @@ class Board(GraphNode):
         
         # Create targets from provided CMSIS pack.
         if ('pack' in session.options) and (session.options['pack'] is not None):
-            pack_target.populate_targets_from_pack(session.options['pack'])
+            pack_target.PackTargets.populate_targets_from_pack(session.options['pack'])
 
         # Create targets from the cmsis-pack-manager cache.
         if self._target_type not in TARGET:

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -43,7 +43,7 @@ class Board(GraphNode):
 
         # Create targets from the cmsis-pack-manager cache.
         if self._target_type not in TARGET:
-            pack_target.populate_target_from_cache(target)
+            pack_target.ManagedPacks.populate_target(target)
         
         # Create Target instance.
         try:

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -72,104 +72,126 @@ class ManagedPacks(object):
     def populate_target(device_name):
         """! @brief Add targets from cmsis-pack-manager matching the given name.
 
-        Targets are added to the `#TARGET` list.
+        Targets are added to the `#TARGET` list. A case-insensitive comparison against the
+        device part number is used to find the target to populate. If multiple packs are installed
+        that provide the same part numbers, all matching targets will be populated.
+        """
+        targets = ManagedPacks.get_installed_targets()
+        for dev in targets:
+            if device_name.lower() == dev.part_number.lower():
+                PackTargets.populate_device(dev)
+
+class _PackTargetMethods(object):
+    """! @brief Container for methods added to the dynamically generated pack target subclass."""
+
+    def _pack_target__init__(self, session):
+        """! @brief Constructor for dynamically created target class."""
+        super(self.__class__, self).__init__(session, self._pack_device.memory_map)
+
+        self.vendor = self._pack_device.vendor
+        self.part_families = self._pack_device.families
+        self.part_number = self._pack_device.part_number
+
+        self._svd_location = SVDFile(filename=self._pack_device.svd)
+
+    def _pack_target_create_init_sequence(self):
+        """! @brief Creates an init task to set the default reset type."""
+        seq = super(self.__class__,self).create_init_sequence()
+        seq.insert_after('create_cores',
+            ('set_default_reset_type', self.set_default_reset_type))
+        return seq
+
+    def _pack_target_set_default_reset_type(self):
+        """! @brief Set's the first core's default reset type to the one specified in the pack."""
+        if 0 in self.cores:
+            self.cores[0].default_reset_type = self._pack_device.default_reset_type
+
+class PackTargets(object):
+    """! @brief Namespace for CMSIS-Pack target generation utilities. """
+
+    @staticmethod
+    def _find_family_class(dev):
+        """! @brief Search the families list for matching entry."""
+        for familyInfo in FAMILIES:
+            # Skip if wrong vendor.
+            if dev.vendor != familyInfo.vendor:
+                continue
+
+            # Scan each level of families
+            for familyName in dev.families:
+                for regex in familyInfo.matches:
+                    # Require the regex to match the entire family name.
+                    match = regex.match(familyName)
+                    if match and match.span() == (0, len(familyName)):
+                        return familyInfo.klass
+        else:
+            # Default target superclass.
+            return CoreSightTarget
+
+    @staticmethod
+    def _generate_pack_target(dev):
+        """! @brief Generates a new.
+
+        The new target class is added to the `#TARGET` list.
+
+        @param dev A CmsisPackDevice object.
+        @return A new subclass of either CoreSightTarget or one of the family classes.
         """
         try:
-            cache = cmsis_pack_manager.Cache(True, True)
-            for name in cache.index.keys():
-                if name.lower() == device_name.lower():
-                    dev = cache.index[name]
-                    pack = cache.pack_from_cache(dev)
-                    populate_targets_from_pack(pack)
-        except FileNotFoundError:
-            # cmsis-pack-manager can raise this exception if the cache is empty.
-            pass
-
-def _pack_target__init__(self, session):
-    """! @brief Constructor for dynamically created target class."""
-    super(self.__class__, self).__init__(session, self._pack_device.memory_map)
-
-    self.vendor = self._pack_device.vendor
-    self.part_families = self._pack_device.families
-    self.part_number = self._pack_device.part_number
-
-    self._svd_location = SVDFile(filename=self._pack_device.svd)
-
-def _pack_target_create_init_sequence(self):
-    """! @brief Creates an init task to set the default reset type."""
-    seq = super(self.__class__,self).create_init_sequence()
-    seq.insert_after('create_cores',
-        ('set_default_reset_type', self.set_default_reset_type))
-    return seq
-
-def _pack_target_set_default_reset_type(self):
-    """! @brief Set's the first core's default reset type to the one specified in the pack."""
-    if 0 in self.cores:
-        self.cores[0].default_reset_type = self._pack_device.default_reset_type
-
-def _find_family_class(dev):
-    """! @brief Search the families list for matching entry."""
-    for familyInfo in FAMILIES:
-        # Skip if wrong vendor.
-        if dev.vendor != familyInfo.vendor:
-            continue
-
-        # Scan each level of families
-        for familyName in dev.families:
-            for regex in familyInfo.matches:
-                # Require the regex to match the entire family name.
-                match = regex.match(familyName)
-                if match and match.span() == (0, len(familyName)):
-                    return familyInfo.klass
-    else:
-        # Default target superclass.
-        return CoreSightTarget
-
-def _create_targets_from_pack(pack_or_path):
-    """! @brief Iterator yielding parsed targets for all devices defined by the given pack.
-
-    @param pack_or_path May be a string which is a path to a .pack file, a file object, or
-        a ZipFile instance.
-    @return Each yielded result is a 2-tuple of the target's part number string, plus a
-        dynamically created subclass of CmsisPackTarget for the target.
-    """
-    try:
-        if isinstance(pack_or_path, six.string_types):
-            LOG.info("Loading CMSIS-Pack: %s", pack_or_path)
-        pack = CmsisPack(pack_or_path)
-        for dev in pack.devices:
             # Look up the target family superclass.
-            superklass = _find_family_class(dev)
+            superklass = PackTargets._find_family_class(dev)
 
-            # Replace spaces with underscores on the target class name.
-            subclassName = dev.part_number.replace(' ', '_')
+            # Replace spaces and dashes with underscores on the new target subclass name.
+            subclassName = dev.part_number.replace(' ', '_').replace('-', '_')
 
             # Create a new subclass for this target.
-            targetClass = type(dev.part_number, (superklass,), {
+            targetClass = type(subclassName, (superklass,), {
                         "_pack_device": dev,
-                        "__init__": _pack_target__init__,
-                        "create_init_sequence": _pack_target_create_init_sequence,
-                        "set_default_reset_type": _pack_target_set_default_reset_type,
+                        "__init__": _PackTargetMethods._pack_target__init__,
+                        "create_init_sequence": _PackTargetMethods._pack_target_create_init_sequence,
+                        "set_default_reset_type": _PackTargetMethods._pack_target_set_default_reset_type,
                     })
-            yield (dev.part_number, targetClass)
-    except (MalformedCmsisPackError, FileNotFoundError_) as err:
-        LOG.warning(err)
-        return
+            return targetClass
+        except (MalformedCmsisPackError, FileNotFoundError_) as err:
+            LOG.warning(err)
+            return None
 
-def populate_targets_from_pack(pack_list):
-    """! @brief Adds targets defined in the provided CMSIS-Pack.
+    @staticmethod
+    def populate_device(dev):
+        """! @brief Generates and populates the target defined by a CmsisPackDevice.
 
-    Targets are added to the `#TARGET` list.
+        The new target class is added to the `#TARGET` list.
 
-    @param pack_list Sequence of strings that are paths to .pack files, file objects, or
-        ZipFile instances. May also be a single object of one of the accepted types.
-    """
-    if not isinstance(pack_list, (list, tuple)):
-        pack_list = [pack_list]
-    for pack_or_path in pack_list:
-        for part, tgt in _create_targets_from_pack(pack_or_path):
-            part = part.lower()
+        @param dev A CmsisPackDevice object.
+        """
+        try:
+            tgt = PackTargets._generate_pack_target(dev)
+            if tgt is None:
+                return
+            part = dev.part_number.lower()
 
             # Make sure there isn't a duplicate target name.
             if part not in TARGET:
                 TARGET[part] = tgt
+        except (MalformedCmsisPackError, FileNotFoundError_) as err:
+            LOG.warning(err)
+
+    @staticmethod
+    def populate_targets_from_pack(pack_list):
+        """! @brief Adds targets defined in the provided CMSIS-Pack.
+
+        Targets are added to the `#TARGET` list.
+
+        @param pack_list Sequence of strings that are paths to .pack files, file objects,
+            ZipFile instances, or CmsisPack instance. May also be a single object of one of
+            the accepted types.
+        """
+        if not isinstance(pack_list, (list, tuple)):
+            pack_list = [pack_list]
+        for pack_or_path in pack_list:
+            if isinstance(pack_or_path, six.string_types):
+                LOG.info("Loading CMSIS-Pack: %s", pack_or_path)
+            if not isinstane(pack_or_path, CmsisPack):
+                pack = CmsisPack(pack_or_path)
+            for dev in pack.devices:
+                PackTargets.populate_device(dev)

--- a/pyocd/tools/lists.py
+++ b/pyocd/tools/lists.py
@@ -127,18 +127,13 @@ class ListGenerator(object):
             targets.append(d)
         
         # Add targets from cmsis-pack-manager cache.
-        for dev in pack_target.get_supported_targets():
+        for dev in pack_target.ManagedPacks.get_installed_targets():
             try:
-                if 'vendor' in dev:
-                    vendor = dev['vendor'].split(':')[0]
-                else:
-                    vendor = dev['from_pack']['vendor']
-            
                 targets.append({
-                    'name' : dev['name'].lower(),
-                    'part_families' : [],
-                    'part_number' : dev['name'],
-                    'vendor' : vendor,
+                    'name' : dev.part_number.lower(),
+                    'part_families' : dev.families,
+                    'part_number' : dev.part_number,
+                    'vendor' : dev.vendor,
                     'source' : 'pack',
                     })
             except KeyError:


### PR DESCRIPTION
The main purpose of these changes is twofold: support listing installed managed packs, and support managed targets with a name coming from the `Dname` attribute. The latter opens up a wider set of part numbers for managed pack targets.

As part of this change, the `pyocd pack --show` command now only reports the installed packs, not targets of installed packs. You can see that with `pyocd list --targets`. Also, family information is displayed for the targets list for managed pack targets.