### PR TITLE
Several pack targets fixes

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -2,9 +2,9 @@ output*.txt
 gdb_test_raw*.txt
 test_params*.txt
 test_results*.txt
-automated_test_results*.txt
-automated_test_summary.txt
-test_results.xml
+automated_test_result*.txt
+automated_test_summary*.txt
+test_results*.xml
 pyocd.yaml
 
 

--- a/test/gdb_test.py
+++ b/test/gdb_test.py
@@ -142,7 +142,6 @@ def test_gdb(board_id=None, n=0):
                 "--telnet-port=%i" % telnet_port,
                 "--frequency=%i" % target_test_params['test_clock'],
                 "--uid=%s" % board_id,
-                '-Oboard_config_file=test_boards.json'
                 ]
         server = PyOCDTool()
         server.run(args)

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
 envlist = py27,py37
 
+# Defaults for all test environments.
 [testenv]
 deps = pytest
 changedir = test
+passenv = CI_JOBS
 commands =
     python automated_test.py -j4 -q
 


### PR DESCRIPTION
- Fixed typo in `PackTargets.populate_targets_from_pack()`.
- Changed pack target loading log messages to be the same for both managed and explicit packs.
- Made methods in `_PackTargetMethods` static. This fixes an error that occurs only with Python 2.7, where it required the type of 'self' to be `_PackTargetMethods`.
- Some other cleanup.

Also included are some automated test improvements to work better with tox.

Closes #634 