### PR TITLE
Exception related improvements

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,8 @@ frequency: 8000000 # Set 8 MHz SWD default for all probes
 
 - `debug.log_flm_info`: (bool) Log details of loaded .FLM flash algos.
 
+- `debug.traceback`: (bool) Print tracebacks for exceptions.
+
 - `enable_multicore_debug`: (bool) Whether to put pyOCD into multicore debug mode. The primary effect
     is to modify the default software reset type for secondary cores to use VECTRESET, which will
     fall back to emulated reset if the secondary core is not v7-M.

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -31,6 +31,7 @@ import cmsis_pack_manager
 from . import __version__
 from .core.session import Session
 from .core.helpers import ConnectHelper
+from .core import exceptions
 from .target import TARGET
 from .target.pack import pack_target
 from .gdbserver import GDBServer
@@ -332,8 +333,10 @@ class PyOCDTool(object):
             return 0
         except KeyboardInterrupt:
             return 0
+        except exceptions.Error as e:
+            LOG.error(e, exc_info=Session.get_current().log_tracebacks)
         except Exception as e:
-            LOG.error("uncaught exception: %s", e, exc_info=True)
+            LOG.error("uncaught exception: %s", e, exc_info=Session.get_current().log_tracebacks)
             return 1
     
     def show_options_help(self):

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -94,7 +94,7 @@ class Board(GraphNode):
                 self.target.disconnect(resume)
                 self._inited = False
             except:
-                log.error("link exception during target disconnect:", exc_info=True)
+                log.error("link exception during target disconnect:", exc_info=self._session.log_tracebacks)
 
     @property
     def session(self):

--- a/pyocd/board/mbed_board.py
+++ b/pyocd/board/mbed_board.py
@@ -62,7 +62,7 @@ class MbedBoard(Board):
             # If there still isn't a known target, tell the user about it. Leaving target
             # set to None will cause cortex_m to be selected by the Board ctor.
             if target is None:
-                LOG.warning("Board ID %s is not recognized; you will be able to use pyOCD but not program flash.", board_id)
+                LOG.warning("Board ID %s is not recognized, using generic cortex_m target.", board_id)
 
         super(MbedBoard, self).__init__(session, target)
 

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -229,7 +229,7 @@ class CoreSightTarget(Target, GraphNode):
             if self.session.options.get('allow_no_cores', False):
                 logging.error("No cores were discovered!")
             else:
-                raise exceptions.Error("No cores were discovered!")
+                raise exceptions.DebugError("No cores were discovered!")
 
     def disconnect(self, resume=True):
         self.notify(Notification(event=Target.EVENT_PRE_DISCONNECT, source=self))

--- a/pyocd/core/exceptions.py
+++ b/pyocd/core/exceptions.py
@@ -18,11 +18,27 @@ class Error(RuntimeError):
     """! @brief Parent of all errors pyOCD can raise"""
     pass
 
-class ProbeError(Error):
-    """! @brief Error communicating with device"""
+class TargetSupportError(Error):
+    """! @brief Error related to target support"""
     pass
 
-class TransferError(ProbeError):
+class ProbeError(Error):
+    """! @brief Error communicating with the debug probe"""
+    pass
+
+class ProbeDisconnected(ProbeError):
+    """! @brief The connection to the debug probe was lost"""
+    pass
+
+class TargetError(Error):
+    """! @brief An error that happens on the target"""
+    pass
+
+class DebugError(TargetError):
+    """! @brief Error controlling target debug resources"""
+    pass
+
+class TransferError(DebugError):
     """! @brief Error ocurred with a transfer over SWD or JTAG"""
     pass
 
@@ -65,7 +81,7 @@ class TransferFaultError(TransferError):
                 desc += "-0x%08x" % self.fault_end_address
         return desc
   
