### PR TITLE
Fix STLink auto-detection on Windows

### DIFF
--- a/pyocd/probe/stlink/detect/windows.py
+++ b/pyocd/probe/stlink/detect/windows.py
@@ -234,7 +234,7 @@ class CompatibleIDsNotFoundException(Exception):
     pass
 
 
-class MbedLsToolsWindows(StlinkDetectBase):
+class StlinkDetectWindows(StlinkDetectBase):
     """ mbed-enabled platform detection for Windows
     """
 


### PR DESCRIPTION
Fixed for the failure to rename `MbedLsToolsWindows` class to `StlinkDetectWindows` as expected in other parts of the code.
