### PR TITLE
STLink auto-detect code cleanup

### DIFF
--- a/pyocd/probe/stlink/detect/base.py
+++ b/pyocd/probe/stlink/detect/base.py
@@ -58,7 +58,6 @@ class StlinkDetectBase(object):
         """
         platform_count = {}
         candidates = list(self.find_candidates())
-        logger.debug("Candidates for display %r", candidates)
         result = []
         for device in candidates:
             if not device.get("mount_point", None):
@@ -97,11 +96,6 @@ class StlinkDetectBase(object):
         """
         htm_target_id, daplink_info = self._read_htm_ids(device["mount_point"])
         if htm_target_id:
-            logger.debug(
-                "Found htm target id, %s, for usb target id %s",
-                htm_target_id,
-                device["target_id_usb_id"],
-            )
             device["target_id"] = htm_target_id
         else:
             logger.debug(
@@ -139,13 +133,11 @@ class StlinkDetectBase(object):
         m = re.search("\\?code=([a-fA-F0-9]+)", line)
         if m:
             result = m.groups()[0]
-            logger.debug("Found target id %s in htm line %s", result, line)
             return result
         # Last resort, we can try to see if old mbed.htm format is there
         m = re.search("\\?auth=([a-fA-F0-9]+)", line)
         if m:
             result = m.groups()[0]
-            logger.debug("Found target id %s in htm line %s", result, line)
             return result
 
         return None

--- a/pyocd/probe/stlink/detect/linux.py
+++ b/pyocd/probe/stlink/detect/linux.py
@@ -15,14 +15,12 @@
 
 import re
 import os
+import logging
 
 from .base import StlinkDetectBase
 
-import logging
-
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
-del logging
 
 SYSFS_BLOCK_DEVICE_PATH = "/sys/class/block"
 
@@ -49,15 +47,12 @@ class StlinkDetectLinuxGeneric(StlinkDetectBase):
 
     def find_candidates(self):
         disk_ids = self._dev_by_id("disk")
-#         serial_ids = self._dev_by_id("serial")
         mount_ids = dict(self._fat_mounts())
         usb_info = self._sysfs_block_devices(disk_ids.values())
-        logger.debug("Mount mapping %r", mount_ids)
 
         return [
             {
                 "mount_point": mount_ids.get(disk_dev),
-#                 "serial_port": serial_ids.get(disk_uuid),
                 "target_id_usb_id": disk_uuid,
                 "vendor_id": usb_info.get(disk_dev, {}).get("vendor_id"),
                 "product_id": usb_info.get(disk_dev, {}).get("product_id"),
@@ -76,7 +71,6 @@ class StlinkDetectLinuxGeneric(StlinkDetectBase):
             to_ret = dict(
                 self._hex_ids([os.path.join(dir, f) for f in os.listdir(dir)])
             )
-            logger.debug("Found %s devices by id %r", device_type, to_ret)
             return to_ret
         else:
             logger.error(
@@ -110,7 +104,6 @@ class StlinkDetectLinuxGeneric(StlinkDetectBase):
         @details Uses regular expressions to get a USBID (TargeTIDs) a "by-id"
           symbolic link
         """
-        logger.debug("Converting device list %r", dev_list)
         for dl in dev_list:
             match = self.nlp.search(dl)
             if match:

--- a/pyocd/probe/stlink/detect/windows.py
+++ b/pyocd/probe/stlink/detect/windows.py
@@ -17,15 +17,12 @@ import re
 import sys
 from collections import defaultdict
 from copy import copy
+import logging
 
 from .base import StlinkDetectBase
 
-import logging
-
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
-DEBUG = logging.DEBUG
-del logging
 
 if sys.version_info[0] < 3:
     import _winreg as winreg
@@ -36,10 +33,6 @@ else:
 MAX_COMPOSITE_DEVICE_SUBDEVICES = 5
 MBED_STORAGE_DEVICE_VENDOR_STRINGS = [
     "ven_mbed",
-    "ven_segger",
-    "ven_arm_v2m",
-    "ven_nxp",
-    "ven_atmel",
 ]
 
 
@@ -95,9 +88,6 @@ def _get_cached_mounted_points():
                 continue
 
             mount_point = mount_point_match.group(1)
-            logger.debug(
-                "Mount point %s found for volume %s", mount_point, volume_string
-            )
 
             result.append({"mount_point": mount_point, "volume_string": volume_string})
     except OSError:
@@ -236,7 +226,6 @@ def _iter_keys(key):
 def _iter_vals(key):
     """! Iterate over values of a key
     """
-    logger.debug("_iter_vals %r", key)
     for i in range(winreg.QueryInfoKey(key)[1]):
         yield winreg.EnumValue(key, i)
 
@@ -365,12 +354,6 @@ class MbedLsToolsWindows(StlinkDetectBase):
                     if any(
                         e.startswith(new_entry_key_string) for e in entry_key_strings
                     ):
-                        logger.debug(
-                            "Assigning new entry key string of %s to device %s, "
-                            "as found in ParentIdPrefix",
-                            new_entry_key_string,
-                            target_id_usb_id,
-                        )
                         entry_key_string = new_entry_key_string
                         is_prefix = True
                 except OSError:
@@ -503,14 +486,5 @@ class MbedLsToolsWindows(StlinkDetectBase):
         """
         stdout, stderr, retcode = self._run_cli_process("dir %s" % path)
         result = True if retcode == 0 else False
-
-        if result:
-            logger.debug("Mount point %s is ready", path)
-        else:
-            logger.debug(
-                "Mount point %s reported not ready with error '%s'",
-                path,
-                stderr.strip(),
-            )
 
         return result

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -94,7 +94,7 @@ class StlinkProbe(DebugProbe):
 
     def create_associated_board(self, session):
         if self._mbed_info:
-            return MbedBoard(session, board_id=self._mbed_info['target_id_mbed_htm'][0:4])
+            return MbedBoard(session, board_id=self._board_id)
         else:
             return None
     


### PR DESCRIPTION
This change set removes more unnecessary code from the `pyocd.probe.stlink.detect` module. It also removes a large number of debug logs.