### PR TITLE
Breakpoint manager optimization

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,9 +156,6 @@ These session options are currently only applied when running the GDB server.
     are only served on localhost, making them inaccessible across the network. If False, you can
     connect to these ports from any machine that is on the same network. Default is True.
 
-- `soft_bkpt_as_hard`: (bool) Whether to force all breakpoints to be hardware breakpoints. Default
-    is False.
-
 - `step_into_interrupt`: (bool) Set this option to True to enable interrupts when performing step
     operations. Otherwise interrupts will be disabled and step operations cannot be interrupted.
     Default is False.

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -51,7 +51,6 @@ OPTIONS_INFO = {
     'semihost_console_type': OptionInfo('semihost_console_type', str, "If set to \"telnet\" then the semihosting telnet server will be started, otherwise semihosting will print to the console."),
     'semihost_use_syscalls': OptionInfo('semihost_use_syscalls', str, "Whether to use GDB syscalls for semihosting file access operations."),
     'serve_local_only': OptionInfo('serve_local_only', str, "When this option is True, the GDB server and semihosting telnet ports are only served on localhost."),
-    'soft_bkpt_as_hard': OptionInfo('soft_bkpt_as_hard', str, "Whether to force all breakpoints to be hardware breakpoints."),
     'step_into_interrupt': OptionInfo('step_into_interrupt', str, "Enable interrupts when performing step operations."),
     'swv_clock': OptionInfo('swv_clock', int, "Frequency in Hertz of the SWO baud rate. Default is 1 MHz."),
     'swv_system_clock': OptionInfo('swv_system_clock', int, "Frequency in Hertz of the target's system clock. Used to compute the SWO baud rate divider. No default."),

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -430,7 +430,7 @@ class CortexM(Target, CoreSightComponent):
         # Set up breakpoints manager.
         self.sw_bp = SoftwareBreakpointProvider(self)
         self.bp_manager = BreakpointManager(self)
-        self.bp_manager.add_provider(self.sw_bp, Target.BREAKPOINT_SW)
+        self.bp_manager.add_provider(self.sw_bp)
 
     ## @brief Connect related CoreSight components.
     def add_child(self, cmp):
@@ -438,7 +438,7 @@ class CortexM(Target, CoreSightComponent):
         
         if isinstance(cmp, FPB):
             self.fpb = cmp
-            self.bp_manager.add_provider(cmp, Target.BREAKPOINT_HW)
+            self.bp_manager.add_provider(cmp)
         elif isinstance(cmp, DWT):
             self.dwt = cmp
 

--- a/pyocd/coresight/dwt.py
+++ b/pyocd/coresight/dwt.py
@@ -155,7 +155,7 @@ class DWT(CoreSightComponent):
                 self.watchpoint_used += 1
                 return True
 
-        logging.error('No more available watchpoint!!, dropped watch at 0x%X', addr)
+        logging.error('No more watchpoints are available, dropped watchpoint at 0x%08x', addr)
         return False
 
     ## @brief Remove a hardware watchpoint.

--- a/pyocd/coresight/fpb.py
+++ b/pyocd/coresight/fpb.py
@@ -72,6 +72,7 @@ class FPB(BreakpointProvider, CoreSightComponent):
         for bp in self.hw_breakpoints:
             self.ap.write_memory(bp.comp_register_addr, 0)
 
+    @property
     def bp_type(self):
         return Target.BREAKPOINT_HW
 
@@ -87,6 +88,7 @@ class FPB(BreakpointProvider, CoreSightComponent):
         logging.debug('fpb has been disabled')
         return
 
+    @property
     def available_breakpoints(self):
         return len(self.hw_breakpoints) - self.num_hw_breakpoint_used
 
@@ -106,8 +108,8 @@ class FPB(BreakpointProvider, CoreSightComponent):
             logging.error('Breakpoint out of range 0x%X', addr)
             return None
 
-        if self.available_breakpoints() == 0:
-            logging.error('No more available breakpoint!!, dropped bp at 0x%X', addr)
+        if self.available_breakpoints == 0:
+            logging.error('No more hardware breakpoints are available, dropped breakpoint at 0x%08x', addr)
             return None
 
         for bp in self.hw_breakpoints:

--- a/pyocd/debug/breakpoints/provider.py
+++ b/pyocd/debug/breakpoints/provider.py
@@ -39,6 +39,7 @@ class BreakpointProvider(object):
     def do_filter_memory(self):
         return False
 
+    @property
     def available_breakpoints(self):
         raise NotImplementedError()
 

--- a/pyocd/debug/breakpoints/software.py
+++ b/pyocd/debug/breakpoints/software.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2015-2017 Arm Limited
+# Copyright (c) 2015-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +36,7 @@ class SoftwareBreakpointProvider(BreakpointProvider):
     def init(self):
         pass
 
+    @property
     def bp_type(self):
         return Target.BREAKPOINT_SW
 
@@ -43,6 +44,7 @@ class SoftwareBreakpointProvider(BreakpointProvider):
     def do_filter_memory(self):
         return True
 
+    @property
     def available_breakpoints(self):
         return -1
 

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -275,7 +275,6 @@ class GDBServer(threading.Thread):
         self.target.set_vector_catch(convert_vector_catch(self.vector_catch))
         self.step_into_interrupt = session.options.get('step_into_interrupt', False)
         self.persist = session.options.get('persist', False)
-        self.soft_bkpt_as_hard = session.options.get('soft_bkpt_as_hard', False)
         self.enable_semihosting = session.options.get('enable_semihosting', False)
         self.semihost_console_type = session.options.get('semihost_console_type', 'telnet')
         self.semihost_use_syscalls = session.options.get('semihost_use_syscalls', False)
@@ -568,7 +567,7 @@ class GDBServer(threading.Thread):
         self.log.debug("GDB breakpoint %s%d @ %x" % (data[0:1], int(data[1:2]), addr))
 
         # handle software breakpoint Z0/z0
-        if data[1:2] == b'0' and not self.soft_bkpt_as_hard:
+        if data[1:2] == b'0':
             if data[0:1] == b'Z':
                 if not self.target.set_breakpoint(addr, Target.BREAKPOINT_SW):
                     return self.create_rsp_packet(b'E01') #EPERM
@@ -577,7 +576,7 @@ class GDBServer(threading.Thread):
             return self.create_rsp_packet(b"OK")
 
         # handle hardware breakpoint Z1/z1
-        if data[1:2] == b'1' or (self.soft_bkpt_as_hard and data[1:2] == b'0'):
+        if data[1:2] == b'1':
             if data[0:1] == b'Z':
                 if self.target.set_breakpoint(addr, Target.BREAKPOINT_HW) is False:
                     return self.create_rsp_packet(b'E01') #EPERM

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -77,7 +77,7 @@ class GDBServerTool(object):
         parser.add_argument("-s", "--step-int", dest="step_into_interrupt", default=False, action="store_true", help="Allow single stepping to step into interrupts.")
         parser.add_argument("-f", "--frequency", dest="frequency", default=1000000, type=int, help="Set the SWD clock frequency in Hz.")
         parser.add_argument("-o", "--persist", dest="persist", default=False, action="store_true", help="Keep GDB server running even after remote has detached.")
-        parser.add_argument("-bh", "--soft-bkpt-as-hard", dest="soft_bkpt_as_hard", default=False, action="store_true", help="Replace software breakpoints with hardware breakpoints.")
+        parser.add_argument("-bh", "--soft-bkpt-as-hard", dest="soft_bkpt_as_hard", default=False, action="store_true", help="Replace software breakpoints with hardware breakpoints (ignored).")
         group = parser.add_mutually_exclusive_group()
         group.add_argument("-ce", "--chip_erase", action="store_true", help="Use chip erase when programming.")
         group.add_argument("-se", "--sector_erase", action="store_true", help="Use sector erase when programming.")
@@ -127,7 +127,6 @@ class GDBServerTool(object):
             'gdbserver_port' : self.args.port_number,
             'step_into_interrupt' : args.step_into_interrupt,
             'persist' : args.persist,
-            'soft_bkpt_as_hard' : args.soft_bkpt_as_hard,
             'chip_erase': self.get_chip_erase(args),
             'hide_programming_progress' : args.hide_progress,
             'fast_program' : args.fast_program,


### PR DESCRIPTION
`BreakpointManager` postpones adding or removing breakpoints until a flush, which is normally done via a pre-run notification. This works well with how gdb seems to always remove and re-add breakpoints for each step operation. Now the manager will recognize that a breakpoint is not actually being removed, so it won't have to touch the hardware.

These changes include support for keeping a minimum number of hardware breakpoints always available for statement stepping (not single instruction stepping). It only allows these reserved hw breakpoints to be used if the target is being resumed and there is a single new breakpoint. Normally the minimum hw breakpoint count would be set to 1 (it's not advantageous to set it higher). However, the minimum is set to 0 for now (i.e., not reserving any hw breakpoints), so as to not introduce any potential problems.

Also included is the removal of the `soft_bkpt_as_hard` user option. This made sense long ago when pyOCD did not support software breakpoints (!), but it's pretty useless these days.