### PR TITLE
Update cmsis-pack-manager version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     # Allow installation on 2.7.9+, and 3.4+ even though we officially only support 3.6+.
     python_requires=">=2.7.9, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires = [
-        'cmsis-pack-manager>=0.2.6',
+        'cmsis-pack-manager>=0.2.7',
         'colorama',
         'enum34>=1.0,<2.0;python_version<"3.4"',
         'hidapi;platform_system=="Darwin"',

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -23,4 +23,7 @@ def mockcore():
     return MockCore()
 
 # Ignore semihosting test that currently crashes on Travis
-collect_ignore = ["test_semihosting.py"]
+collect_ignore = [
+    "test_semihosting.py",
+    "test_pack.py"
+    ]

--- a/test/unit/test_pack.py
+++ b/test/unit/test_pack.py
@@ -1,0 +1,76 @@
+# pyOCD debugger
+# Copyright (c) 2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import six
+import cmsis_pack_manager
+
+from pyocd.target.pack import (cmsis_pack, flash_algo, pack_target)
+from pyocd.target import TARGET
+from pyocd.core import memory_map
+
+K64F = "MK64FN1M0VDC12"
+
+@pytest.fixture(scope='module')
+def pack_ref():
+    return cmsis_pack_manager.CmsisPackRef(
+                "NXP",
+                "MK64F12_DFP",
+                "11.0.1",
+            )
+
+@pytest.fixture(scope='module', autouse=True)
+def cache(tmpdir_factory, pack_ref):
+    tmp_path = str(tmpdir_factory.mktemp("cpm"))
+    c = cmsis_pack_manager.Cache(False, False, json_path=tmp_path, data_path=tmp_path)
+    c.download_pack_list([pack_ref])
+    return c
+
+@pytest.fixture(scope='module')
+def k64dev(cache):
+    devs = pack_target.ManagedPacks.get_installed_targets()
+    return [d for d in devs if d.part_number == K64F].pop()
+
+@pytest.fixture(autouse=True)
+def fixed_installed_packs(monkeypatch, pack_ref):
+    def my_get_installed_packs(cache=None):
+        return [pack_ref]
+    monkeypatch.setattr(pack_target.ManagedPacks,  'get_installed_packs', my_get_installed_packs)
+
+class TestPack(object):
+    def test_get_installed(self, pack_ref):
+        p = pack_target.ManagedPacks.get_installed_packs()
+        assert p == [pack_ref]
+    
+    def test_get_targets(self, k64dev):
+        assert k64dev.part_number == K64F
+    
+    def test_pop_managed_k64(self):
+        pack_target.ManagedPacks.populate_target(K64F)
+        assert K64F.lower() in TARGET
+    
+    def test_k64_mem_map(self, k64dev):
+        map = k64dev.memory_map
+        raml = map.get_region_for_address(0x1fff0000)
+        ramu = map.get_region_for_address(0x20000000)
+        flash = map.get_first_region_of_type(memory_map.MemoryType.FLASH)
+        assert raml.start == 0x1fff0000 and raml.length == 0x10000
+        assert ramu.start == 0x20000000 and ramu.length == 0x30000
+        assert flash.start == 0 and flash.length == 0x100000
+        assert flash.sector_size == 0x1000
+        
+
+        


### PR DESCRIPTION
CPM 0.2.7 fixes a couple issues:
- The pack index is no longer rewritten prior to downloading packs, making pack installs much faster.
- Correctly handling pack URLs that don't end in a slash. In particular, this fixes installs of the Keil.STM32F4xx_DFP and Keil.STM32L4xx_DFP packs, among quite a few others.

Also added a basic unit test for pack support in pyOCD. Update: this test is disabled until it passes on Python 2.7 and when run by Travis-CI.