### PR TITLE
Modified DebugContext

### DIFF
--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -121,7 +121,7 @@ class CoreSightTarget(Target, GraphNode):
     def add_core(self, core):
         core.halt_on_connect = self.halt_on_connect
         core.delegate = self.delegate
-        core.set_target_context(CachingDebugContext(DebugContext(core)))
+        core.set_target_context(CachingDebugContext(core))
         self.cores[core.core_number] = core
         self.add_child(core)
         self._root_contexts[core.core_number] = None

--- a/pyocd/coresight/component.py
+++ b/pyocd/coresight/component.py
@@ -53,4 +53,10 @@ class CoreSightComponent(GraphNode):
     @address.setter
     def address(self, newAddr):
         self._address = newAddr
+
+class CoreSightCoreComponent(CoreSightComponent):
+    """! @brief CoreSight component for a CPU core.
     
+    This class serves only as a superclass for identifying core-type components.
+    """
+    pass

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -18,7 +18,7 @@ from ..core.target import Target
 from ..core import exceptions
 from ..utility import (cmdline, conversion, timeout)
 from ..utility.notification import Notification
-from .component import CoreSightComponent
+from .component import CoreSightCoreComponent
 from .fpb import FPB
 from .dwt import DWT
 from ..debug.breakpoints.manager import BreakpointManager
@@ -193,7 +193,7 @@ def sysm_to_psr_mask(sysm):
         mask |= CortexM.APSR_MASK
     return mask
 
-class CortexM(Target, CoreSightComponent):
+class CortexM(Target, CoreSightCoreComponent):
     """! @brief CoreSight component for a v6-M or v7-M Cortex-M core.
     
     This class has basic functions to access a Cortex-M core:
@@ -407,7 +407,7 @@ class CortexM(Target, CoreSightComponent):
 
     def __init__(self, rootTarget, ap, memoryMap=None, core_num=0, cmpid=None, address=None):
         Target.__init__(self, rootTarget.session, memoryMap)
-        CoreSightComponent.__init__(self, ap, cmpid, address)
+        CoreSightCoreComponent.__init__(self, ap, cmpid, address)
 
         self.root_target = rootTarget
         self.arch = 0

--- a/pyocd/debug/context.py
+++ b/pyocd/debug/context.py
@@ -15,46 +15,71 @@
 # limitations under the License.
 
 from ..core.memory_interface import MemoryInterface
-from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index, is_single_float_register,
-                                    is_double_float_register)
+from pyocd.coresight.component import CoreSightCoreComponent
+from ..coresight.cortex_m import (
+    CORE_REGISTER,
+    register_name_to_index,
+    is_single_float_register,
+    is_double_float_register
+    )
 from ..utility import conversion
 
 class DebugContext(MemoryInterface):
     """! @brief Viewport for inspecting the system being debugged.
     
-    A debug context is used to access registers and other target information. It enables these
-    accesses to be redirected to different locations. For instance, if you want to read registers
-    from a call frame that is not the topmost, then a context would redirect those reads to
-    locations on the stack.
+    A debug context is used to access target registers and memory. It enables these accesses to be
+    redirected to different locations. For instance, if you want to read registers from a call frame
+    that is not the topmost, then a context would redirect those reads to locations on the stack.
     
-    A context always has a specific core associated with it, which cannot be changed after the
-    context is created.
+    A context always has both a parent context and a specific core associated with it, neither of
+    which can be changed after the context is created. The parent context is passed into the
+    constructor. For the top-level debug context, the parent *is* the core. For other contexts that
+    have a context as their parent, the core is set to the topmost parent's core.
+    
+    The DebugContext class itself is meant to be used as a base class. It's primary purpose is to
+    provide the default implementation of methods to forward calls up to the parent and eventually
+    to the core.
     """
     
-    def __init__(self, core):
-        self._core = core
+    def __init__(self, parent):
+        """! @brief Debug context constructor.
+        
+        @param self
+        @param parent The parent of this context. Can be either a core (CoreSightCoreComponent) or
+            another DebugContext instance.
+        """
+        self._parent = parent
+        
+        if isinstance(self._parent, CoreSightCoreComponent):
+            self._core = parent
+        else:
+            self._core = parent.core
+
+    @property
+    def parent(self):
+        return self._parent
 
     @property
     def core(self):
         return self._core
 
     def write_memory(self, addr, value, transfer_size=32):
-        return self._core.write_memory(addr, value, transfer_size)
+        return self._parent.write_memory(addr, value, transfer_size)
 
     def read_memory(self, addr, transfer_size=32, now=True):
-        return self._core.read_memory(addr, transfer_size, now)
+        return self._parent.read_memory(addr, transfer_size, now)
 
     def write_memory_block8(self, addr, value):
-        return self._core.write_memory_block8(addr, value)
+        return self._parent.write_memory_block8(addr, value)
 
     def write_memory_block32(self, addr, data):
-        return self._core.write_memory_block32(addr, data)
+        return self._parent.write_memory_block32(addr, data)
 
     def read_memory_block8(self, addr, size):
-        return self._core.read_memory_block8(addr, size)
+        return self._parent.read_memory_block8(addr, size)
 
     def read_memory_block32(self, addr, size):
-        return self._core.read_memory_block32(addr, size)
+        return self._parent.read_memory_block32(addr, size)
 
     def read_core_register(self, reg):
         """! @brief Read CPU register
