### PR TITLE
Log the debug probe's firmware version

### DIFF
--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -143,10 +143,7 @@ class CMSISDAPProtocol(object):
                 return (resp[5] << 24) | (resp[4] << 16) | (resp[3] << 8) | resp[2]
 
         # String values. They are sent as C strings with a terminating null char, so we strip it out.
-        x = array.array('B', [i for i in resp[2:2 + resp[1]]]).tostring()
-        if x[-1] == '\x00':
-            x = x[0:-1]
-        return x
+        return bytearray(resp[2:2 + resp[1] - 1]).decode('ascii')
 
     def set_led(self, type, enabled):
         cmd = []

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -551,6 +551,11 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         else:
             self._packet_count = self._protocol.dap_info(self.ID.MAX_PACKET_COUNT)
 
+        # Log probe's firmware version.
+        fw_version = self._protocol.dap_info(self.ID.FW_VER)
+        if fw_version:
+            LOG.debug("CMSIS-DAP probe %s firmware version: %s", self._unique_id, fw_version)
+
         self._interface.set_packet_count(self._packet_count)
         self._packet_size = self._protocol.dap_info(self.ID.MAX_PACKET_SIZE)
         self._interface.set_packet_size(self._packet_size)


### PR DESCRIPTION
For STLink probes, it logs the version in the same style that STMicro uses, such as "V2J33M25".

For CMSIS-DAP, it simply reports whatever the probe returns for the firmware version string from the [DAP_Info](http://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__Info.html) command. If the version string is empty, no version is logged.