-class FlashFailure(RuntimeError):
+class FlashFailure(TargetError):
     """! @brief Exception raised when flashing fails for some reason. """
     def __init__(self, msg, address=None, result_code=None):
         super(FlashFailure, self).__init__(msg)

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -25,6 +25,7 @@ OPTIONS_INFO = {
     'chip_erase': OptionInfo('chip_erase', str, "Whether to perform a chip erase or sector erases when programming flash."),
     'config_file': OptionInfo('config_file', str, "Path to custom config file."),
     'debug.log_flm_info': OptionInfo('debug.log_flm_info', bool, "Log details of loaded .FLM flash algos."),
+    'debug.traceback': OptionInfo('debug.traceback', bool, "Print tracebacks for exceptions."),
     'enable_multicore_debug': OptionInfo('enable_multicore', bool, "Whether to put pyOCD into multicore debug mode."),
     'fast_program': OptionInfo('fast_program', str, "Setting this option to True will use CRC checks of existing flash sector contents to determine whether pages need to be programmed."),
     'frequency': OptionInfo('frequency', int, "SWD/JTAG frequency in Hertz."),

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -79,7 +79,11 @@ class Session(object):
     
     @classmethod
     def get_current(cls):
-        """! @brief Return the most recently created Session instance.
+        """! @brief Return the most recently created Session instance or a default Session.
+        
+        By default this method will return the most recently created Session object that is
+        still alive. If no live session exists, a new default session will be created and returned.
+        That at least provides access to the user's config file(s).
         
         Used primarily so code that doesn't have a session reference can access user options. This
         method should only be used to access options that are unlikely to differ between sessions,
@@ -88,7 +92,7 @@ class Session(object):
         if cls._current_session is not None:
             return cls._current_session()
         else:
-            return None
+            return Session(None)
 
     ## @brief Session constructor.
     #
@@ -218,6 +222,11 @@ class Session(object):
     @property
     def user_script_proxy(self):
         return self._user_script_proxy
+    
+    @property
+    def log_tracebacks(self):
+        """! @brief Quick access to debug.traceback option since it is widely used."""
+        return self._options.get('debug.traceback', True)
 
     def __enter__(self):
         assert self._probe is not None
@@ -317,17 +326,17 @@ class Session(object):
                 self.board.uninit()
                 self._inited = False
             except:
-                LOG.error("exception during board uninit:", exc_info=True)
+                LOG.error("exception during board uninit:", exc_info=self.log_tracebacks)
         
         if self._probe.is_open:
             try:
                 self._probe.disconnect()
             except:
-                LOG.error("probe exception during disconnect:", exc_info=True)
+                LOG.error("probe exception during disconnect:", exc_info=self.log_tracebacks)
             try:
                 self._probe.close()
             except:
-                LOG.error("probe exception during close:", exc_info=True)
+                LOG.error("probe exception during close:", exc_info=self.log_tracebacks)
 
 class UserScriptFunctionProxy(object):
     """! @brief Proxy for user script functions.

--- a/pyocd/coresight/itm.py
+++ b/pyocd/coresight/itm.py
@@ -80,7 +80,7 @@ class ITM(CoreSightComponent):
             self.ap.write32(self.address + ITM.LAR, ITM.LAR_KEY)
             val = self.ap.read32(self.address + ITM.LSR)
             if val & ITM.LSR_SLK_MASK:
-                raise exceptions.Error("Failed to unlock ITM")
+                raise exceptions.DebugError("Failed to unlock ITM")
         
         # Disable the ITM until enabled.
         self.disable()

--- a/pyocd/debug/cache.py
+++ b/pyocd/debug/cache.py
@@ -23,12 +23,13 @@ from ..coresight.cortex_m import (
     is_psr_subregister,
     sysm_to_psr_mask
 )
+from ..core import exceptions
 from ..utility import conversion
 from intervaltree import (Interval, IntervalTree)
 import logging
 
 ## @brief Generic failure to access memory.
-class MemoryAccessError(RuntimeError):
+class MemoryAccessError(exceptions.Error):
     pass
 
 ## @brief Holds hit ratio metrics for the caches.

--- a/pyocd/debug/semihost.py
+++ b/pyocd/debug/semihost.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2015 Arm Limited
+# Copyright (c) 2015-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,10 +20,9 @@ import io
 import logging
 import time
 import datetime
-import traceback
 import six
 import pyocd
-from ..core import exceptions
+from ..core import (exceptions, session)
 
 # Debug logging options
 LOG_SEMIHOST = True
@@ -189,8 +188,7 @@ class InternalSemihostIOHandler(SemihostIOHandler):
             return fd
         except IOError as e:
             self._errno = e.errno
-            logging.error("Semihost: failed to open file '%s'", filename)
-            traceback.print_exc()
+            logging.error("Semihost: failed to open file '%s'", filename, exc_info=session.Session.get_current().log_tracebacks)
             return -1
 
     def close(self, fd):
@@ -439,8 +437,8 @@ class SemihostAgent(object):
                 logging.warning("Semihost: unimplemented request pc=%x r0=%x r1=%x", pc, op, args)
                 result = -1
             except Exception as e:
-                logging.warning("Exception while handling semihost request: %s", e)
-                traceback.print_exc(e)
+                logging.warning("Exception while handling semihost request: %s", e,
+                    exc_info=session.Session.get_current().log_tracebacks)
                 result = -1
         else:
             result = -1

--- a/pyocd/flash/flash_builder.py
+++ b/pyocd/flash/flash_builder.py
@@ -180,6 +180,10 @@ class FlashBuilder(object):
         @param addr Base address of the block of data passed to this method. The entire block of
             data must be contained within the flash memory region associated with this instance.
         @param data Data to be programmed. Should be a list of byte values.
+        
+        @exception FlashFailure Address range of added data is outside the address range of the
+            flash region associated with the builder.
+        @exception ValueError Attempt to add overlapping data.
         """
         # Ignore empty data.
         if len(data) == 0:
@@ -225,6 +229,8 @@ class FlashBuilder(object):
         @param keep_unwritten If true, unwritten pages in an erased sector and unwritten
             contents of a modified page will be read from the target and added to the data to be
             programmed.
+
+        @exception FlashFailure Could not get sector or page info for an address.
         """
         assert len(self.flash_operation_list) > 0
         

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -35,7 +35,6 @@ import logging, threading, socket
 from struct import unpack
 from time import (sleep, time)
 import sys
-import traceback
 import six
 from six.moves import queue
 from xml.etree.ElementTree import (Element, SubElement, tostring)
@@ -451,8 +450,7 @@ class GDBServer(threading.Thread):
                 self._cleanup_for_next_connection()
 
             except Exception as e:
-                self.log.error("Unexpected exception: %s", e)
-                traceback.print_exc()
+                self.log.error("Unexpected exception: %s", e, exc_info=self.session.log_tracebacks)
 
     def _run_connection(self):
         while True:
@@ -480,8 +478,7 @@ class GDBServer(threading.Thread):
                             self.is_target_running = False
                             self.send_stop_notification()
                     except Exception as e:
-                        self.log.error("Unexpected exception: %s", e)
-                        traceback.print_exc()
+                        self.log.error("Unexpected exception: %s", e, exc_info=self.session.log_tracebacks)
 
                 # read command
                 try:
@@ -520,8 +517,7 @@ class GDBServer(threading.Thread):
                             return
 
             except Exception as e:
-                self.log.error("Unexpected exception: %s", e)
-                traceback.print_exc()
+                self.log.error("Unexpected exception: %s", e, exc_info=self.session.log_tracebacks)
 
     def handle_message(self, msg):
         try:
@@ -541,8 +537,7 @@ class GDBServer(threading.Thread):
             return reply, detach
 
         except Exception as e:
-            self.log.error("Unhandled exception in handle_message: %s", e)
-            traceback.print_exc()
+            self.log.error("Unhandled exception in handle_message: %s", e, exc_info=self.session.log_tracebacks)
             return self.create_rsp_packet(b"E01"), 0
 
     def extended_remote(self):
@@ -730,8 +725,7 @@ class GDBServer(threading.Thread):
                     self.target.halt()
                 except:
                     pass
-                traceback.print_exc()
-                self.log.debug('Target is unavailable temporarily.')
+                self.log.warning('Exception while target was running: %s', e, exc_info=self.session.log_tracebacks)
                 val = ('S%02x' % self.target_facade.get_signal_value()).encode()
                 break
 
@@ -1066,8 +1060,7 @@ class GDBServer(threading.Thread):
                     self.thread_provider = rtos
                     break
             except RuntimeError as e:
-                self.log.error("Error during symbol lookup: " + str(e))
-                traceback.print_exc()
+                self.log.error("Error during symbol lookup: " + str(e), exc_info=self.session.log_tracebacks)
 
         self.did_init_thread_providers = True
 

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -410,7 +410,7 @@ class CMSISDAPProbe(DebugProbe):
         elif isinstance(exc, (DAPAccess.DeviceError, DAPAccess.CommandError)):
             return exceptions.ProbeError(str(exc))
         elif isinstance(exc, DAPAccess.Error):
-            return exceptions.PyOCDError(str(exc))
+            return exceptions.Error(str(exc))
         else:
             return exc
 

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -28,6 +28,7 @@ from .cmsis_dap_core import (Command, Pin, Capabilities, DAP_TRANSFER_OK,
                              DAP_TRANSFER_FAULT, DAP_TRANSFER_WAIT,
                              DAPSWOTransport, DAPSWOMode, DAPSWOControl,
                              DAPSWOStatus)
+from ...core import session
 
 # CMSIS-DAP values
 AP_ACC = 1 << 0
@@ -460,7 +461,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
                 all_daplinks.append(new_daplink)
             except DAPAccessIntf.TransferError:
                 logger = logging.getLogger(__name__)
-                logger.error('Failed to get unique id', exc_info=True)
+                logger.error('Failed to get unique id', exc_info=session.Session.get_current().log_tracebacks)
         return all_daplinks
 
     @staticmethod
@@ -506,7 +507,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
                     result_interface = interface
             except Exception:
                 logger = logging.getLogger(__name__)
-                logger.error('Failed to get unique id for open', exc_info=True)
+                logger.error('Failed to get unique id for open', exc_info=session.Session.get_current().log_tracebacks)
         return result_interface
 
     # ------------------------------------------- #

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -32,7 +32,7 @@ from ...core.memory_map import (MemoryMap, MemoryType, MEMORY_TYPE_CLASS_MAP, Fl
 
 LOG = logging.getLogger(__name__)
 
-class MalformedCmsisPackError(exceptions.Error):
+class MalformedCmsisPackError(exceptions.TargetSupportError):
     """! @brief Exception raised for errors parsing a CMSIS-Pack."""
     pass
 

--- a/pyocd/target/pack/flash_algo.py
+++ b/pyocd/target/pack/flash_algo.py
@@ -30,7 +30,7 @@ LOG = logging.getLogger(__name__)
 
 FLASH_ALGO_STACK_SIZE = 512
 
-class FlashAlgoException(exceptions.Error):
+class FlashAlgoException(exceptions.TargetSupportError):
     """! @brief Exception class for errors parsing an FLM file."""
     pass
 

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 import sys
 import os
 import logging
-import traceback
 import argparse
 import json
 import pkg_resources
@@ -300,8 +299,7 @@ class GDBServerTool(object):
                 for gdb in gdbs:
                     gdb.stop()
             except Exception as e:
-                print("uncaught exception: %s" % e)
-                traceback.print_exc()
+                logging.error("uncaught exception: %s" % e, exc_info=Session.get_current().log_tracebacks)
                 for gdb in gdbs:
                     gdb.stop()
                 return 1

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -22,7 +22,6 @@ import os
 import sys
 import optparse
 from optparse import make_option
-import traceback
 import six
 import prettytable
 
@@ -35,7 +34,7 @@ except ImportError:
 from .. import __version__
 from .. import (utility, coresight)
 from ..core.helpers import ConnectHelper
-from ..core import exceptions
+from ..core import (exceptions, session)
 from ..target.family import target_kinetis
 from ..probe.pydapaccess import DAPAccess
 from ..probe.debug_probe import DebugProbe
@@ -467,17 +466,20 @@ class PyOCDConsole(object):
             handler(args)
         except ValueError:
             print("Error: invalid argument")
-            traceback.print_exc()
+            if session.Session.get_current().log_tracebacks:
+                traceback.print_exc()
         except exceptions.TransferError as e:
             print("Error:", e)
-            traceback.print_exc()
+            if session.Session.get_current().log_tracebacks:
+                traceback.print_exc()
         except ToolError as e:
             print("Error:", e)
         except ToolExitException:
             raise
         except Exception as e:
             print("Unexpected exception:", e)
-            traceback.print_exc()
+            if session.Session.get_current().log_tracebacks:
+                traceback.print_exc()
 
 class PyOCDCommander(object):
     def __init__(self, args, cmds=None):
@@ -654,10 +656,12 @@ class PyOCDCommander(object):
             self.exit_code = 0
         except ValueError:
             print("Error: invalid argument")
-            traceback.print_exc()
+            if session.Session.get_current().log_tracebacks:
+                traceback.print_exc()
         except exceptions.TransferError:
             print("Error: transfer failed")
-            traceback.print_exc()
+            if session.Session.get_current().log_tracebacks:
+                traceback.print_exc()
             self.exit_code = 2
         except ToolError as e:
             print("Error:", e)
@@ -697,12 +701,14 @@ class PyOCDCommander(object):
         except exceptions.TransferFaultError as e:
             if not self.board.target.is_locked():
                 print("Transfer fault while initing board: %s" % e)
-                traceback.print_exc()
+                if session.Session.get_current().log_tracebacks:
+                    traceback.print_exc()
                 self.exit_code = 1
                 return False
         except Exception as e:
             print("Exception while initing board: %s" % e)
-            traceback.print_exc()
+            if session.Session.get_current().log_tracebacks:
+                traceback.print_exc()
             self.exit_code = 1
             return False
 
@@ -1148,7 +1154,8 @@ class PyOCDCommander(object):
                     print(result)
         except Exception as e:
             print("Exception while executing expression:", e)
-            traceback.print_exc()
+            if session.Session.get_current().log_tracebacks:
+                traceback.print_exc()
 
     def handle_core(self, args):
         if len(args) < 1:


### PR DESCRIPTION
Three parts to this PR:

1. The pyOCD exception hierarchy is cleaned up a bit. There are new `TargetSupportError`, `TargetError`, and `DebugError` exception classes. And a few misc classes were brought into the hierarchy.
2. When the target type defaults to `cortex_m`, a helpful message is logged as a warning to informs the user that they can debug but not program flash, and how to set the target type. Not noticing this was a frequent cause of error reports and confusion.
3. A `debug.traceback` user option was added that lets the user control whether tracebacks are logged for exceptions. The default is currently True, so pyOCD's behaviour does not change. But the default will be set to False at some point.