@@ -80,7 +105,7 @@ class DebugContext(MemoryInterface):
         return vals[0]
 
     def read_core_registers_raw(self, reg_list):
-        return self._core.read_core_registers_raw(reg_list)
+        return self._parent.read_core_registers_raw(reg_list)
 
     def write_core_register(self, reg, data):
         """! Write a CPU register.
@@ -104,7 +129,7 @@ class DebugContext(MemoryInterface):
         self.write_core_registers_raw([reg], [data])
 
     def write_core_registers_raw(self, reg_list, data_list):
-        self._core.write_core_registers_raw(reg_list, data_list)
+        self._parent.write_core_registers_raw(reg_list, data_list)
 
     def flush(self):
         self._core.flush()

--- a/pyocd/debug/elf/flash_reader.py
+++ b/pyocd/debug/elf/flash_reader.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2016 Arm Limited
+# Copyright (c) 2016-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,9 +24,8 @@ LOG = logging.getLogger(__name__)
 class FlashReaderContext(DebugContext):
     """! @brief Reads flash memory regions from an ELF file instead of the target."""
 
-    def __init__(self, parentContext, elf):
-        super(FlashReaderContext, self).__init__(parentContext.core)
-        self._parent = parentContext
+    def __init__(self, parent, elf):
+        super(FlashReaderContext, self).__init__(parent)
         self._elf = elf
 
         self._build_regions()
@@ -79,13 +78,4 @@ class FlashReaderContext(DebugContext):
 
     def read_memory_block32(self, addr, size):
         return conversion.byte_list_to_u32le_list(self.read_memory_block8(addr, size))
-
-    def write_memory(self, addr, value, transfer_size=32):
-        return self._parent.write_memory(addr, value, transfer_size)
-
-    def write_memory_block8(self, addr, value):
-        return self._parent.write_memory_block8(addr, value)
-
-    def write_memory_block32(self, addr, data):
-        return self._parent.write_memory_block32(addr, data)
 

--- a/pyocd/rtos/argon.py
+++ b/pyocd/rtos/argon.py
@@ -147,11 +147,10 @@ class ArgonThreadContext(DebugContext):
                  # (reserved word: 196)
             }
 
-    def __init__(self, parentContext, thread):
-        super(ArgonThreadContext, self).__init__(parentContext.core)
-        self._parent = parentContext
+    def __init__(self, parent, thread):
+        super(ArgonThreadContext, self).__init__(parent)
         self._thread = thread
-        self._has_fpu = parentContext.core.has_fpu
+        self._has_fpu = self.core.has_fpu
 
     def read_core_registers_raw(self, reg_list):
         reg_list = [register_name_to_index(reg) for reg in reg_list]
@@ -179,7 +178,7 @@ class ArgonThreadContext(DebugContext):
         swStacked = 0x20
         table = self.CORE_REGISTER_OFFSETS
         if self._has_fpu:
-            if inException and self._parent.core.is_vector_catch():
+            if inException and self.core.is_vector_catch():
                 # Vector catch has just occurred, take live LR
                 exceptionLR = self._parent.read_core_register('lr')
 
@@ -223,9 +222,6 @@ class ArgonThreadContext(DebugContext):
                 reg_vals.append(0)
 
         return reg_vals
-
-    def write_core_registers_raw(self, reg_list, data_list):
-        self._parent.write_core_registers_raw(reg_list, data_list)
 
 class ArgonThread(TargetThread):
     """! @brief Base class representing a thread on the target."""

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -152,11 +152,10 @@ class FreeRTOSThreadContext(DebugContext):
             }
     FPU_EXTENDED_REGISTER_OFFSETS.update(COMMON_REGISTER_OFFSETS)
 
-    def __init__(self, parentContext, thread):
-        super(FreeRTOSThreadContext, self).__init__(parentContext.core)
-        self._parent = parentContext
+    def __init__(self, parent, thread):
+        super(FreeRTOSThreadContext, self).__init__(parent)
         self._thread = thread
-        self._has_fpu = parentContext.core.has_fpu
+        self._has_fpu = self.core.has_fpu
 
     def read_core_registers_raw(self, reg_list):
         reg_list = [register_name_to_index(reg) for reg in reg_list]
@@ -185,7 +184,7 @@ class FreeRTOSThreadContext(DebugContext):
         table = self.NOFPU_REGISTER_OFFSETS
         if self._has_fpu:
             try:
-                if inException and self._parent.core.is_vector_catch():
+                if inException and self.core.is_vector_catch():
                     # Vector catch has just occurred, take live LR
                     exceptionLR = self._parent.read_core_register('lr')
                 else:
@@ -231,9 +230,6 @@ class FreeRTOSThreadContext(DebugContext):
                 reg_vals.append(0)
 
         return reg_vals
-
-    def write_core_registers_raw(self, reg_list, data_list):
-        self._parent.write_core_registers_raw(reg_list, data_list)
 
 class FreeRTOSThread(TargetThread):
     """! @brief A FreeRTOS task."""

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -130,11 +130,10 @@ class RTXThreadContext(DebugContext):
                  # (reserved word: 196)
             }
 
-    def __init__(self, parentContext, thread):
-        super(RTXThreadContext, self).__init__(parentContext.core)
-        self._parent = parentContext
+    def __init__(self, parent, thread):
+        super(RTXThreadContext, self).__init__(parent)
         self._thread = thread
-        self._has_fpu = parentContext.core.has_fpu
+        self._has_fpu = self.core.has_fpu
 
     def read_core_registers_raw(self, reg_list):
         reg_list = [register_name_to_index(reg) for reg in reg_list]
@@ -163,7 +162,7 @@ class RTXThreadContext(DebugContext):
         table = self.NOFPU_REGISTER_OFFSETS
         if self._has_fpu:
             try:
-                if inException and self._parent.core.is_vector_catch():
+                if inException and self.core.is_vector_catch():
                     # Vector catch has just occurred, take live LR
                     exceptionLR = self._parent.read_core_register('lr')
                 else:
@@ -208,9 +207,6 @@ class RTXThreadContext(DebugContext):
                 reg_vals.append(0)
 
         return reg_vals
-
-    def write_core_registers_raw(self, reg_list, data_list):
-        self._parent.write_core_registers_raw(reg_list, data_list)
 
 class RTXTargetThread(TargetThread):
     """! @brief Base class representing a thread on the target."""

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -70,11 +70,10 @@ class ZephyrThreadContext(DebugContext):
                  13: 0, # r13/sp
             }
 
-    def __init__(self, parentContext, thread):
-        super(ZephyrThreadContext, self).__init__(parentContext.core)
-        self._parent = parentContext
+    def __init__(self, parent, thread):
+        super(ZephyrThreadContext, self).__init__(parent)
         self._thread = thread
-        self._has_fpu = parentContext.core.has_fpu
+        self._has_fpu = self.core.has_fpu
 
     def read_core_registers_raw(self, reg_list):
         reg_list = [register_name_to_index(reg) for reg in reg_list]
@@ -139,9 +138,6 @@ class ZephyrThreadContext(DebugContext):
             continue
 
         return reg_vals
-
-    def write_core_registers_raw(self, reg_list, data_list):
-        self._parent.write_core_registers_raw(reg_list, data_list)
 
 class ZephyrThread(TargetThread):
     """! @brief A Zephyr task."""

--- a/test/unit/mockcore.py
+++ b/test/unit/mockcore.py
@@ -16,6 +16,7 @@
 
 from pyocd.debug.cache import MemoryCache
 from pyocd.debug.context import DebugContext
+from pyocd.coresight.component import CoreSightCoreComponent
 from pyocd.coresight.cortex_m import (
     CORE_REGISTER,
     register_name_to_index,
@@ -29,7 +30,7 @@ from pyocd.utility import mask
 import pytest
 import logging
 
-class MockCore(object):
+class MockCore(CoreSightCoreComponent):
     def __init__(self):
         self.run_token = 1
         self.flash_region = memory_map.FlashRegion(start=0, length=1*1024, blocksize=1024, name='flash')

--- a/test/unit/test_memcache.py
+++ b/test/unit/test_memcache.py
@@ -24,7 +24,7 @@ import logging
 
 @pytest.fixture(scope='function')
 def memcache(mockcore):
-    return MemoryCache(DebugContext(mockcore))
+    return MemoryCache(DebugContext(mockcore), mockcore)
 
 class TestMemoryCache:
     def test_1(self, mockcore, memcache):

--- a/test/unit/test_regcache.py
+++ b/test/unit/test_regcache.py
@@ -31,7 +31,7 @@ import logging
 
 @pytest.fixture(scope='function')
 def regcache(mockcore):
-    return RegisterCache(DebugContext(mockcore))
+    return RegisterCache(DebugContext(mockcore), mockcore)
 
 # Copy of the register list without composite registers.
 CORE_REGS_NO_COMPOSITES = CORE_REGISTER.copy()


### PR DESCRIPTION
Changed `DebugContext` to take a parent in its constructor that can be either a context or a core. Its methods then always forward calls to the parent. This removes the need to use a `DebugContext` instance as the top level context, and subclasses don't have to worry about forwarding methods they don't override.

Added a `CoreSightCoreComponent` class between `CoreSightComponent` and `CortexM` to serve as a superclass of all core implementation classes.

These changes allow other context classes such as the RTOS thread contexts to be simplified.

Also fixes an issue where the register cache was bypassed if an ELF file was set (enabling flash contents to be read from the ELF instead of the target).
