### PR TITLE
Missed converting a couple user options get() calls

### DIFF
--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -348,7 +348,7 @@ class GDBServer(threading.Thread):
                 self.log.warning("Cannot enable SWV due to missing swv_system_clock option")
             else:
                 sys_clock = int(session.options.get("swv_system_clock"))
-                swo_clock = int(session.options.get("swv_clock", 1000000))
+                swo_clock = int(session.options.get("swv_clock"))
                 self._swv_reader = SWVReader(session, self.core)
                 self._swv_reader.init(sys_clock, swo_clock, console_file)
 

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -387,7 +387,7 @@ class CmsisPackDevice(object):
             
             # Log details of this flash algo if the debug option is enabled.
             current_session = core.session.Session.get_current()
-            if current_session and current_session.options.get("debug.log_flm_info", False):
+            if current_session and current_session.options.get("debug.log_flm_info"):
                 LOG.debug("Flash algo info: %s", packAlgo.flash_info)
             
             # Choose the page size. The check for <=32 is to handle some flash algos with incorrect


### PR DESCRIPTION
Accidentally missed removing the default value parameter from a couple calls to `get()` a user option.