### PR TITLE
Logging configuration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 - [Target support](target_support.md)
 - [Configuration](configuration.md)
 - [User scripts](user_scripts.md)
+- [Configuring logging](configuring_logging.md)
 - [Debugging multicore devices](multicore_debug.md)
 - [Introduction to the pyOCD Python API](python_api.md)
 - [Python API examples](api_examples.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,27 @@ frequency: 8000000 # Set 8 MHz SWD default for all probes
 - `keep_unwritten`: (bool) Whether to load existing flash content for ranges of sectors that will
     be erased but not written with new data. Default is True.
 
+- `logging`: (dict or file path) Specifies a [logging configuration
+    dictionary](https://docs.python.org/2.7/library/logging.config.html#logging-config-dictschema).
+    Alternately the value can be a file path string that points to a local YAML file
+    containing the logging configuration. The file path is most useful when passing the `logging`
+    option via the command line, since you can't provide a dictionary this way. No default.
+
+    Example logging configuration:
+    ````yaml
+    logging:
+      version: 1
+      root:
+        level: INFO
+      loggers:
+        flash:
+          level: DEBUG
+    ````
+
+    Note that the `version` key is optional in the logging configuration. If not present, pyOCD
+    will set the schema version to 1 (currently the only version). This behaviour may change in the
+    future if a new logging configuration schema is introduced.
+
 - `no_config`: (bool) Do not use default config file.
 
 - `pack`: (str or list of str) Path or list of paths to CMSIS Device Family Packs. Devices defined

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,26 +99,9 @@ frequency: 8000000 # Set 8 MHz SWD default for all probes
 - `keep_unwritten`: (bool) Whether to load existing flash content for ranges of sectors that will
     be erased but not written with new data. Default is True.
 
-- `logging`: (dict or file path) Specifies a [logging configuration
-    dictionary](https://docs.python.org/2.7/library/logging.config.html#logging-config-dictschema).
-    Alternately the value can be a file path string that points to a local YAML file
-    containing the logging configuration. The file path is most useful when passing the `logging`
-    option via the command line, since you can't provide a dictionary this way. No default.
-
-    Example logging configuration:
-    ````yaml
-    logging:
-      version: 1
-      root:
-        level: INFO
-      loggers:
-        flash:
-          level: DEBUG
-    ````
-
-    Note that the `version` key is optional in the logging configuration. If not present, pyOCD
-    will set the schema version to 1 (currently the only version). This behaviour may change in the
-    future if a new logging configuration schema is introduced.
+- `logging`: (dict or file path) Either a dictionary with logging configuration, or a path to a
+    separate yaml logging configuration file. See the [logging configuration
+    documentation](configuring_logging.md) for details of how to use this option.
 
 - `no_config`: (bool) Do not use default config file.
 

--- a/docs/configuring_logging.md
+++ b/docs/configuring_logging.md
@@ -1,0 +1,127 @@
+Configuring Logging
+===================
+
+## Overview
+
+pyOCD uses the standard Python [logging](https://docs.python.org/2.7/library/logging.html) package
+for all its logging.
+
+There are multiple log levels, in order from least to most verbose:
+- CRITICAL
+- ERROR
+- WARNING
+- INFO
+- DEBUG
+
+The CRITICAL level is used only by the `pyocd` tool for reporting fatal errors.
+
+Each subcommand for the `pyocd` tool has a default logging level.
+
+Subcommand     | Default level
+---------------|--------------
+`list`         | INFO
+`json`         | Logging fully disabled
+`flash`        | WARNING
+`erase`        | WARNING
+`gdbserver`    | INFO
+`commander`    | WARNING
+`pack`         | INFO
+
+
+## Basic control
+
+For most users, the command line `--verbose`/`-v` and `--quiet`/`-q` arguments provide sufficient control
+over logging. These arguments can be listed multiple times. Each use increases or decreases the
+logging verbosity level. For example, a single `--verbose` moves `pyocd flash` from the default
+level of WARNING to INFO.
+
+
+## Advanced control
+
+Fine-grained control of pyOCD log output is available through logging configuration. The logging
+package supports loading a configuration dictionary to control almost all aspects of log output.
+
+The `logging` user option is used to specify the logging configuration. It can be set to either a
+logging configuration dictionary or the path to a YAML file containing a configuration dictionary.
+Usually it is easiest to include the configuration directly in a `pyocd.yaml` config file. See the
+[configuration documentation](configuration.md) for more on config files. The file path is most
+useful when passing the `logging` option via the command line, since you can't provide a dictionary
+this way.
+
+
+### Loggers
+
+Each module in pyOCD uses its own module-specific logger with a name matching the dotted module
+name, for instance `pyocd.coresight.fpb`. This lets you control verbosity at the module level. Even
+more advanced configurations, such as routing a particular module's log output to a separate file,
+are also possible.
+
+The best way to see which loggers are available is simply to look at the pyOCD source code to see
+its package structure.
+
+
+### Controlling module log levels
+
+A basic logging configuration to control verbosity at the module level looks like this, as shown
+in a `pyocd.yaml` config file:
+
+```yaml
+logging:
+  loggers:
+    pyocd.flash.loader:
+      level: DEBUG
+    pyocd.flash.flash_builder:
+      level: DEBUG
+```
+
+The top level `logging` key is the user option. Under it must be a `loggers` key, which has the
+name of each module you wish to configure as a child key. Then, under each module name, the `level`
+key specifies the log level for that module. Due to the way logging propagation works, you do not
+need to set the level of parent loggers to match the child levels. In fact, setting the level of a
+parent logger
+such as `pyocd` will set the level for all children—this is an easy way to control the log level
+for all of pyOCD.
+
+
+### Full control
+
+The full schema for the logging configuration dictionary is documented in the [logging.config
+module
+documentation](https://docs.python.org/2.7/library/logging.config.html#logging-config-dictschema).
+The logging module's [advanced
+tutorial](https://docs.python.org/2.7/howto/logging.html#logging-advanced-tutorial) has a good
+introduction to the features and log output flow, so you can better understand the configuration
+schema.
+
+The `version` key described in the schema is optional in pyOCD's logging configuration. If not
+present, pyOCD will set the schema version to 1 (currently the only version). In addition, pyOCD
+will set the `disabled_existing_loggers` key to false unless it is specified in the configuration
+(the default is true).
+
+Note that if you change the configuration for the root logger, you will need to define a handler
+and formatter in the configuration (see the example below).
+
+Here is a much more complex example configuration that sets a custom formatter:
+
+```yaml
+logging:
+  formatters:
+    brief:
+      format: '%(relativeCreated)07d - %(levelname)s - %(name)s - %(message)s'
+  handlers:
+    console:
+      class: logging.StreamHandler
+      formatter: brief   # reference to "brief" formatter above
+      level: DEBUG
+      stream: ext://sys.stdout
+  root:
+    level: INFO
+    handlers:
+      - console          # reference to "console" handler above
+  loggers:
+    pyocd:
+      level: INFO        # set all pyocd loggers to INFO level
+    pyocd.core.coresight_target:
+      level: DEBUG       # set this logger to DEBUG level
+```
+

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -334,9 +334,10 @@ class PyOCDTool(object):
         except KeyboardInterrupt:
             return 0
         except exceptions.Error as e:
-            LOG.error(e, exc_info=Session.get_current().log_tracebacks)
+            LOG.critical(e, exc_info=Session.get_current().log_tracebacks)
+            return 1
         except Exception as e:
-            LOG.error("uncaught exception: %s", e, exc_info=Session.get_current().log_tracebacks)
+            LOG.critical("uncaught exception: %s", e, exc_info=Session.get_current().log_tracebacks)
             return 1
     
     def show_options_help(self):

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -21,7 +21,7 @@ from ..utility.graph import GraphNode
 import logging
 import six
 
-log = logging.getLogger('board')
+LOG = logging.getLogger(__name__)
 
 class Board(GraphNode):
     """!
@@ -56,11 +56,11 @@ class Board(GraphNode):
                 "all available targets." % self._target_type), exc)
         
         # Tell the user what target type is selected.
-        log.info("Target type is %s", self._target_type)
+        LOG.info("Target type is %s", self._target_type)
         
         # Log a helpful warning when using the generic cortex_m target.
         if self._target_type == 'cortex_m':
-            log.warning("Generic cortex_m target type is selected; is this intentional? "
+            LOG.warning("Generic cortex_m target type is selected; is this intentional? "
                         "You will be able to debug but not program flash. To set the "
                         "target type use the '--target' argument or target_type option. "
                         "Use 'pyocd list --targets' to see available targets.")
@@ -88,13 +88,13 @@ class Board(GraphNode):
     def uninit(self):
         """! @brief Uninitialize the board."""
         if self._inited:
-            log.debug("uninit board %s", self)
+            LOG.debug("uninit board %s", self)
             try:
                 resume = self.session.options.get('resume_on_disconnect', True)
                 self.target.disconnect(resume)
                 self._inited = False
             except:
-                log.error("link exception during target disconnect:", exc_info=self._session.log_tracebacks)
+                LOG.error("link exception during target disconnect:", exc_info=self._session.log_tracebacks)
 
     @property
     def session(self):

--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -21,6 +21,8 @@ import logging
 import threading
 from contextlib import contextmanager
 
+LOG = logging.getLogger(__name__)
+
 # Set to True to enable logging of all DP and AP accesses.
 LOG_DAP = False
 
@@ -225,7 +227,7 @@ class AccessPort(object):
         self.has_rom_table = (self.rom_addr != 0xffffffff) and ((self.rom_addr & AP_ROM_TABLE_ENTRY_PRESENT_MASK) != 0)
         self.rom_addr &= 0xfffffffc # clear format and present bits
 
-        logging.info("AP#%d IDR = 0x%08x (%s)", self.ap_num, self.idr, desc)
+        LOG.info("AP#%d IDR = 0x%08x (%s)", self.ap_num, self.idr, desc)
  
     @_locked
     def init_rom_table(self):
@@ -234,7 +236,7 @@ class AccessPort(object):
                 self.rom_table = ROMTable(self)
                 self.rom_table.init()
         except exceptions.TransferError as error:
-            logging.error("Transfer error while reading AP#%d ROM table: %s", self.ap_num, error)
+            LOG.error("Transfer error while reading AP#%d ROM table: %s", self.ap_num, error)
 
     @_locked
     def read_reg(self, addr, now=True):
@@ -316,7 +318,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         # memory interface based on AP register accesses.
         memoryInterface = self.dp.link.get_memory_interface_for_ap(self.ap_num)
         if memoryInterface is not None:
-            logging.debug("Using accelerated memory access interface")
+            LOG.debug("Using accelerated memory access interface")
             self.write_memory = memoryInterface.write_memory
             self.read_memory = memoryInterface.read_memory
             self.write_memory_block32 = memoryInterface.write_memory_block32
@@ -337,7 +339,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         
         default_hprot = (csw & CSW_HPROT_MASK) >> CSW_HPROT_SHIFT
         default_hnonsec = (csw & CSW_HNONSEC_MASK) >> CSW_HNONSEC_SHIFT
-        logging.debug("AP#%d default HPROT=%x HNONSEC=%x", self.ap_num, default_hprot, default_hnonsec)
+        LOG.debug("AP#%d default HPROT=%x HNONSEC=%x", self.ap_num, default_hprot, default_hnonsec)
         
         # Now attempt to see which HPROT and HNONSEC bits are implemented.
         AccessPort.write_reg(self, MEM_AP_CSW, csw | CSW_HNONSEC_MASK | CSW_HPROT_MASK)
@@ -345,7 +347,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         
         self._impl_hprot = (csw & CSW_HPROT_MASK) >> CSW_HPROT_SHIFT
         self._impl_hnonsec = (csw & CSW_HNONSEC_MASK) >> CSW_HNONSEC_SHIFT
-        logging.debug("AP#%d implemented HPROT=%x HNONSEC=%x", self.ap_num, self._impl_hprot, self._impl_hnonsec)
+        LOG.debug("AP#%d implemented HPROT=%x HNONSEC=%x", self.ap_num, self._impl_hprot, self._impl_hnonsec)
         
         # Update current HPROT and HNONSEC, and the current base CSW value.
         self.hprot = self._hprot & self._impl_hprot

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -27,6 +27,8 @@ import logging
 from time import (time, sleep)
 from xml.etree.ElementTree import (Element, SubElement, tostring)
 
+LOG = logging.getLogger(__name__)
+
 # pylint: disable=invalid_name
 
 # CPUID PARTNO values
@@ -537,7 +539,7 @@ class CortexM(Target, CoreSightComponent):
 
         implementer = (cpuid & CortexM.CPUID_IMPLEMENTER_MASK) >> CortexM.CPUID_IMPLEMENTER_POS
         if implementer != CortexM.CPUID_IMPLEMENTER_ARM:
-            logging.warning("CPU implementer is not ARM!")
+            LOG.warning("CPU implementer is not ARM!")
 
         self.arch = (cpuid & CortexM.CPUID_ARCHITECTURE_MASK) >> CortexM.CPUID_ARCHITECTURE_POS
         self.core_type = (cpuid & CortexM.CPUID_PARTNO_MASK) >> CortexM.CPUID_PARTNO_POS
@@ -550,9 +552,9 @@ class CortexM(Target, CoreSightComponent):
             self._supports_vectreset = True
         
         if self.core_type in CORE_TYPE_NAME:
-            logging.info("CPU core #%d is %s r%dp%d", self.core_number, CORE_TYPE_NAME[self.core_type], self.cpu_revision, self.cpu_patch)
+            LOG.info("CPU core #%d is %s r%dp%d", self.core_number, CORE_TYPE_NAME[self.core_type], self.cpu_revision, self.cpu_patch)
         else:
-            logging.warning("CPU core #%d type is unrecognized", self.core_number)
+            LOG.warning("CPU core #%d type is unrecognized", self.core_number)
 
     def _check_for_fpu(self):
         """! @brief Determine if a core has an FPU.
@@ -589,7 +591,7 @@ class CortexM(Target, CoreSightComponent):
                 fpu_type = "FPv5-SP"
             else:
                 fpu_type = "FPv4-SP"
-            logging.info("FPU present: " + fpu_type)
+            LOG.info("FPU present: " + fpu_type)
 
     def write_memory(self, addr, value, transfer_size=32):
         """! @brief Write a single memory location.
@@ -649,7 +651,7 @@ class CortexM(Target, CoreSightComponent):
         # but now value of dhcsr is saved
         dhcsr = self.read_memory(CortexM.DHCSR)
         if not (dhcsr & (CortexM.C_STEP | CortexM.C_HALT)):
-            logging.error('cannot step: target not halted')
+            LOG.error('cannot step: target not halted')
             return
 
         self.notify(Notification(event=Target.EVENT_PRE_RUN, source=self, data=Target.RUN_TYPE_STEP))
@@ -947,7 +949,7 @@ class CortexM(Target, CoreSightComponent):
         """! @brief Resume execution of the core.
         """
         if self.get_state() != Target.TARGET_HALTED:
-            logging.debug('cannot resume: target not halted')
+            LOG.debug('cannot resume: target not halted')
             return
         self.notify(Notification(event=Target.EVENT_PRE_RUN, source=self, data=Target.RUN_TYPE_RESUME))
         self._run_token += 1

--- a/pyocd/coresight/cortex_m_v8m.py
+++ b/pyocd/coresight/cortex_m_v8m.py
@@ -60,7 +60,7 @@ class CortexM_v8M(CortexM):
 
         implementer = (cpuid & CortexM.CPUID_IMPLEMENTER_MASK) >> CortexM.CPUID_IMPLEMENTER_POS
         if implementer != CortexM.CPUID_IMPLEMENTER_ARM:
-            logging.warning("CPU implementer is not ARM!")
+            LOG.warning("CPU implementer is not ARM!")
 
         self.arch = (cpuid & CortexM.CPUID_ARCHITECTURE_MASK) >> CortexM.CPUID_ARCHITECTURE_POS
         self.core_type = (cpuid & CortexM.CPUID_PARTNO_MASK) >> CortexM.CPUID_PARTNO_POS
@@ -73,9 +73,9 @@ class CortexM_v8M(CortexM):
         
         if self.core_type in CORE_TYPE_NAME:
             if self.has_security_extension:
-                logging.info("CPU core #%d is %s r%dp%d (security ext present)", self.core_number, CORE_TYPE_NAME[self.core_type], self.cpu_revision, self.cpu_patch)
+                LOG.info("CPU core #%d is %s r%dp%d (security ext present)", self.core_number, CORE_TYPE_NAME[self.core_type], self.cpu_revision, self.cpu_patch)
             else:
-                logging.info("CPU core #%d is %s r%dp%d", self.core_number, CORE_TYPE_NAME[self.core_type], self.cpu_revision, self.cpu_patch)
+                LOG.info("CPU core #%d is %s r%dp%d", self.core_number, CORE_TYPE_NAME[self.core_type], self.cpu_revision, self.cpu_patch)
         else:
-            logging.warning("CPU core #%d type is unrecognized", self.core_number)
+            LOG.warning("CPU core #%d type is unrecognized", self.core_number)
 

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -24,6 +24,8 @@ import os
 import os.path
 import six
 
+LOG = logging.getLogger(__name__)
+
 # DP register addresses.
 DP_IDCODE = 0x0 # read-only
 DP_ABORT = 0x0 # write-only
@@ -89,7 +91,7 @@ class DebugPort(object):
         """
         cwd = os.getcwd()
         logfile = os.path.join(cwd, self.DAP_LOG_FILE)
-        logging.info("dap logfile: %s", logfile)
+        LOG.info("dap logfile: %s", logfile)
         self.logger = logging.getLogger('dap')
         self.logger.propagate = False
         formatter = logging.Formatter('%(relativeCreated)010dms:%(levelname)s:%(name)s:%(message)s')
@@ -105,7 +107,7 @@ class DebugPort(object):
         self.link.swj_sequence()
         try:
             self.read_id_code()
-            logging.info("DP IDR = 0x%08x (v%d%s rev%d)", self.dpidr, self.dp_version,
+            LOG.info("DP IDR = 0x%08x (v%d%s rev%d)", self.dpidr, self.dp_version,
                 " MINDP" if self.is_mindp else "", self.dp_revision)
         except exceptions.TransferError:
             # If the read of the DP IDCODE fails, retry SWJ sequence. The DP may have been
@@ -191,7 +193,7 @@ class DebugPort(object):
                     break
                 apList.append(ap_num)
             except Exception as e:
-                logging.error("Exception while probing AP#%d: %s", ap_num, repr(e))
+                LOG.error("Exception while probing AP#%d: %s", ap_num, repr(e))
                 break
             ap_num += 1
         
@@ -217,7 +219,7 @@ class DebugPort(object):
             ap = AccessPort.create(self, ap_num)
             self.aps[ap_num] = ap
         except Exception as e:
-            logging.error("Exception reading AP#%d IDR: %s", ap_num, repr(e))
+            LOG.error("Exception reading AP#%d IDR: %s", ap_num, repr(e))
     
     def init_ap_roms(self):
         """! @brief Init task that generates a call sequence to init all AP ROMs."""

--- a/pyocd/coresight/dwt.py
+++ b/pyocd/coresight/dwt.py
@@ -19,6 +19,8 @@ from ..core.target import Target
 from .component import CoreSightComponent
 import logging
 
+LOG = logging.getLogger(__name__)
+
 # Need a local copy to prevent circular import.
 # Debug Exception and Monitor Control Register
 DEMCR = 0xE000EDFC
@@ -106,7 +108,7 @@ class DWT(CoreSightComponent):
         
         dwt_ctrl = self.ap.read_memory(self.address + DWT.DWT_CTRL)
         watchpoint_count = (dwt_ctrl & DWT.DWT_CTRL_NUM_COMP_MASK) >> DWT.DWT_CTRL_NUM_COMP_SHIFT
-        logging.info("%d hardware watchpoints", watchpoint_count)
+        LOG.info("%d hardware watchpoints", watchpoint_count)
         for i in range(watchpoint_count):
             comparatorAddress = self.address + DWT.DWT_COMP_BASE + DWT.DWT_COMP_BLOCK_SIZE * i
             self.watchpoints.append(Watchpoint(comparatorAddress, self))
@@ -132,7 +134,7 @@ class DWT(CoreSightComponent):
             return True
 
         if type not in DWT.WATCH_TYPE_TO_FUNCT:
-            logging.error("Invalid watchpoint type %i", type)
+            LOG.error("Invalid watchpoint type %i", type)
             return False
 
         for watch in self.watchpoints:
@@ -142,13 +144,13 @@ class DWT(CoreSightComponent):
                 watch.size = size
 
                 if size not in DWT.WATCH_SIZE_TO_MASK:
-                    logging.error('Watchpoint of size %d not supported by device', size)
+                    LOG.error('Watchpoint of size %d not supported by device', size)
                     return False
 
                 mask = DWT.WATCH_SIZE_TO_MASK[size]
                 self.ap.write_memory(watch.comp_register_addr + DWT.DWT_MASK_OFFSET, mask)
                 if self.ap.read_memory(watch.comp_register_addr + DWT.DWT_MASK_OFFSET) != mask:
-                    logging.error('Watchpoint of size %d not supported by device', size)
+                    LOG.error('Watchpoint of size %d not supported by device', size)
                     return False
 
                 self.ap.write_memory(watch.comp_register_addr, addr)
@@ -156,7 +158,7 @@ class DWT(CoreSightComponent):
                 self.watchpoint_used += 1
                 return True
 
-        logging.error('No more watchpoints are available, dropped watchpoint at 0x%08x', addr)
+        LOG.error('No more watchpoints are available, dropped watchpoint at 0x%08x', addr)
         return False
 
     def remove_watchpoint(self, addr, size, type):

--- a/pyocd/coresight/itm.py
+++ b/pyocd/coresight/itm.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 from ..core.target import Target
 from ..core import exceptions
 from .component import CoreSightComponent

--- a/pyocd/coresight/tpiu.py
+++ b/pyocd/coresight/tpiu.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 from .component import CoreSightComponent
 
 class TPIU(CoreSightComponent):

--- a/pyocd/debug/breakpoints/software.py
+++ b/pyocd/debug/breakpoints/software.py
@@ -19,6 +19,8 @@ from ...core import exceptions
 from ...core.target import Target
 import logging
 
+LOG = logging.getLogger(__name__)
+
 class SoftwareBreakpoint(Breakpoint):
     def __init__(self, provider):
         super(SoftwareBreakpoint, self).__init__(provider)
@@ -72,7 +74,7 @@ class SoftwareBreakpointProvider(BreakpointProvider):
             self._breakpoints[addr] = bp
             return bp
         except exceptions.TransferError:
-            logging.debug("Failed to set sw bp at 0x%x" % addr)
+            LOG.debug("Failed to set sw bp at 0x%x" % addr)
             return None
 
     def remove_breakpoint(self, bp):
@@ -85,7 +87,7 @@ class SoftwareBreakpointProvider(BreakpointProvider):
             # Remove from our list.
             del self._breakpoints[bp.addr]
         except exceptions.TransferError:
-            logging.debug("Failed to remove sw bp at 0x%x" % bp.addr)
+            LOG.debug("Failed to remove sw bp at 0x%x" % bp.addr)
 
     def filter_memory(self, addr, size, data):
         for bp in self._breakpoints.values():

--- a/pyocd/debug/cache.py
+++ b/pyocd/debug/cache.py
@@ -28,6 +28,8 @@ from ..utility import conversion
 from intervaltree import (Interval, IntervalTree)
 import logging
 
+LOG = logging.getLogger(__name__)
+
 class MemoryAccessError(exceptions.Error):
     """! @brief Generic failure to access memory."""
     pass
@@ -90,7 +92,7 @@ class RegisterCache(object):
     def __init__(self, parentContext):
         self._context = parentContext
         self._run_token = -1
-        self._log = logging.getLogger('regcache')
+        self._log = LOG.getChild('regcache')
         self._reset_cache()
 
     def _reset_cache(self):
@@ -230,7 +232,7 @@ class MemoryCache(object):
     def __init__(self, context):
         self._context = context
         self._run_token = -1
-        self._log = logging.getLogger('memcache')
+        self._log = LOG.getChild('memcache')
         self._reset_cache()
 
     def _reset_cache(self):

--- a/pyocd/debug/context.py
+++ b/pyocd/debug/context.py
@@ -18,7 +18,6 @@ from ..core.memory_interface import MemoryInterface
 from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index, is_single_float_register,
                                     is_double_float_register)
 from ..utility import conversion
-import logging
 
 class DebugContext(MemoryInterface):
     """! @brief Viewport for inspecting the system being debugged.

--- a/pyocd/debug/elf/decoder.py
+++ b/pyocd/debug/elf/decoder.py
@@ -23,6 +23,8 @@ from collections import namedtuple
 from itertools import islice
 import logging
 
+LOG = logging.getLogger(__name__)
+
 FunctionInfo = namedtuple('FunctionInfo', 'name subprogram low_pc high_pc')
 LineInfo = namedtuple('LineInfo', 'cu filename dirname line')
 SymbolInfo = namedtuple('SymbolInfo', 'name address size type')
@@ -200,7 +202,7 @@ class DwarfAddressDecoder(object):
                                 toAddr += 1
                             self.line_tree.addi(fromAddr, toAddr, info)
                     except:
-                        logging.debug("Problematic lineprog:")
+                        LOG.debug("Problematic lineprog:")
                         self._dump_lineprog(lineprog)
                         raise
 
@@ -214,9 +216,9 @@ class DwarfAddressDecoder(object):
         for i, e in enumerate(lineprog.get_entries()):
             s = e.state
             if s is None:
-                logging.debug("%d: cmd=%d ext=%d args=%s", i, e.command, int(e.is_extended), repr(e.args))
+                LOG.debug("%d: cmd=%d ext=%d args=%s", i, e.command, int(e.is_extended), repr(e.args))
             else:
-                logging.debug("%d: %06x %4d stmt=%1d block=%1d end=%d file=[%d]%s", i, s.address, s.line, s.is_stmt, int(s.basic_block), int(s.end_sequence), s.file, lineprog['file_entry'][s.file-1].name)
+                LOG.debug("%d: %06x %4d stmt=%1d block=%1d end=%d file=[%d]%s", i, s.address, s.line, s.is_stmt, int(s.basic_block), int(s.end_sequence), s.file, lineprog['file_entry'][s.file-1].name)
 
     def dump_subprograms(self):
         for prog in self.subprograms:
@@ -230,6 +232,6 @@ class DwarfAddressDecoder(object):
             except KeyError:
                 high_pc = 0xffffffff
             filename = os.path.basename(prog._parent.attributes['DW_AT_name'].value.replace('\\', '/'))
-            logging.debug("%s%s%08x %08x %s", name, (' ' * (50-len(name))), low_pc, high_pc, filename)
+            LOG.debug("%s%s%08x %08x %s", name, (' ' * (50-len(name))), low_pc, high_pc, filename)
 
 

--- a/pyocd/debug/elf/elf.py
+++ b/pyocd/debug/elf/elf.py
@@ -18,7 +18,6 @@ from ...core.memory_map import (MemoryRange, MemoryMap)
 from .decoder import (ElfSymbolDecoder, DwarfAddressDecoder)
 from elftools.elf.elffile import ELFFile
 from elftools.elf.constants import SH_FLAGS
-import logging
 import six
 
 class ELFSection(MemoryRange):

--- a/pyocd/debug/elf/flash_reader.py
+++ b/pyocd/debug/elf/flash_reader.py
@@ -19,6 +19,8 @@ from ...utility import conversion
 import logging
 from intervaltree import (Interval, IntervalTree)
 
+LOG = logging.getLogger(__name__)
+
 class FlashReaderContext(DebugContext):
     """! @brief Reads flash memory regions from an ELF file instead of the target."""
 
@@ -26,7 +28,6 @@ class FlashReaderContext(DebugContext):
         super(FlashReaderContext, self).__init__(parentContext.core)
         self._parent = parentContext
         self._elf = elf
-        self._log = logging.getLogger('flashreadercontext')
 
         self._build_regions()
 
@@ -37,7 +38,7 @@ class FlashReaderContext(DebugContext):
             length = sect.length
             sect.data # Go ahead and read the data from the file.
             self._tree.addi(start, start + length, sect)
-            self._log.debug("created flash section [%x:%x] for section %s", start, start + length, sect.name)
+            LOG.debug("created flash section [%x:%x] for section %s", start, start + length, sect.name)
 
     def read_memory(self, addr, transfer_size=32, now=True):
         length = transfer_size // 8
@@ -49,7 +50,7 @@ class FlashReaderContext(DebugContext):
         addr -= section.start
 
         def read_memory_cb():
-            self._log.debug("read flash data [%x:%x] from section %s", section.start + addr, section.start + addr  + length, section.name)
+            LOG.debug("read flash data [%x:%x] from section %s", section.start + addr, section.start + addr  + length, section.name)
             data = section.data[addr:addr + length]
             if transfer_size == 8:
                 return data[0]
@@ -73,7 +74,7 @@ class FlashReaderContext(DebugContext):
         section = matches.pop().data
         addr -= section.start
         data = section.data[addr:addr + size]
-        self._log.debug("read flash data [%x:%x]", section.start + addr, section.start + addr  + size)
+        LOG.debug("read flash data [%x:%x]", section.start + addr, section.start + addr  + size)
         return list(data)
 
     def read_memory_block32(self, addr, size):

--- a/pyocd/debug/semihost.py
+++ b/pyocd/debug/semihost.py
@@ -24,6 +24,8 @@ import six
 import pyocd
 from ..core import (exceptions, session)
 
+LOG = logging.getLogger(__name__)
+
 # Debug logging options
 LOG_SEMIHOST = True
 
@@ -103,7 +105,7 @@ class SemihostIOHandler(object):
           file descriptor, the caller must handle the open request.
         """
         filename = self.agent._get_string(fnptr, fnlen)
-        logging.debug("Semihost: open '%s' mode %s", filename, mode)
+        LOG.debug("Semihost: open '%s' mode %s", filename, mode)
 
         # Handle standard I/O.
         if filename == ':tt':
@@ -114,7 +116,7 @@ class SemihostIOHandler(object):
             elif mode == 'a':
                 fd = STDERR_FD
             else:
-                logging.warning("Unrecognized semihosting console open file combination: mode=%s", mode)
+                LOG.warning("Unrecognized semihosting console open file combination: mode=%s", mode)
                 return -1, filename
             return fd, filename
         return None, filename
@@ -191,7 +193,7 @@ class InternalSemihostIOHandler(SemihostIOHandler):
             return fd
         except IOError as e:
             self._errno = e.errno
-            logging.error("Semihost: failed to open file '%s'", filename, exc_info=session.Session.get_current().log_tracebacks)
+            LOG.error("Semihost: failed to open file '%s'", filename, exc_info=session.Session.get_current().log_tracebacks)
             return -1
 
     def close(self, fd):
@@ -220,7 +222,7 @@ class InternalSemihostIOHandler(SemihostIOHandler):
             return 0
         except IOError as e:
             self._errno = e.errno
-            logging.debug("Semihost: exception: %s", e)
+            LOG.debug("Semihost: exception: %s", e)
             return -1
 
     def read(self, fd, ptr, length):
@@ -234,7 +236,7 @@ class InternalSemihostIOHandler(SemihostIOHandler):
                 data = data.encode()
         except IOError as e:
             self._errno = e.errno
-            logging.debug("Semihost: exception: %s", e)
+            LOG.debug("Semihost: exception: %s", e)
             return -1
         data = bytearray(data)
         self.agent.context.write_memory_block8(ptr, data)
@@ -438,10 +440,10 @@ class SemihostAgent(object):
             try:
                 result = handler(args)
             except NotImplementedError:
-                logging.warning("Semihost: unimplemented request pc=%x r0=%x r1=%x", pc, op, args)
+                LOG.warning("Semihost: unimplemented request pc=%x r0=%x r1=%x", pc, op, args)
                 result = -1
             except Exception as e:
-                logging.warning("Exception while handling semihost request: %s", e,
+                LOG.warning("Exception while handling semihost request: %s", e,
                     exc_info=session.Session.get_current().log_tracebacks)
                 result = -1
         else:
@@ -502,30 +504,30 @@ class SemihostAgent(object):
         mode = self.OPEN_MODES[mode]
 
         if LOG_SEMIHOST:
-            logging.debug("Semihost: open %x/%x, mode %s", fnptr, fnlen, mode)
+            LOG.debug("Semihost: open %x/%x, mode %s", fnptr, fnlen, mode)
         return self.io_handler.open(fnptr, fnlen, mode)
 
     def handle_sys_close(self, args):
         fd = self._get_args(args, 1)
         if LOG_SEMIHOST:
-            logging.debug("Semihost: close fd=%d", fd)
+            LOG.debug("Semihost: close fd=%d", fd)
         return self.io_handler.close(fd)
 
     def handle_sys_writec(self, args):
         if LOG_SEMIHOST:
-            logging.debug("Semihost: writec %x", args)
+            LOG.debug("Semihost: writec %x", args)
         return self.console.write(STDOUT_FD, args, 1)
 
     def handle_sys_write0(self, args):
         msg = self._get_string(args)
         if LOG_SEMIHOST:
-            logging.debug("Semihost: write0 msg='%s'", msg)
+            LOG.debug("Semihost: write0 msg='%s'", msg)
         return self.console.write(STDOUT_FD, args, len(msg))
 
     def handle_sys_write(self, args):
         fd, data_ptr, length = self._get_args(args, 3)
         if LOG_SEMIHOST:
-            logging.debug("Semihost: write fd=%d ptr=%x len=%d", fd, data_ptr, length)
+            LOG.debug("Semihost: write fd=%d ptr=%x len=%d", fd, data_ptr, length)
         if fd in (STDOUT_FD, STDERR_FD):
             return self.console.write(fd, data_ptr, length)
         else:
@@ -534,7 +536,7 @@ class SemihostAgent(object):
     def handle_sys_read(self, args):
         fd, ptr, length = self._get_args(args, 3)
         if LOG_SEMIHOST:
-            logging.debug("Semihost: read fd=%d ptr=%x len=%d", fd, ptr, length)
+            LOG.debug("Semihost: read fd=%d ptr=%x len=%d", fd, ptr, length)
         if fd == STDIN_FD:
             return self.console.read(fd, ptr, length)
         else:
@@ -542,7 +544,7 @@ class SemihostAgent(object):
 
     def handle_sys_readc(self, args):
         if LOG_SEMIHOST:
-            logging.debug("Semihost: readc")
+            LOG.debug("Semihost: readc")
         return self.console.readc()
 
     def handle_sys_iserror(self, args):
@@ -551,19 +553,19 @@ class SemihostAgent(object):
     def handle_sys_istty(self, args):
         fd = self._get_args(args, 1)
         if LOG_SEMIHOST:
-            logging.debug("Semihost: istty fd=%d", fd)
+            LOG.debug("Semihost: istty fd=%d", fd)
         return self.io_handler.istty(fd)
 
     def handle_sys_seek(self, args):
         fd, pos = self._get_args(args, 2)
         if LOG_SEMIHOST:
-            logging.debug("Semihost: seek fd=%d pos=%d", fd, pos)
+            LOG.debug("Semihost: seek fd=%d pos=%d", fd, pos)
         return self.io_handler.seek(fd, pos)
 
     def handle_sys_flen(self, args):
         fd = self._get_args(args, 1)
         if LOG_SEMIHOST:
-            logging.debug("Semihost: flen fd=%d", fd)
+            LOG.debug("Semihost: flen fd=%d", fd)
         return self.io_handler.flen(fd)
 
     def handle_sys_tmpnam(self, args):

--- a/pyocd/debug/semihost.py
+++ b/pyocd/debug/semihost.py
@@ -26,8 +26,8 @@ from ..core import (exceptions, session)
 
 LOG = logging.getLogger(__name__)
 
-# Debug logging options
-LOG_SEMIHOST = True
+TRACE = LOG.getChild("trace")
+TRACE.setLevel(logging.CRITICAL)
 
 ## bkpt #0xab instruction
 BKPT_INSTR = 0xbeab
@@ -503,31 +503,26 @@ class SemihostAgent(object):
             return -1
         mode = self.OPEN_MODES[mode]
 
-        if LOG_SEMIHOST:
-            LOG.debug("Semihost: open %x/%x, mode %s", fnptr, fnlen, mode)
+        TRACE.debug("Semihost: open %x/%x, mode %s", fnptr, fnlen, mode)
         return self.io_handler.open(fnptr, fnlen, mode)
 
     def handle_sys_close(self, args):
         fd = self._get_args(args, 1)
-        if LOG_SEMIHOST:
-            LOG.debug("Semihost: close fd=%d", fd)
+        TRACE.debug("Semihost: close fd=%d", fd)
         return self.io_handler.close(fd)
 
     def handle_sys_writec(self, args):
-        if LOG_SEMIHOST:
-            LOG.debug("Semihost: writec %x", args)
+        TRACE.debug("Semihost: writec %x", args)
         return self.console.write(STDOUT_FD, args, 1)
 
     def handle_sys_write0(self, args):
         msg = self._get_string(args)
-        if LOG_SEMIHOST:
-            LOG.debug("Semihost: write0 msg='%s'", msg)
+        TRACE.debug("Semihost: write0 msg='%s'", msg)
         return self.console.write(STDOUT_FD, args, len(msg))
 
     def handle_sys_write(self, args):
         fd, data_ptr, length = self._get_args(args, 3)
-        if LOG_SEMIHOST:
-            LOG.debug("Semihost: write fd=%d ptr=%x len=%d", fd, data_ptr, length)
+        TRACE.debug("Semihost: write fd=%d ptr=%x len=%d", fd, data_ptr, length)
         if fd in (STDOUT_FD, STDERR_FD):
             return self.console.write(fd, data_ptr, length)
         else:
@@ -535,16 +530,14 @@ class SemihostAgent(object):
 
     def handle_sys_read(self, args):
         fd, ptr, length = self._get_args(args, 3)
-        if LOG_SEMIHOST:
-            LOG.debug("Semihost: read fd=%d ptr=%x len=%d", fd, ptr, length)
+        TRACE.debug("Semihost: read fd=%d ptr=%x len=%d", fd, ptr, length)
         if fd == STDIN_FD:
             return self.console.read(fd, ptr, length)
         else:
             return self.io_handler.read(fd, ptr, length)
 
     def handle_sys_readc(self, args):
-        if LOG_SEMIHOST:
-            LOG.debug("Semihost: readc")
+        TRACE.debug("Semihost: readc")
         return self.console.readc()
 
     def handle_sys_iserror(self, args):
@@ -552,20 +545,17 @@ class SemihostAgent(object):
 
     def handle_sys_istty(self, args):
         fd = self._get_args(args, 1)
-        if LOG_SEMIHOST:
-            LOG.debug("Semihost: istty fd=%d", fd)
+        TRACE.debug("Semihost: istty fd=%d", fd)
         return self.io_handler.istty(fd)
 
     def handle_sys_seek(self, args):
         fd, pos = self._get_args(args, 2)
-        if LOG_SEMIHOST:
-            LOG.debug("Semihost: seek fd=%d pos=%d", fd, pos)
+        TRACE.debug("Semihost: seek fd=%d pos=%d", fd, pos)
         return self.io_handler.seek(fd, pos)
 
     def handle_sys_flen(self, args):
         fd = self._get_args(args, 1)
-        if LOG_SEMIHOST:
-            LOG.debug("Semihost: flen fd=%d", fd)
+        TRACE.debug("Semihost: flen fd=%d", fd)
         return self.io_handler.flen(fd)
 
     def handle_sys_tmpnam(self, args):

--- a/pyocd/debug/svd/loader.py
+++ b/pyocd/debug/svd/loader.py
@@ -21,6 +21,8 @@ from zipfile import ZipFile
 
 from .parser import SVDParser
 
+LOG = logging.getLogger(__name__)
+
 ## Path within the pyocd package to the generated zip containing builting SVD files.
 BUILTIN_SVD_DATA_PATH = "debug/svd/svd_data.zip"
 
@@ -65,4 +67,4 @@ class SVDLoader(threading.Thread):
             if self._callback:
                 self._callback(self._svd_device)
         except IOError:
-            logging.warning("Failed to load SVD file %s", self._svd_location.filename)
+            LOG.warning("Failed to load SVD file %s", self._svd_location.filename)

--- a/pyocd/flash/loader.py
+++ b/pyocd/flash/loader.py
@@ -194,7 +194,7 @@ class FileProgrammer(object):
             try:
                 self._loader.add_data(start, data)
             except ValueError as e:
-                logging.warning("Failed to add data chunk: %s", e)
+                LOG.warning("Failed to add data chunk: %s", e)
 
     def _program_elf(self, file_obj, **kwargs):
         """! ELF format loader"""

--- a/pyocd/gdbserver/context_facade.py
+++ b/pyocd/gdbserver/context_facade.py
@@ -21,6 +21,8 @@ import logging
 import six
 from xml.etree import ElementTree
 
+LOG = logging.getLogger(__name__)
+
 MAP_XML_HEADER = b"""<?xml version="1.0"?>
 <!DOCTYPE memory-map PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN" "http://sourceware.org/gdb/gdb-memory-map.dtd">
 """
@@ -61,7 +63,7 @@ class GDBDebugContextFacade(object):
     def get_register_context(self):
         """! @brief Return hexadecimal dump of registers as expected by GDB.
         """
-        logging.debug("GDB getting register context")
+        LOG.debug("GDB getting register context")
         resp = b''
         reg_num_list = [reg.reg_num for reg in self._register_list]
         vals = self._context.read_core_registers_raw(reg_num_list)
@@ -71,14 +73,14 @@ class GDBDebugContextFacade(object):
                 resp += six.b(conversion.u64_to_hex16le(regValue))
             else:
                 resp += six.b(conversion.u32_to_hex8le(regValue))
-            logging.debug("GDB reg: %s = 0x%X", reg.name, regValue)
+            LOG.debug("GDB reg: %s = 0x%X", reg.name, regValue)
 
         return resp
 
     def set_register_context(self, data):
         """! @brief Set registers from GDB hexadecimal string.
         """
-        logging.debug("GDB setting register context")
+        LOG.debug("GDB setting register context")
         reg_num_list = []
         reg_data_list = []
         for reg in self._register_list:
@@ -90,7 +92,7 @@ class GDBDebugContextFacade(object):
                 data = data[8:]
             reg_num_list.append(reg.reg_num)
             reg_data_list.append(regValue)
-            logging.debug("GDB reg: %s = 0x%X", reg.name, regValue)
+            LOG.debug("GDB reg: %s = 0x%X", reg.name, regValue)
         self._context.write_core_registers_raw(reg_num_list, reg_data_list)
 
     def set_register(self, reg, data):
@@ -107,7 +109,7 @@ class GDBDebugContextFacade(object):
                 value = conversion.hex16_to_u64be(data)
             else:
                 value = conversion.hex8_to_u32be(data)
-            logging.debug("GDB: write reg %s: 0x%X", regName, value)
+            LOG.debug("GDB: write reg %s: 0x%X", regName, value)
             self._context.write_core_register_raw(regName, value)
 
     def gdb_get_register(self, reg):
@@ -120,7 +122,7 @@ class GDBDebugContextFacade(object):
                 resp = six.b(conversion.u64_to_hex16le(regValue))
             else:
                 resp = six.b(conversion.u32_to_hex8le(regValue))
-            logging.debug("GDB reg: %s = 0x%X", regName, regValue)
+            LOG.debug("GDB reg: %s = 0x%X", regName, regValue)
         return resp
 
     def get_t_response(self, forceSignal=None):
@@ -154,7 +156,7 @@ class GDBDebugContextFacade(object):
             except IndexError:
                 pass
 
-        logging.debug("GDB lastSignal: %d", signal)
+        LOG.debug("GDB lastSignal: %d", signal)
         return signal
 
     def get_reg_index_value_pairs(self, regIndexList):

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -101,7 +101,8 @@ class GDBServerPacketIOThread(threading.Thread):
     """
     
     def __init__(self, abstract_socket):
-        super(GDBServerPacketIOThread, self).__init__(name="gdb-packet-thread")
+        super(GDBServerPacketIOThread, self).__init__()
+        self.name = "gdb-packet-thread-port%d" % abstract_socket.port
         self.log = LOG.getChild('gdbpacket')
         self._abstract_socket = abstract_socket
         self._receive_queue = queue.Queue()
@@ -153,6 +154,8 @@ class GDBServerPacketIOThread(threading.Thread):
                     raise ConnectionClosedException()
 
     def run(self):
+        self.log.debug("Starting GDB server packet I/O thread")
+
         self._abstract_socket.set_timeout(0.01)
 
         while not self._shutdown_event.is_set():
@@ -261,7 +264,7 @@ class GDBServer(threading.Thread):
     It implements the RSP (Remote Serial Protocol).
     """
     def __init__(self, session, core=None, server_listening_callback=None):
-        threading.Thread.__init__(self)
+        super(GDBServer, self).__init__()
         self.session = session
         self.board = session.board
         if core is None:
@@ -270,6 +273,7 @@ class GDBServer(threading.Thread):
         else:
             self.core = core
             self.target = self.board.target.cores[core]
+        self.name = "gdb-server-core%d" % self.core
         self.log = LOG.getChild('gdbserver')
         self.abstract_socket = None
         self.port = session.options.get('gdbserver_port', 3333)

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -41,6 +41,8 @@ from xml.etree.ElementTree import (Element, SubElement, tostring)
 
 CTRL_C = b'\x03'
 
+LOG = logging.getLogger(__name__)
+
 # Logging options. Set to True to enable.
 LOG_MEM = False # Log memory accesses.
 LOG_ACK = False # Log ack or nak.
@@ -100,7 +102,7 @@ class GDBServerPacketIOThread(threading.Thread):
     
     def __init__(self, abstract_socket):
         super(GDBServerPacketIOThread, self).__init__(name="gdb-packet-thread")
-        self.log = logging.getLogger('gdbpacket.%d' % abstract_socket.port)
+        self.log = LOG.getChild('gdbpacket')
         self._abstract_socket = abstract_socket
         self._receive_queue = queue.Queue()
         self._shutdown_event = threading.Event()
@@ -268,7 +270,7 @@ class GDBServer(threading.Thread):
         else:
             self.core = core
             self.target = self.board.target.cores[core]
-        self.log = logging.getLogger('gdbserver')
+        self.log = LOG.getChild('gdbserver')
         self.abstract_socket = None
         self.port = session.options.get('gdbserver_port', 3333)
         if self.port != 0:

--- a/pyocd/gdbserver/syscall.py
+++ b/pyocd/gdbserver/syscall.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import os
-import logging
 from ..debug.semihost import SemihostIOHandler
 
 # Open mode flags

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -47,8 +47,8 @@ class SWOStatus:
 
 LOG = logging.getLogger(__name__)
 
-# Set to True to enable logging of packet filling logic.
-LOG_PACKET_BUILDS = False
+TRACE = LOG.getChild("trace")
+TRACE.setLevel(logging.CRITICAL)
 
 def _get_interfaces():
     """! @brief Get the connected USB devices"""
@@ -165,8 +165,7 @@ class _Command(object):
         self._data = []
         self._dap_index = None
         self._data_encoded = False
-        if LOG_PACKET_BUILDS:
-            LOG.debug("New _Command")
+        TRACE.debug("New _Command")
 
     def _get_free_words(self, blockAllowed, isRead):
         """! @brief Return the number of words free in the transmit packet
@@ -230,11 +229,10 @@ class _Command(object):
             max_count = self._write_count + self._read_count + size
             delta = max_count - 255
             size = min(size - delta, size)
-            if LOG_PACKET_BUILDS:
-                LOG.debug("get_request_space(%d, %02x:%s)[wc=%d, rc=%d, ba=%d->%d] -> (sz=%d, free=%d, delta=%d)" %
+            TRACE.debug("get_request_space(%d, %02x:%s)[wc=%d, rc=%d, ba=%d->%d] -> (sz=%d, free=%d, delta=%d)" %
                     (count, request, 'r' if is_read else 'w', self._write_count, self._read_count, self._block_allowed, blockAllowed, size, free, delta))
-        elif LOG_PACKET_BUILDS:
-            LOG.debug("get_request_space(%d, %02x:%s)[wc=%d, rc=%d, ba=%d->%d] -> (sz=%d, free=%d)" %
+        else:
+            TRACE.debug("get_request_space(%d, %02x:%s)[wc=%d, rc=%d, ba=%d->%d] -> (sz=%d, free=%d)" %
                 (count, request, 'r' if is_read else 'w', self._write_count, self._read_count, self._block_allowed, blockAllowed, size, free))
 
         # We can get a negative free count if the packet already contains more data than can be
@@ -271,8 +269,7 @@ class _Command(object):
             self._write_count += count
         self._data.append((count, request, data))
 
-        if LOG_PACKET_BUILDS:
-            LOG.debug("add(%d, %02x:%s) -> [wc=%d, rc=%d, ba=%d]" %
+        TRACE.debug("add(%d, %02x:%s) -> [wc=%d, rc=%d, ba=%d]" %
                 (count, request, 'r' if (request & READ) else 'w', self._write_count, self._read_count, self._block_allowed))
 
     def _encode_transfer_data(self):
@@ -938,8 +935,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
             # This request doesn't fit in the packet so send it.
             if size == 0:
-                if LOG_PACKET_BUILDS:
-                    LOG.debug("_write: send packet [size==0]")
+                TRACE.debug("_write: send packet [size==0]")
                 self._send_packet()
                 cmd = self._crnt_cmd
                 continue
@@ -955,8 +951,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
             # Packet has been filled so send it
             if cmd.get_full():
-                if LOG_PACKET_BUILDS:
-                    LOG.debug("_write: send packet [full]")
+                TRACE.debug("_write: send packet [full]")
                 self._send_packet()
                 cmd = self._crnt_cmd
 

--- a/pyocd/probe/pydapaccess/interface/__init__.py
+++ b/pyocd/probe/pydapaccess/interface/__init__.py
@@ -21,6 +21,8 @@ from .pyusb_backend import PyUSB
 from .pyusb_v2_backend import PyUSBv2
 from .pywinusb_backend import PyWinUSB
 
+LOG = logging.getLogger(__name__)
+
 INTERFACE = {
              'hidapiusb': HidApiUSB,
              'pyusb': PyUSB,
@@ -33,7 +35,7 @@ USB_BACKEND = os.getenv('PYOCD_USB_BACKEND', "") # pylint: disable=invalid-name
 
 # Check validity of backend env var.
 if USB_BACKEND and ((USB_BACKEND not in INTERFACE) or (not INTERFACE[USB_BACKEND].isAvailable)):
-    logging.error("Invalid USB backend specified in PYOCD_USB_BACKEND: " + USB_BACKEND)
+    LOG.error("Invalid USB backend specified in PYOCD_USB_BACKEND: " + USB_BACKEND)
     USB_BACKEND = ""
 
 # Select backend based on OS and availability.

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -22,13 +22,13 @@ import logging
 import os
 import six
 
-log = logging.getLogger('hidapi')
+LOG = logging.getLogger(__name__)
 
 try:
     import hid
 except:
     if os.name == "posix" and os.uname()[0] == 'Darwin':
-        log.error("cython-hidapi is required on a Mac OS X Machine")
+        LOG.error("cython-hidapi is required on a Mac OS X Machine")
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True
@@ -60,7 +60,7 @@ class HidApiUSB(Interface):
         devices = hid.enumerate()
 
         if not devices:
-            log.debug("No Mbed device connected")
+            LOG.debug("No Mbed device connected")
             return []
 
         boards = []
@@ -81,7 +81,7 @@ class HidApiUSB(Interface):
             try:
                 dev = hid.device(vendor_id=vid, product_id=pid, path=deviceInfo['path'])
             except IOError as exc:
-                log.debug("Failed to open USB device: %s", exc)
+                LOG.debug("Failed to open USB device: %s", exc)
                 continue
 
             # Create the USB interface object for this device.
@@ -118,7 +118,7 @@ class HidApiUSB(Interface):
     def close(self):
         """! @brief Close the interface
         """
-        log.debug("closing interface")
+        LOG.debug("closing interface")
         self.device.close()
 
     def set_packet_count(self, count):

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -25,14 +25,14 @@ from time import sleep
 import platform
 import errno
 
-log = logging.getLogger('pyusb')
+LOG = logging.getLogger(__name__)
 
 try:
     import usb.core
     import usb.util
 except:
     if os.name == "posix" and not os.uname()[0] == 'Darwin':
-        log.error("PyUSB is required on a Linux Machine")
+        LOG.error("PyUSB is required on a Linux Machine")
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True
@@ -102,7 +102,7 @@ class PyUSB(Interface):
                 kernel_driver_was_attached = True
         except NotImplementedError as e:
             # Some implementations don't don't have kernel attach/detach
-            log.debug('Exception detaching kernel driver: %s' %
+            LOG.debug('Exception detaching kernel driver: %s' %
                           str(e))
 
         # Explicitly claim the interface
@@ -221,7 +221,7 @@ class PyUSB(Interface):
         """
         assert self.closed is False
 
-        log.debug("closing interface")
+        LOG.debug("closing interface")
         self.closed = True
         self.read_sem.release()
         self.thread.join()
@@ -232,7 +232,7 @@ class PyUSB(Interface):
             try:
                 self.dev.attach_kernel_driver(self.intf_number)
             except Exception as exception:
-                log.warning('Exception attaching kernel driver: %s',
+                LOG.warning('Exception attaching kernel driver: %s',
                                 str(exception))
         usb.util.dispose_resources(self.dev)
         self.ep_out = None
@@ -272,15 +272,15 @@ class FindDap(object):
                 # If we recognize this device as one that should be CMSIS-DAP, we can raise
                 # the level of the log message since it's almost certainly a permissions issue.
                 if is_known_cmsis_dap_vid_pid(dev.idVendor, dev.idProduct):
-                    log.warning(msg)
+                    LOG.warning(msg)
                 else:
-                    log.debug(msg)
+                    LOG.debug(msg)
             else:
-                log.debug("Error accessing USB device (VID=%04x PID=%04x): %s",
+                LOG.debug("Error accessing USB device (VID=%04x PID=%04x): %s",
                     dev.idVendor, dev.idProduct, error)
             return False
         except (IndexError, NotImplementedError) as error:
-            log.debug("Error accessing USB device (VID=%04x PID=%04x): %s", dev.idVendor, dev.idProduct, error)
+            LOG.debug("Error accessing USB device (VID=%04x PID=%04x): %s", dev.idVendor, dev.idProduct, error)
             return False
 
         if device_string is None:

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -26,13 +26,13 @@ import six
 
 OPEN_TIMEOUT_S = 60.0
 
-log = logging.getLogger('pywinusb')
+LOG = logging.getLogger(__name__)
 
 try:
     import pywinusb.hid as hid
 except:
     if os.name == "nt":
-        log.error("PyWinUSB is required on a Windows Machine")
+        LOG.error("PyWinUSB is required on a Windows Machine")
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True
@@ -130,7 +130,7 @@ class PyWinUSB(Interface):
                 boards.append(new_board)
             except Exception as e:
                 if (str(e) != "Failure to get HID pre parsed data"):
-                    log.error("Receiving Exception: %s", e)
+                    LOG.error("Receiving Exception: %s", e)
                 dev.close()
 
         return boards
@@ -175,5 +175,5 @@ class PyWinUSB(Interface):
     def close(self):
         """! @brief Close the interface
         """
-        log.debug("closing interface")
+        LOG.debug("closing interface")
         self.device.close()

--- a/pyocd/probe/stlink/detect/base.py
+++ b/pyocd/probe/stlink/detect/base.py
@@ -21,8 +21,7 @@ from os.path import expanduser, isfile, join, exists, isdir
 import logging
 import functools
 
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
+LOG = logging.getLogger(__name__)
 
 
 class StlinkDetectBase(object):
@@ -82,7 +81,7 @@ class StlinkDetectBase(object):
                 self._update_device_from_htm(device)
 
         except (OSError, IOError) as e:
-            logger.warning(
+            LOG.warning(
                 'Marking device with mount point "%s" as unmounted due to the '
                 "following error: %s",
                 device["mount_point"],
@@ -98,7 +97,7 @@ class StlinkDetectBase(object):
         if htm_target_id:
             device["target_id"] = htm_target_id
         else:
-            logger.debug(
+            LOG.debug(
                 "Could not read htm on from usb id %s. Falling back to usb id",
                 device["target_id_usb_id"],
             )

--- a/pyocd/probe/stlink/detect/darwin.py
+++ b/pyocd/probe/stlink/detect/darwin.py
@@ -27,8 +27,7 @@ from xml.parsers.expat import ExpatError
 from .base import StlinkDetectBase
 
 
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
+LOG = logging.getLogger(__name__)
 
 mbed_volume_name_match = re.compile(r"\b(mbed)\b", re.I)
 

--- a/pyocd/probe/stlink/detect/linux.py
+++ b/pyocd/probe/stlink/detect/linux.py
@@ -19,8 +19,7 @@ import logging
 
 from .base import StlinkDetectBase
 
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
+LOG = logging.getLogger(__name__)
 
 SYSFS_BLOCK_DEVICE_PATH = "/sys/class/block"
 
@@ -73,7 +72,7 @@ class StlinkDetectLinuxGeneric(StlinkDetectBase):
             )
             return to_ret
         else:
-            logger.error(
+            LOG.error(
                 "Could not get %s devices by id. "
                 "This could be because your Linux distribution "
                 "does not use udev, or does not create /dev/%s/by-id "
@@ -126,7 +125,7 @@ class StlinkDetectLinuxGeneric(StlinkDetectBase):
                     end_index = index
 
             if end_index is None:
-                logger.debug(
+                LOG.debug(
                     "Did not find suitable usb folder for usb info: %s", full_sysfs_path
                 )
                 continue
@@ -146,7 +145,7 @@ class StlinkDetectLinuxGeneric(StlinkDetectBase):
                 with open(vendor_id_file_paths, "r") as vendor_file:
                     vendor_id = vendor_file.read().strip()
             except OSError as e:
-                logger.debug(
+                LOG.debug(
                     "Failed to read vendor id file %s weith error:",
                     vendor_id_file_paths,
                     e,
@@ -156,7 +155,7 @@ class StlinkDetectLinuxGeneric(StlinkDetectBase):
                 with open(product_id_file_paths, "r") as product_file:
                     product_id = product_file.read().strip()
             except OSError as e:
-                logger.debug(
+                LOG.debug(
                     "Failed to read product id file %s weith error:",
                     product_id_file_paths,
                     e,

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -23,7 +23,7 @@ import six
 import threading
 from enum import Enum
 
-log = logging.getLogger('stlink')
+LOG = logging.getLogger(__name__)
 
 class STLink(object):
     """!

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -27,10 +27,10 @@ import platform
 import errno
 from binascii import hexlify
 
-# Set to True to enable debug logs of USB data transfers.
-LOG_USB_DATA = False
-
 LOG = logging.getLogger(__name__)
+
+TRACE = LOG.getChild("trace")
+TRACE.setLevel(logging.CRITICAL)
 
 STLinkInfo = namedtuple('STLinkInfo', 'version_name out_ep in_ep swv_ep')
 
@@ -214,25 +214,21 @@ class STLinkUSBInterface(object):
         
         try:
             # Command phase.
-            if LOG_USB_DATA:
-                LOG.debug("  USB CMD> %s" % ' '.join(['%02x' % i for i in paddedCmd]))
+            TRACE.debug("  USB CMD> %s" % ' '.join(['%02x' % i for i in paddedCmd]))
             count = self._ep_out.write(paddedCmd, timeout)
             assert count == len(paddedCmd)
             
             # Optional data out phase.
             if writeData is not None:
-                if LOG_USB_DATA:
-                    LOG.debug("  USB OUT> %s" % ' '.join(['%02x' % i for i in writeData]))
+                TRACE.debug("  USB OUT> %s" % ' '.join(['%02x' % i for i in writeData]))
                 count = self._ep_out.write(writeData, timeout)
                 assert count == len(writeData)
             
             # Optional data in phase.
             if readSize is not None:
-                if LOG_USB_DATA:
-                    LOG.debug("  USB IN < (%d bytes)" % readSize)
+                TRACE.debug("  USB IN < (%d bytes)" % readSize)
                 data = self._read(readSize)
-                if LOG_USB_DATA:
-                    LOG.debug("  USB IN < %s" % ' '.join(['%02x' % i for i in data]))
+                TRACE.debug("  USB IN < %s" % ' '.join(['%02x' % i for i in data]))
                 return data
         except usb.core.USBError as exc:
             six.raise_from(exceptions.ProbeError("USB Error: %s" % exc), exc)

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -30,7 +30,7 @@ from binascii import hexlify
 # Set to True to enable debug logs of USB data transfers.
 LOG_USB_DATA = False
 
-log = logging.getLogger('stlink.usb')
+LOG = logging.getLogger(__name__)
 
 STLinkInfo = namedtuple('STLinkInfo', 'version_name out_ep in_ep swv_ep')
 
@@ -78,7 +78,7 @@ class STLinkUSBInterface(object):
                 # We've already checked that this is an STLink device by VID/PID, so we
                 # can use a warning log level to let the user know it's almost certainly
                 # a permissions issue.
-                log.warning("%s while trying to get the STLink USB device configuration "
+                LOG.warning("%s while trying to get the STLink USB device configuration "
                    "(VID=%04x PID=%04x). This can probably be remedied with a udev rule. "
                    "See <https://github.com/mbedmicro/pyOCD/tree/master/udev> for help.",
                    error, dev.idVendor, dev.idProduct)
@@ -215,24 +215,24 @@ class STLinkUSBInterface(object):
         try:
             # Command phase.
             if LOG_USB_DATA:
-                log.debug("  USB CMD> %s" % ' '.join(['%02x' % i for i in paddedCmd]))
+                LOG.debug("  USB CMD> %s" % ' '.join(['%02x' % i for i in paddedCmd]))
             count = self._ep_out.write(paddedCmd, timeout)
             assert count == len(paddedCmd)
             
             # Optional data out phase.
             if writeData is not None:
                 if LOG_USB_DATA:
-                    log.debug("  USB OUT> %s" % ' '.join(['%02x' % i for i in writeData]))
+                    LOG.debug("  USB OUT> %s" % ' '.join(['%02x' % i for i in writeData]))
                 count = self._ep_out.write(writeData, timeout)
                 assert count == len(writeData)
             
             # Optional data in phase.
             if readSize is not None:
                 if LOG_USB_DATA:
-                    log.debug("  USB IN < (%d bytes)" % readSize)
+                    LOG.debug("  USB IN < (%d bytes)" % readSize)
                 data = self._read(readSize)
                 if LOG_USB_DATA:
-                    log.debug("  USB IN < %s" % ' '.join(['%02x' % i for i in data]))
+                    LOG.debug("  USB IN < %s" % ' '.join(['%02x' % i for i in data]))
                 return data
         except usb.core.USBError as exc:
             six.raise_from(exceptions.ProbeError("USB Error: %s" % exc), exc)

--- a/pyocd/rtos/common.py
+++ b/pyocd/rtos/common.py
@@ -20,6 +20,8 @@ from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index)
 from ..core import exceptions
 import logging
 
+LOG = logging.getLogger(__name__)
+
 ## Mask on EXC_RETURN indicating whether space for FP registers is allocated
 # on the frame. The bit is 0 if the frame is extended.
 EXC_RETURN_EXT_FRAME_MASK = (1 << 4)
@@ -55,7 +57,7 @@ def read_c_string(context, ptr):
                     s += chr(c)
                     badCount = 0
     except exceptions.TransferError:
-        logging.debug("TransferError while trying to read 16 bytes at 0x%08x", ptr)
+        LOG.debug("TransferError while trying to read 16 bytes at 0x%08x", ptr)
 
     return s
 

--- a/pyocd/rtos/provider.py
+++ b/pyocd/rtos/provider.py
@@ -16,6 +16,8 @@
 
 import logging
 
+LOG = logging.getLogger(__name__)
+
 class TargetThread(object):
     """! @brief Base class representing a thread on the target."""
 
@@ -55,7 +57,7 @@ class ThreadProvider(object):
         syms = {}
         for name in symbolList:
             addr = symbolProvider.get_symbol_value(name)
-            logging.debug("Value for symbol %s = %s", name, hex(addr) if addr is not None else "<none>")
+            LOG.debug("Value for symbol %s = %s", name, hex(addr) if addr is not None else "<none>")
             if addr is None:
                 return None
             syms[name] = addr

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -22,7 +22,7 @@ from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index)
 import logging
 
 # Create a logger for this module.
-log = logging.getLogger("rtx5")
+LOG = logging.getLogger(__name__)
 
 class TargetList(object):
     def __init__(self, context, ptr, nextOffset):
@@ -42,7 +42,7 @@ class TargetList(object):
                 # Read the next item in the list.
                 node = self._context.read32(node + self._offset)
             except exceptions.TransferError as exc:
-                log.warning("TransferError while reading list elements (list=0x%08x, node=0x%08x), terminating list: %s", self._list, node, exc)
+                LOG.warning("TransferError while reading list elements (list=0x%08x, node=0x%08x), terminating list: %s", self._list, node, exc)
                 break
 
 class RTXThreadContext(DebugContext):
@@ -178,7 +178,7 @@ class RTXThreadContext(DebugContext):
                     hwStacked = 0x68
                     swStacked = 0x60
             except exceptions.TransferError:
-                log.debug("Transfer error while reading thread's saved LR")
+                LOG.debug("Transfer error while reading thread's saved LR")
 
         for reg in reg_list:
 
@@ -253,16 +253,16 @@ class RTXTargetThread(TargetThread):
             
             self.update_state()
         except exceptions.TransferError as exc:
-            log.debug("Transfer error while reading thread %x name: %s", self._base, exc)
+            LOG.debug("Transfer error while reading thread %x name: %s", self._base, exc)
             self._name = "?"
-        log.debug('RTXTargetThread 0x%x' % base)
+        LOG.debug('RTXTargetThread 0x%x' % base)
     
     def update_state(self):
         try:
             state = self._target_context.read8(self._base + RTXTargetThread.STATE_OFFSET)
             priority = self._target_context.read8(self._base + RTXTargetThread.PRIORITY_OFFSET)
         except exceptions.TransferError as exc:
-            log.debug("Transfer error while reading thread %x state: %s", self._base, exc)
+            LOG.debug("Transfer error while reading thread %x state: %s", self._base, exc)
         else:
             self._state = state
             self._priority = priority
@@ -297,7 +297,7 @@ class RTXTargetThread(TargetThread):
         try:
             return self._target_context.read32(self._base + RTXTargetThread.SP_OFFSET)
         except exceptions.TransferError:
-            log.debug("Transfer error while reading thread's stack pointer @ 0x%08x", self._base + RTXTargetThread.SP_OFFSET)
+            LOG.debug("Transfer error while reading thread's stack pointer @ 0x%08x", self._base + RTXTargetThread.SP_OFFSET)
             return 0
 
     def get_stack_frame(self):
@@ -306,7 +306,7 @@ class RTXTargetThread(TargetThread):
         try:
             return self._target_context.read8(self._base + RTXTargetThread.STACKFRAME_OFFSET) | 0xFFFFFF00
         except exceptions.TransferError:
-            log.debug("Transfer error while reading thread's stack frame @ 0x%08x", self._base + RTXTargetThread.STACKFRAME_OFFSET)
+            LOG.debug("Transfer error while reading thread's stack frame @ 0x%08x", self._base + RTXTargetThread.STACKFRAME_OFFSET)
             return 0xFFFFFFFD
 
 class RTX5ThreadProvider(ThreadProvider):
@@ -331,7 +331,7 @@ class RTX5ThreadProvider(ThreadProvider):
         self._os_rtx_info = symbolProvider.get_symbol_value('osRtxInfo')
         if self._os_rtx_info is None:
             return False
-        log.debug('osRtxInfo = 0x%08x', self._os_rtx_info)
+        LOG.debug('osRtxInfo = 0x%08x', self._os_rtx_info)
         self._readylist = self._os_rtx_info + RTX5ThreadProvider.THREADLIST_OFFSET
         self._delaylist = self._os_rtx_info + RTX5ThreadProvider.DELAYLIST_OFFSET
         self._waitlist = self._os_rtx_info + RTX5ThreadProvider.WAITLIST_OFFSET
@@ -411,7 +411,7 @@ class RTX5ThreadProvider(ThreadProvider):
             # if kernel state says we are (eg post reset)
             return self.get_kernel_state() != 0 and not self._target.in_thread_mode_on_main_stack()
         except exceptions.TransferError as exc:
-            log.debug("Transfer error checking if enabled: %s", exc)
+            LOG.debug("Transfer error checking if enabled: %s", exc)
             return False
 
     @property
@@ -423,7 +423,7 @@ class RTX5ThreadProvider(ThreadProvider):
         try:
             return self._threads[id]
         except KeyError:
-            log.debug("key error getting current thread id=%s; self._threads = %s",
+            LOG.debug("key error getting current thread id=%s; self._threads = %s",
                 ("%x" % id) if (id is not None) else id, repr(self._threads))
             return None
 

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -23,7 +23,7 @@ from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index)
 import logging
 
 # Create a logger for this module.
-log = logging.getLogger("zephyr")
+LOG = logging.getLogger(__name__)
 
 class TargetList(object):
     def __init__(self, context, ptr, next_offset):
@@ -41,7 +41,7 @@ class TargetList(object):
                 # Read next list node pointer.
                 node = self._context.read32(node + self._list_node_next_offset)
             except exceptions.TransferError:
-                log.warning("TransferError while reading list elements (list=0x%08x, node=0x%08x), terminating list", self._list, node)
+                LOG.warning("TransferError while reading list elements (list=0x%08x, node=0x%08x), terminating list", self._list, node)
                 node = 0
 
 class ZephyrThreadContext(DebugContext):
@@ -85,7 +85,7 @@ class ZephyrThreadContext(DebugContext):
 
         # If this is the current thread and we're not in an exception, just read the live registers.
         if isCurrent and not inException:
-            log.debug("Reading live registers")
+            LOG.debug("Reading live registers")
             return self._parent.read_core_registers_raw(reg_list)
 
         # Because of above tests, from now on, inException implies isCurrent;
@@ -104,7 +104,7 @@ class ZephyrThreadContext(DebugContext):
             # If this is a stack pointer register, add an offset to account for the exception stack frame
             if reg == 13:
                 val = sp + exceptionFrame
-                log.debug("Reading register %d = 0x%x", reg, val)
+                LOG.debug("Reading register %d = 0x%x", reg, val)
                 reg_vals.append(val)
                 continue
 
@@ -115,7 +115,7 @@ class ZephyrThreadContext(DebugContext):
                     addr = self._thread._base + self._thread._offsets["t_stack_ptr"] + calleeOffset
                     val = self._parent.read32(addr)
                     reg_vals.append(val)
-                    log.debug("Reading callee-saved register %d at 0x%08x = 0x%x", reg, addr, val)
+                    LOG.debug("Reading callee-saved register %d at 0x%08x = 0x%x", reg, addr, val)
                 except exceptions.TransferError:
                     reg_vals.append(0)
                 continue
@@ -127,14 +127,14 @@ class ZephyrThreadContext(DebugContext):
                     addr = sp + stackFrameOffset
                     val = self._parent.read32(addr)
                     reg_vals.append(val)
-                    log.debug("Reading stack frame register %d at 0x%08x = 0x%x", reg, addr, val)
+                    LOG.debug("Reading stack frame register %d at 0x%08x = 0x%x", reg, addr, val)
                 except exceptions.TransferError:
                     reg_vals.append(0)
                 continue
 
             # If we get here, this is a register not in any of the dictionaries
             val = self._parent.read_core_register_raw(reg)
-            log.debug("Reading live register %d = 0x%x", reg, val)
+            LOG.debug("Reading live register %d = 0x%x", reg, val)
             reg_vals.append(val)
             continue
 
@@ -178,7 +178,7 @@ class ZephyrThread(TargetThread):
         try:
             self.update_info()
         except exceptions.TransferError:
-            log.debug("Transfer error while reading thread info")
+            LOG.debug("Transfer error while reading thread info")
 
     def get_stack_pointer(self):
         # Get stack pointer saved in thread struct.
@@ -186,7 +186,7 @@ class ZephyrThread(TargetThread):
         try:
             return self._target_context.read32(addr)
         except exceptions.TransferError:
-            log.debug("Transfer error while reading thread's stack pointer @ 0x%08x", addr)
+            LOG.debug("Transfer error while reading thread's stack pointer @ 0x%08x", addr)
             return 0
 
     def update_info(self):
@@ -203,7 +203,7 @@ class ZephyrThread(TargetThread):
 
 
         except exceptions.TransferError:
-            log.debug("Transfer error while reading thread info")
+            LOG.debug("Transfer error while reading thread info")
 
     @property
     def state(self):
@@ -290,16 +290,16 @@ class ZephyrThreadProvider(ThreadProvider):
     def _get_offsets(self):
         # Read the kernel and thread structure member offsets
         size = self._target_context.read8(self._symbols["_kernel_openocd_size_t_size"])
-        log.debug("_kernel_openocd_size_t_size = %d", size)
+        LOG.debug("_kernel_openocd_size_t_size = %d", size)
         if size != 4:
-            log.error("Unsupported _kernel_openocd_size_t_size")
+            LOG.error("Unsupported _kernel_openocd_size_t_size")
             return None
 
         offsets = {}
         for index, name in enumerate(self.ZEPHYR_OFFSETS):
             offset = self._symbols["_kernel_openocd_offsets"] + index * size
             offsets[name] = self._target_context.read32(offset)
-            log.debug("%s = 0x%04x", name, offsets[name])
+            LOG.debug("%s = 0x%04x", name, offsets[name])
 
         return offsets
 
@@ -310,19 +310,19 @@ class ZephyrThreadProvider(ThreadProvider):
             self._version = None
             self._all_threads = None
             self._curr_thread = None
-            log.debug("_offsets, _all_threads, and _curr_thread are invalid")
+            LOG.debug("_offsets, _all_threads, and _curr_thread are invalid")
         else:
             self._version = self._offsets["version"]
             self._all_threads = self._symbols["_kernel"] + self._offsets["k_threads"]
             self._curr_thread = self._symbols["_kernel"] + self._offsets["k_curr_thread"]
-            log.debug("version = %d, _all_threads = 0x%08x, _curr_thread = 0x%08x", self._version, self._all_threads, self._curr_thread)
+            LOG.debug("version = %d, _all_threads = 0x%08x, _curr_thread = 0x%08x", self._version, self._all_threads, self._curr_thread)
 
     def invalidate(self):
         self._threads = {}
 
     def event_handler(self, notification):
         if notification.event == Target.EVENT_POST_RESET:
-            log.debug("Invalidating threads list: %s" % (repr(notification)))
+            LOG.debug("Invalidating threads list: %s" % (repr(notification)))
             self.invalidate();
 
         elif notification.event == Target.EVENT_POST_FLASH_PROGRAM:
@@ -333,7 +333,7 @@ class ZephyrThreadProvider(ThreadProvider):
         newThreads = {}
 
         currentThread = self._target_context.read32(self._curr_thread)
-        log.debug("currentThread = 0x%08x", currentThread)
+        LOG.debug("currentThread = 0x%08x", currentThread)
 
         for threadBase in allThreads:
             try:
@@ -350,14 +350,14 @@ class ZephyrThreadProvider(ThreadProvider):
                 if threadBase == currentThread:
                     t.state = ZephyrThread.RUNNING
 
-                log.debug("Thread 0x%08x (%s)", threadBase, t.name)
+                LOG.debug("Thread 0x%08x (%s)", threadBase, t.name)
                 newThreads[t.unique_id] = t
             except exceptions.TransferError:
-                log.debug("TransferError while examining thread 0x%08x", threadBase)
+                LOG.debug("TransferError while examining thread 0x%08x", threadBase)
 
         # Create fake handler mode thread.
         if self._target_context.read_core_register('ipsr') > 0:
-            log.debug("creating handler mode thread")
+            LOG.debug("creating handler mode thread")
             t = HandlerModeThread(self._target_context, self)
             newThreads[t.unique_id] = t
 

--- a/pyocd/target/builtin/target_CC3220SF.py
+++ b/pyocd/target/builtin/target_CC3220SF.py
@@ -23,6 +23,8 @@ from ...core.memory_map import (RomRegion, FlashRegion, RamRegion, MemoryMap)
 import logging
 import time
 
+LOG = logging.getLogger(__name__)
+
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [
                                 0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,
@@ -86,7 +88,7 @@ class Flash_cc3220sf(Flash):
 
         # check the return code
         if result != 0:
-            logging.error('init error: %i', result)
+            LOG.error('init error: %i', result)
 
         # erase the cookie which take up one page
         self.erase_sector(0x01000000)
@@ -108,7 +110,7 @@ class Flash_cc3220sf(Flash):
 
         # check the return code
         if result != 0:
-            logging.error('init error: %i', result)
+            LOG.error('init error: %i', result)
 
 
 class CC3220SF(CoreSightTarget):

--- a/pyocd/target/builtin/target_CY8C6xx7.py
+++ b/pyocd/target/builtin/target_CY8C6xx7.py
@@ -25,6 +25,8 @@ from ...flash.flash import Flash
 from ...utility.notification import Notification
 from ...utility.timeout import Timeout
 
+LOG = logging.getLogger(__name__)
+
 flash_algo_main = {
     'load_address': 0x08000000,
 
@@ -298,12 +300,12 @@ class CortexM_CY8C6xx7(CortexM):
 
         vtbase &= 0xFFFFFF00
         if vtbase < 0x10000000 or vtbase > 0x18000000:
-            logging.info("Vector Table address invalid (0x%08X), will not halt at main()", vtbase)
+            LOG.info("Vector Table address invalid (0x%08X), will not halt at main()", vtbase)
             return
 
         entry = self.read_memory(vtbase + 4)
         if entry < 0x10000000 or entry > 0x18000000:
-            logging.info("Entry Point address invalid (0x%08X), will not halt at main()", entry)
+            LOG.info("Entry Point address invalid (0x%08X), will not halt at main()", entry)
             return
 
         self.set_breakpoint(entry)

--- a/pyocd/target/builtin/target_CY8C6xxA.py
+++ b/pyocd/target/builtin/target_CY8C6xxA.py
@@ -25,6 +25,8 @@ from ...flash.flash import Flash
 from ...utility.notification import Notification
 from ...utility.timeout import Timeout
 
+LOG = logging.getLogger(__name__)
+
 flash_algo_main = {
     'load_address': 0x08000000,
 
@@ -489,12 +491,12 @@ class CortexM_CY8C6xxA(CortexM):
 
         vtbase &= 0xFFFFFF00
         if vtbase < 0x10000000 or vtbase > 0x18000000:
-            logging.info("Vector Table address invalid (0x%08X), will not halt at main()", vtbase)
+            LOG.info("Vector Table address invalid (0x%08X), will not halt at main()", vtbase)
             return
 
         entry = self.read_memory(vtbase + 4)
         if entry < 0x10000000 or entry > 0x18000000:
-            logging.info("Entry Point address invalid (0x%08X), will not halt at main()", entry)
+            LOG.info("Entry Point address invalid (0x%08X), will not halt at main()", entry)
             return
 
         self.set_breakpoint(entry)

--- a/pyocd/target/builtin/target_K32W042S1M2xxx.py
+++ b/pyocd/target/builtin/target_K32W042S1M2xxx.py
@@ -52,7 +52,7 @@ MDM_CORE_STATUS_CM0P_HALTED = (1 << 15)
 
 HALT_TIMEOUT = 2.0
 
-log = logging.getLogger("target.k32w042s")
+LOG = logging.getLogger(__name__)
 
 FLASH_ALGO = {
     'load_address' : 0x20000000,
@@ -209,7 +209,7 @@ class K32W042S(Kinetis):
                 while to.check():
                     if self.mdm_ap.read_reg(MDM_CORE_STATUS) & MDM_CORE_STATUS_CM4_HALTED != MDM_CORE_STATUS_CM4_HALTED:
                         break
-                    log.debug("Waiting for mdm halt")
+                    LOG.debug("Waiting for mdm halt")
                     sleep(0.01)
                 else:
                     raise RuntimeError("Timed out waiting for core to halt")

--- a/pyocd/target/builtin/target_MAX32600.py
+++ b/pyocd/target/builtin/target_MAX32600.py
@@ -19,6 +19,8 @@ from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, DeviceRegion, MemoryMap)
 import logging
 
+LOG = logging.getLogger(__name__)
+
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [
     0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,
@@ -67,7 +69,7 @@ class MAX32600(CoreSightTarget):
         super(MAX32600, self).__init__(link, self.memoryMap)
 
     def dsb(self):
-        logging.info("Triggering Destructive Security Bypass...")
+        LOG.info("Triggering Destructive Security Bypass...")
 
         self.link.vendor(1)
 
@@ -75,7 +77,7 @@ class MAX32600(CoreSightTarget):
         self.link.init()
 
     def fge(self):
-        logging.info("Triggering Factory Global Erase...")
+        LOG.info("Triggering Factory Global Erase...")
 
         self.link.vendor(2)
 

--- a/pyocd/target/builtin/target_MAX32620.py
+++ b/pyocd/target/builtin/target_MAX32620.py
@@ -18,7 +18,6 @@ from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MAX32625.py
+++ b/pyocd/target/builtin/target_MAX32625.py
@@ -18,7 +18,6 @@ from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MAX32630.py
+++ b/pyocd/target/builtin/target_MAX32630.py
@@ -18,7 +18,6 @@ from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
@@ -19,7 +19,6 @@ from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RomRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO_QUADSPI = {
     'load_address' : 0x20000000,

--- a/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
+++ b/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
@@ -19,7 +19,6 @@ from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RomRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO_QUADSPI = {
     'load_address' : 0x20000000,

--- a/pyocd/target/builtin/target_MK20DX128xxx5.py
+++ b/pyocd/target/builtin/target_MK20DX128xxx5.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MK22FN1M0Axxx12.py
+++ b/pyocd/target/builtin/target_MK22FN1M0Axxx12.py
@@ -24,7 +24,7 @@ SIM_FCFG1 = 0x4004804C
 SIM_FCFG2 = 0x40048050
 SIM_FCFG2_PFLSH = (1 << 23)
 
-log = logging.getLogger("target.k22fa12")
+LOG = logging.getLogger(__name__)
 
 FLASH_ALGO = {
     'load_address' : 0x20000000,
@@ -116,9 +116,9 @@ class K22FA12(Kinetis):
         # If the device has FlexNVM, then it has half-sized program flash.
         fcfg2 = self.dp.aps[0].read32(SIM_FCFG2)
         if (fcfg2 & SIM_FCFG2_PFLSH) == 0:
-            log.debug("%s: device has FlexNVM", self.part_number)
+            LOG.debug("%s: device has FlexNVM", self.part_number)
             rgn = self.memory_map.get_region_for_address(0)
             rgn._end = 0x7ffff
         else:
-            log.debug("%s: device does not have FlexNVM", self.part_number)
+            LOG.debug("%s: device does not have FlexNVM", self.part_number)
 

--- a/pyocd/target/builtin/target_MK22FN512xxx12.py
+++ b/pyocd/target/builtin/target_MK22FN512xxx12.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MK28FN2M0xxx15.py
+++ b/pyocd/target/builtin/target_MK28FN2M0xxx15.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MK64FN1M0xxx12.py
+++ b/pyocd/target/builtin/target_MK64FN1M0xxx12.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MK66FN2M0xxx18.py
+++ b/pyocd/target/builtin/target_MK66FN2M0xxx18.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MK82FN256xxx15.py
+++ b/pyocd/target/builtin/target_MK82FN256xxx15.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = {
     'load_address' : 0x20000000,

--- a/pyocd/target/builtin/target_MKE15Z256xxx7.py
+++ b/pyocd/target/builtin/target_MKE15Z256xxx7.py
@@ -20,7 +20,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 RCM_MR = 0x4007f010
 RCM_MR_BOOTROM_MASK = 0x6

--- a/pyocd/target/builtin/target_MKE18F256xxx16.py
+++ b/pyocd/target/builtin/target_MKE18F256xxx16.py
@@ -20,7 +20,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 RCM_MR = 0x4007f010
 RCM_MR_BOOTROM_MASK = 0x6

--- a/pyocd/target/builtin/target_MKL02Z32xxx4.py
+++ b/pyocd/target/builtin/target_MKL02Z32xxx4.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKL05Z32xxx4.py
+++ b/pyocd/target/builtin/target_MKL05Z32xxx4.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKL25Z128xxx4.py
+++ b/pyocd/target/builtin/target_MKL25Z128xxx4.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKL26Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL26Z256xxx4.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKL27Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL27Z256xxx4.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKL28Z512xxx7.py
+++ b/pyocd/target/builtin/target_MKL28Z512xxx7.py
@@ -24,6 +24,8 @@ import logging
 import os.path
 from time import (time, sleep)
 
+LOG = logging.getLogger(__name__)
+
 SIM_SDID = 0x40075024
 SIM_SDID_KEYATTR_MASK = 0x70
 SIM_SDID_KEYATTR_SHIFT = 4
@@ -150,7 +152,7 @@ class Flash_kl28z(Flash_Kinetis):
         self.target.write32(SCG_RCCR, (0x3 << SCS_SHIFT) | (1 << DIVSLOW_SHIFT))
 
         csr = self.target.read32(SCG_CSR)
-        logging.debug("SCG_CSR = 0x%08x", csr)
+        LOG.debug("SCG_CSR = 0x%08x", csr)
 
     ##
     # Restore clock registers to original values.
@@ -212,10 +214,10 @@ class KL28x(Kinetis):
         # Check if this is the dual core part.
         sdid = self.aps[0].read_memory(SIM_SDID)
         keyattr = (sdid & SIM_SDID_KEYATTR_MASK) >> SIM_SDID_KEYATTR_SHIFT
-        logging.debug("KEYATTR=0x%x SDID=0x%08x", keyattr, sdid)
+        LOG.debug("KEYATTR=0x%x SDID=0x%08x", keyattr, sdid)
         self.is_dual_core = (keyattr == KEYATTR_DUAL_CORE)
         if self.is_dual_core:
-            logging.info("KL28 is dual core")
+            LOG.info("KL28 is dual core")
             self.memory_map = self.dualMap
 
     def disable_rom_remap(self):

--- a/pyocd/target/builtin/target_MKL43Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL43Z256xxx4.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKL46Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL46Z256xxx4.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKL82Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKL82Z128xxx7.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = {
     'load_address' : 0x20000000,

--- a/pyocd/target/builtin/target_MKV10Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKV10Z128xxx7.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKV11Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKV11Z128xxx7.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKW01Z128xxx4.py
+++ b/pyocd/target/builtin/target_MKW01Z128xxx4.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKW24D512xxx5.py
+++ b/pyocd/target/builtin/target_MKW24D512xxx5.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKW36Z512xxx4.py
+++ b/pyocd/target/builtin/target_MKW36Z512xxx4.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = {
     'load_address' : 0x20000000,

--- a/pyocd/target/builtin/target_MKW40Z160xxx4.py
+++ b/pyocd/target/builtin/target_MKW40Z160xxx4.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_MKW41Z512xxx4.py
+++ b/pyocd/target/builtin/target_MKW41Z512xxx4.py
@@ -18,7 +18,6 @@ from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = {
     'load_address' : 0x20000000,

--- a/pyocd/target/builtin/target_RTL8195AM.py
+++ b/pyocd/target/builtin/target_RTL8195AM.py
@@ -16,7 +16,6 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (RamRegion, MemoryMap)
-import logging
 
 class RTL8195AM(CoreSightTarget):
 
@@ -31,7 +30,3 @@ class RTL8195AM(CoreSightTarget):
 
     def __init__(self, link):
         super(RTL8195AM, self).__init__(link, self.memoryMap)
-
-    def init(self):
-        logging.debug('rtl8195am init')
-        super(RTL8195AM, self).init()

--- a/pyocd/target/builtin/target_STM32F051T8.py
+++ b/pyocd/target/builtin/target_STM32F051T8.py
@@ -18,7 +18,6 @@ from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 #DBGMCU clock
 RCC_APB2ENR_CR = 0x40021018
@@ -91,7 +90,6 @@ class STM32F051(CoreSightTarget):
         return seq
         
     def setup_dbgmcu(self):
-        logging.debug('stm32f051 init')
         enclock = self.read_memory(RCC_APB2ENR_CR)
         enclock |= RCC_APB2ENR_DBGMCU
         self.write_memory(RCC_APB2ENR_CR, enclock)

--- a/pyocd/target/builtin/target_STM32F103RC.py
+++ b/pyocd/target/builtin/target_STM32F103RC.py
@@ -18,7 +18,6 @@ from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 DBGMCU_CR = 0xE0042004
 #0111 1110 0011 1111 1111 1111 0000 0000
@@ -74,7 +73,6 @@ class STM32F103RC(CoreSightTarget):
         return seq
 
     def setup_dbgmcu(self):
-        logging.debug('stm32f103rc init')
         self.write_memory(DBGMCU_CR, DBGMCU_VAL)
 
 

--- a/pyocd/target/builtin/target_nRF51822_xxAA.py
+++ b/pyocd/target/builtin/target_nRF51822_xxAA.py
@@ -20,6 +20,8 @@ from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 import logging
 
+LOG = logging.getLogger(__name__)
+
 # NRF51 specific registers
 RESET = 0x40000544
 RESET_ENABLE = (1 << 0)
@@ -70,8 +72,8 @@ class NRF51(CoreSightTarget):
         is running
         """
         #Regular reset will kick NRF out of DBG mode
-        logging.debug("target_nrf51.reset: enable reset pin")
+        LOG.debug("target_nrf51.reset: enable reset pin")
         self.write_memory(RESET, RESET_ENABLE)
         #reset
-        logging.debug("target_nrf51.reset: trigger nRST pin")
+        LOG.debug("target_nrf51.reset: trigger nRST pin")
         self.reset()

--- a/pyocd/target/builtin/target_nRF52832_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52832_xxAA.py
@@ -18,7 +18,6 @@ from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_nRF52840_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52840_xxAA.py
@@ -18,7 +18,6 @@ from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [

--- a/pyocd/target/builtin/target_ncs36510.py
+++ b/pyocd/target/builtin/target_ncs36510.py
@@ -17,7 +17,6 @@
 from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-import logging
 
 FLASH_ALGO = {
     'load_address' : 0x3fff4000,

--- a/pyocd/target/family/flash_kinetis.py
+++ b/pyocd/target/family/flash_kinetis.py
@@ -17,6 +17,8 @@
 from ...flash.flash import Flash
 import logging
 
+LOG = logging.getLogger(__name__)
+
 # Kinetis security values and addresses
 SECURITY_START = 0x400
 SECURITY_SIZE = 16
@@ -72,26 +74,26 @@ class Flash_Kinetis(Flash):
             for i in range(FPROT_ADDR, FPROT_ADDR_END):
                 if (data[i - address] != 0xff):
                     data[i - address] = 0xff
-                    logging.debug("FCF[%d] at addr 0x%X changed to 0x%X", i - FPROT_ADDR, i, data[i - address])
+                    LOG.debug("FCF[%d] at addr 0x%X changed to 0x%X", i - FPROT_ADDR, i, data[i - address])
 
             # FSEC must be 0xff
             if data[FSEC_ADDR - address] != FSEC_VAL:
                 data[FSEC_ADDR - address] = FSEC_VAL
-                logging.debug("FSEC at addr 0x%X changed to 0x%X", FSEC_ADDR, FSEC_VAL)
+                LOG.debug("FSEC at addr 0x%X changed to 0x%X", FSEC_ADDR, FSEC_VAL)
 
             # FOPT must not be 0x00, any other value is acceptable.
             if data[FOPT_ADDR - address] == 0x00:
-                logging.debug("FOPT is restricted value 0x00")
+                LOG.debug("FOPT is restricted value 0x00")
 
             # FEPROT must be 0xff
             if data[FEPROT_ADDR - address] != FEPROT_VAL:
                 data[FEPROT_ADDR - address] = FEPROT_VAL
-                logging.debug("FEPROT at addr 0x%X changed to 0x%X", FEPROT_ADDR, FEPROT_VAL)
+                LOG.debug("FEPROT at addr 0x%X changed to 0x%X", FEPROT_ADDR, FEPROT_VAL)
 
             # FDPROT must be 0xff
             if data[FDPROT_ADDR - address] != FDPROT_VAL:
                 data[FDPROT_ADDR - address] = FDPROT_VAL
-                logging.debug("FDPROT at addr 0x%X changed to 0x%X", FDPROT_ADDR, FDPROT_VAL)
+                LOG.debug("FDPROT at addr 0x%X changed to 0x%X", FDPROT_ADDR, FDPROT_VAL)
 
             # convert back to tuple
             data = tuple(data)

--- a/pyocd/target/family/target_kinetis.py
+++ b/pyocd/target/family/target_kinetis.py
@@ -47,7 +47,7 @@ MASS_ERASE_TIMEOUT = 10.0
 
 ACCESS_TEST_ATTEMPTS = 10
 
-log = logging.getLogger("target.family.kinetis")
+LOG = logging.getLogger(__name__)
 
 class Kinetis(CoreSightTarget):
     """! @brief Family class for NXP Kinetis devices.
@@ -81,10 +81,10 @@ class Kinetis(CoreSightTarget):
         
         # Check MDM-AP ID.
         if (self.mdm_ap.idr & ~MDM_IDR_VERSION_MASK) != MDM_IDR_EXPECTED:
-            log.error("%s: bad MDM-AP IDR (is 0x%08x)", self.part_number, self.mdm_ap.idr)
+            LOG.error("%s: bad MDM-AP IDR (is 0x%08x)", self.part_number, self.mdm_ap.idr)
         
         self.mdm_ap_version = (self.mdm_ap.idr & MDM_IDR_VERSION_MASK) >> MDM_IDR_VERSION_SHIFT
-        log.debug("MDM-AP version %d", self.mdm_ap_version)
+        LOG.debug("MDM-AP version %d", self.mdm_ap_version)
 
     def check_flash_security(self):
         """! @brief Check security and unlock device.
@@ -118,7 +118,7 @@ class Kinetis(CoreSightTarget):
                 for attempt in range(ACCESS_TEST_ATTEMPTS):
                     self.aps[0].read32(CortexM.DHCSR)
             except exceptions.TransferError:
-                log.debug("Access test failed with fault")
+                LOG.debug("Access test failed with fault")
                 canAccess = False
             else:
                 canAccess = True
@@ -138,19 +138,19 @@ class Kinetis(CoreSightTarget):
             
             # If the device isn't really locked, we have no choice but to halt on connect.
             if not isLocked and not self.halt_on_connect:
-                log.warning("Forcing halt on connect in order to gain control of device")
+                LOG.warning("Forcing halt on connect in order to gain control of device")
                 self.halt_on_connect = True
         
         # Only do a mass erase if the device is actually locked.
         if isLocked:
             if self.auto_unlock:
-                log.warning("%s in secure state: will try to unlock via mass erase", self.part_number)
+                LOG.warning("%s in secure state: will try to unlock via mass erase", self.part_number)
                 
                 # Do the mass erase.
                 if not self.mass_erase():
                     self.dp.assert_reset(False)
                     self.mdm_ap.write_reg(MDM_CTRL, 0)
-                    log.error("%s: mass erase failed", self.part_number)
+                    LOG.error("%s: mass erase failed", self.part_number)
                     raise RuntimeError("unable to unlock device")
                 
                 # Assert that halt on connect was forced above. Reset will stay asserted
@@ -159,9 +159,9 @@ class Kinetis(CoreSightTarget):
 
                 isLocked = False
             else:
-                log.warning("%s in secure state: not automatically unlocking", self.part_number)
+                LOG.warning("%s in secure state: not automatically unlocking", self.part_number)
         else:
-            log.info("%s not in secure state", self.part_number)
+            LOG.info("%s not in secure state", self.part_number)
 
     def perform_halt_on_connect(self):
         """! This init task runs *after* cores are created."""
@@ -189,7 +189,7 @@ class Kinetis(CoreSightTarget):
                 while to.check():
                     if self.mdm_ap.read_reg(MDM_STATUS) & MDM_STATUS_CORE_HALTED == MDM_STATUS_CORE_HALTED:
                         break
-                    log.debug("Waiting for mdm halt")
+                    LOG.debug("Waiting for mdm halt")
                     sleep(0.01)
                 else:
                     raise RuntimeError("Timed out waiting for core to halt")
@@ -240,13 +240,13 @@ class Kinetis(CoreSightTarget):
         """! @brief Private mass erase routine."""
         # Flash must finish initing before we can mass erase.
         if not self._wait_for_flash_init():
-            log.error("Mass erase timeout waiting for flash to finish init")
+            LOG.error("Mass erase timeout waiting for flash to finish init")
             return False
 
         # Check if mass erase is enabled.
         status = self.mdm_ap.read_reg(MDM_STATUS)
         if not (status & MDM_STATUS_MASS_ERASE_ENABLE):
-            log.error("Mass erase disabled. MDM status: 0x%x", status)
+            LOG.error("Mass erase disabled. MDM status: 0x%x", status)
             return False
 
         # Set Flash Mass Erase in Progress bit to start erase.
@@ -260,7 +260,7 @@ class Kinetis(CoreSightTarget):
                     break
                 sleep(0.1)
             else: #if to.did_time_out:
-                log.error("Mass erase timeout waiting for Flash Mass Erase Ack to set")
+                LOG.error("Mass erase timeout waiting for Flash Mass Erase Ack to set")
                 return False
 
         # Wait for Flash Mass Erase in Progress bit to clear when erase is completed.
@@ -271,15 +271,15 @@ class Kinetis(CoreSightTarget):
                     break
                 sleep(0.1)
             else: #if to.did_time_out:
-                log.error("Mass erase timeout waiting for Flash Mass Erase in Progress to clear")
+                LOG.error("Mass erase timeout waiting for Flash Mass Erase in Progress to clear")
                 return False
 
         # Confirm the part was unlocked
         val = self.mdm_ap.read_reg(MDM_STATUS)
         if (val & MDM_STATUS_SYSTEM_SECURITY) == 0:
-            log.warning("%s secure state: unlocked successfully", self.part_number)
+            LOG.warning("%s secure state: unlocked successfully", self.part_number)
             return True
         else:
-            log.error("Failed to unlock. MDM status: 0x%x", val)
+            LOG.error("Failed to unlock. MDM status: 0x%x", val)
             return False
 

--- a/pyocd/tools/flash_tool.py
+++ b/pyocd/tools/flash_tool.py
@@ -38,6 +38,8 @@ from ..utility.cmdline import convert_session_options
 from ..debug.elf.elf import (ELFBinaryFile, SH_FLAGS)
 from ..flash.loader import (FileProgrammer, FlashEraser)
 
+LOG = logging.getLogger(__name__)
+
 LEVELS = {
     'debug': logging.DEBUG,
     'info': logging.INFO,
@@ -133,7 +135,7 @@ def main():
     DAPAccess.set_args(args.daparg)
 
     if not args.no_deprecation_warning:
-        logging.warning("pyocd-flashtool is deprecated; please use the new combined pyocd tool.")
+        LOG.warning("pyocd-flashtool is deprecated; please use the new combined pyocd tool.")
         
     # Sanity checks before attaching to board
     if args.format == 'hex' and not intelhex_available:

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -34,6 +34,8 @@ from ..probe.cmsis_dap_probe import CMSISDAPProbe
 from ..probe.pydapaccess import DAPAccess
 from ..core.session import Session
 
+LOG = logging.getLogger(__name__)
+
 LEVELS = {
     'debug': logging.DEBUG,
     'info': logging.INFO,
@@ -255,7 +257,7 @@ class GDBServerTool(object):
         DAPAccess.set_args(self.args.daparg)
 
         if not self.args.no_deprecation_warning:
-            logging.warning("pyocd-gdbserver is deprecated; please use the new combined pyocd tool.")
+            LOG.warning("pyocd-gdbserver is deprecated; please use the new combined pyocd tool.")
     
         self.process_commands(self.args.commands)
 
@@ -298,7 +300,7 @@ class GDBServerTool(object):
                 for gdb in gdbs:
                     gdb.stop()
             except Exception as e:
-                logging.error("uncaught exception: %s" % e, exc_info=Session.get_current().log_tracebacks)
+                LOG.error("uncaught exception: %s" % e, exc_info=Session.get_current().log_tracebacks)
                 for gdb in gdbs:
                     gdb.stop()
                 return 1

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -54,6 +54,8 @@ try:
 except ImportError:
     isCapstoneAvailable = False # pylint: disable=invalid-name
 
+LOG = logging.getLogger(__name__)
+
 LEVELS = {
         'debug':logging.DEBUG,
         'info':logging.INFO,
@@ -1763,7 +1765,7 @@ class PyOCDTool(object):
         DAPAccess.set_args(self.args.daparg)
         
         if not self.args.no_deprecation_warning:
-            logging.warning("pyocd-tool is deprecated; please use the new combined pyocd tool.")
+            LOG.warning("pyocd-tool is deprecated; please use the new combined pyocd tool.")
         
         # Convert args to new names.
         self.args.target_override = self.args.target

--- a/pyocd/trace/events.py
+++ b/pyocd/trace/events.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 class TraceEvent(object):
     """! @brief Base trace event class."""
     def __init__(self, desc="", ts=0):

--- a/pyocd/trace/sink.py
+++ b/pyocd/trace/sink.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import collections
 
 class TraceEventSink(object):

--- a/pyocd/trace/swo.py
+++ b/pyocd/trace/swo.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from . import events
 
 class SWOParser(object):

--- a/pyocd/utility/notification.py
+++ b/pyocd/utility/notification.py
@@ -18,8 +18,8 @@ import logging
 
 LOG = logging.getLogger(__name__)
 
-## Set to true to log all notifications.
-LOG_NOTIFICATIONS = False
+TRACE = LOG.getChild("trace")
+TRACE.setLevel(logging.CRITICAL)
 
 class Notification(object):
     """!@brief Class that holds information about a notification to subscribers."""
@@ -62,10 +62,7 @@ class Notifier(object):
 
     def notify(self, *notifications):
         for note in notifications:
-            # This debug log is commented out because it produces too much output unless you
-            # are specifically working on notifications.
-            if LOG_NOTIFICATIONS:
-                LOG.debug("Sending notification: %s", repr(note))
+            TRACE.debug("Sending notification: %s", repr(note))
             for cb in self._subscribers.get(note.event, []):
                 cb(note)
 

--- a/pyocd/utility/notification.py
+++ b/pyocd/utility/notification.py
@@ -16,6 +16,11 @@
 
 import logging
 
+LOG = logging.getLogger(__name__)
+
+## Set to true to log all notifications.
+LOG_NOTIFICATIONS = False
+
 class Notification(object):
     """!@brief Class that holds information about a notification to subscribers."""
     def __init__(self, event, source, data=None):
@@ -59,7 +64,8 @@ class Notifier(object):
         for note in notifications:
             # This debug log is commented out because it produces too much output unless you
             # are specifically working on notifications.
-#             logging.debug("Sending notification: %s", repr(note))
+            if LOG_NOTIFICATIONS:
+                LOG.debug("Sending notification: %s", repr(note))
             for cb in self._subscribers.get(note.event, []):
                 cb(note)
 

--- a/pyocd/utility/sequencer.py
+++ b/pyocd/utility/sequencer.py
@@ -17,7 +17,7 @@
 from collections import (OrderedDict, Callable)
 import logging
 
-log = logging.getLogger("sequencer")
+LOG = logging.getLogger(__name__)
 
 class CallSequence(object):
     """! @brief Call sequence manager.
@@ -197,12 +197,12 @@ class CallSequence(object):
         executed.
         """
         for name, call in self._calls.items():
-            log.debug("Running task %s", name)
+            LOG.debug("Running task %s", name)
             resultSequence = call()
             
             # Invoke returned call sequence.
             if resultSequence is not None and isinstance(resultSequence, CallSequence):
-#                 log.debug("Invoking returned call sequence: %s", resultSequence)
+#                 LOG.debug("Invoking returned call sequence: %s", resultSequence)
                 resultSequence.invoke()
     
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
This PR accomplishes two primary goals:
- Normalize logging usage in pyOCD. Every module that writes log messages now uses a module-specific logger with the name of that module, for instance `pyocd.coresight.cortex_m`.
- Enable logging configuration to be customized. A `logger` user option can be set to a [logging configuration dictionary](https://docs.python.org/2.7/library/logging.config.html#logging-config-dictschema) to fully configure all aspects of logging. Full documentation is included.

A few related changes were included:
- Fatal errors are logged by the `pyocd` tool at the CRITICAL level.
- The various LOG_X flags in some modules to control trace logs were converted to trace loggers that have a default level of CRITICAL, so they won't output anything unless overridden by a logging configuration. This lets you control trace output without having to modify source.
- GDB server and packet threads set the thread name (useful if you set a log formatter that prints the thread name).