### PR TITLE
Modify session context manager behaviour

### DIFF
--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -198,13 +198,7 @@ class ConnectHelper(object):
             open_session = init_board
         
         assert len(allProbes) == 1
-        session = Session(allProbes[0], options=options, **kwargs)
-        if open_session:
-            try:
-                session.open()
-            except:
-                session.close()
-                raise
+        session = Session(allProbes[0], auto_open=open_session, options=options, **kwargs)
         return session
 
     @staticmethod

--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -98,8 +98,8 @@ class ConnectHelper(object):
     def list_connected_probes():
         """! @brief List the connected debug probes.   
         
-        @return List of zero or more DebugProbe objects that are currently connected, sorted by the
-              combination of the probe's description and unique ID.
+        Prints a list of all connected probes to stdout. If no probes are connected, a message
+        saying as much is printed instead.
         """
         allProbes = ConnectHelper.get_all_connected_probes(blocking=False)
         if len(allProbes):
@@ -108,20 +108,14 @@ class ConnectHelper(object):
             print(colorama.Fore.RED + "No available debug probes are connected" + colorama.Style.RESET_ALL)
 
     @staticmethod
-    def session_with_chosen_probe(blocking=True, return_first=False,
-                    unique_id=None, board_id=None, # board_id param is deprecated
-                    open_session=True, init_board=None, # init_board param is deprecated
-                    options=None, **kwargs):
-        """! @brief Create a session with a probe possibly chosen by the user.
+    def choose_probe(blocking=True, return_first=False, unique_id=None):
+        """! @brief Return a debug probe possibly chosen by the user.
         
         This method provides an easy to use command line interface for selecting one of the
-        connected debug probes, then creating and opening a Session instance. It has several
-        parameters that control filtering of probes by unique ID, automatic selection of the first
-        discovered probe, and whether to automaticallty open the created Session. In addition, you
-        can pass user options to the Session either with the _options_ parameter or directly as
-        keyword arguments.
+        connected debug probes. It has parameters that control filtering of probes by unique ID and
+        automatic selection of the first discovered probe.
         
-        If, after application of the _unique_id_ and _return_first_ parameter, there are still
+        If, after application of the _unique_id_ and _return_first_ parameters, there are still
         multiple debug probes to choose from, the user is presented with a simple command-line UI
         to select a probe (or abort the selection process).
         
@@ -131,26 +125,18 @@ class ConnectHelper(object):
               the first discovered probe rather than present a selection choice to the user.
         @param unique_id String to match against probes' unique IDs using a contains match. If the
               default of None is passed, then all available probes are matched.
-        @param board_id Deprecated alias of _unique_id_.
-        @param open_session Indicates whether the returned Session object should be opened for the
-              caller. If opening causes an exception, the Session will be automatically closed.
-        @param init_board Deprecated alias of _open_session_.
-        @param options Dictionary of user options.
-        @param kwargs User options passed as keyword arguments.
         
-        @return Either None or a Session instance. If _open_session_ is True then the session will
-              have already been opened, the board and target initialized, and is ready to be used.
+        @return Either None or a DebugProbe instance.
         """
         # Get all matching probes, sorted by name.
-        board_id = unique_id or board_id
-        allProbes = ConnectHelper.get_all_connected_probes(blocking=blocking, unique_id=board_id)
+        allProbes = ConnectHelper.get_all_connected_probes(blocking=blocking, unique_id=unique_id)
 
         # Print some help if the user specified a unique ID, but more than one probe matches.
-        if (board_id is not None) and (len(allProbes) > 1) and not return_first:
-            print(colorama.Fore.RED + "More than one debug probe matches unique ID '%s':" % board_id + colorama.Style.RESET_ALL)
-            board_id = board_id.lower()
+        if (unique_id is not None) and (len(allProbes) > 1) and not return_first:
+            print(colorama.Fore.RED + "More than one debug probe matches unique ID '%s':" % unique_id + colorama.Style.RESET_ALL)
+            unique_id = unique_id.lower()
             for probe in allProbes:
-                head, sep, tail = probe.unique_id.lower().rpartition(board_id)
+                head, sep, tail = probe.unique_id.lower().rpartition(unique_id)
                 highlightedId = head + colorama.Fore.RED + sep + colorama.Style.RESET_ALL + tail
                 print("%s | %s" % (
                     probe.description,
@@ -159,15 +145,15 @@ class ConnectHelper(object):
 
         # Return if no boards are connected.
         if allProbes is None or len(allProbes) == 0:
-            if board_id is None:
+            if unique_id is None:
                 print("No connected debug probes")
             else:
-                print("A debug probe matching unique ID '%s' is not connected, or no connected probe matches" % board_id)
+                print("A debug probe matching unique ID '%s' is not connected, or no connected probe matches" % unique_id)
             return None # No boards to close so it is safe to return
 
         # Select first board
         if return_first:
-            allProbes = allProbes[0:1]
+            return allProbes[0]
 
         # Ask user to select boards if there is more than 1 left
         if len(allProbes) > 1:
@@ -193,13 +179,59 @@ class ConnectHelper(object):
                     break
             allProbes = allProbes[ch:ch + 1]
 
-        # Let deprecated init_board override open_session if it was specified.
-        if init_board is not None:
-            open_session = init_board
-        
         assert len(allProbes) == 1
-        session = Session(allProbes[0], auto_open=open_session, options=options, **kwargs)
-        return session
+        return allProbes[0]
+
+    @staticmethod
+    def session_with_chosen_probe(blocking=True, return_first=False, unique_id=None,
+                    auto_open=True, options=None, **kwargs):
+        """! @brief Create a session with a probe possibly chosen by the user.
+        
+        This method provides an easy to use command line interface for selecting one of the
+        connected debug probes, then creating and opening a Session instance. It has several
+        parameters that control filtering of probes by unique ID and automatic selection of the
+        first discovered probe. In addition, you can pass user options to the Session either with
+        the _options_ parameter or directly as keyword arguments.
+        
+        If, after application of the _unique_id_ and _return_first_ parameter, there are still
+        multiple debug probes to choose from, the user is presented with a simple command-line UI
+        to select a probe (or abort the selection process).
+        
+        Most commonly, this method will be used directly in a **with** statement:
+        @code
+        with ConnectHelper.session_with_chosen_probe() as session:
+            # the session is open and ready for use
+        @endcode
+
+        You can also call this method to get a session, then use the resulting session in a **with**
+        statement. This makes it easy to further modify the session prior to opening it.
+        @code
+        session = ConnectHelper.session_with_chosen_probe()
+        # modify session here before it is opened
+        with session:
+            # the session is open and ready for use
+        @endcode
+        
+        @param blocking Specifies whether to wait for a probe to be connected if there are no
+              available probes.
+        @param return_first If more than one probe is connected, a _return_first_ of True will select
+              the first discovered probe rather than present a selection choice to the user.
+        @param unique_id String to match against probes' unique IDs using a contains match. If the
+              default of None is passed, then all available probes are matched.
+        @param auto_open Sets whether the returned Session object will be opened when used as a
+              context manager.
+        @param options Dictionary of user options.
+        @param kwargs User options passed as keyword arguments.
+        
+        @return Either None or a Session instance.
+        """
+        # Choose a probe.
+        probe = ConnectHelper.choose_probe(
+                    blocking=blocking,
+                    return_first=return_first,
+                    unique_id=unique_id,
+                    )
+        return Session(probe, auto_open=auto_open, options=options, **kwargs)
 
     @staticmethod
     def _print_probe_list(probes):

--- a/pyocd/tools/flash_tool.py
+++ b/pyocd/tools/flash_tool.py
@@ -148,7 +148,7 @@ def main():
                             config_file=args.config,
                             no_config=args.no_config,
                             pack=args.pack,
-                            board_id=args.board_id,
+                            unique_id=args.board_id,
                             target_override=args.target_override,
                             frequency=args.frequency,
                             blocking=False,

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -277,7 +277,7 @@ class GDBServerTool(object):
                     config_file=self.args.config,
                     no_config=self.args.no_config,
                     pack=self.args.pack,
-                    board_id=self.args.board_id,
+                    unique_id=self.args.board_id,
                     target_override=self.args.target_override,
                     frequency=self.args.frequency,
                     **sessionOptions)

--- a/test/connect_test.py
+++ b/test/connect_test.py
@@ -80,7 +80,7 @@ def connect_test(board):
     result = ConnectTestResult()
 
     # Install binary.
-    live_session = ConnectHelper.session_with_chosen_probe(board_id=board_id, **get_session_options())
+    live_session = ConnectHelper.session_with_chosen_probe(unique_id=board_id, **get_session_options())
     live_board = live_session.board
     memory_map = board.target.get_memory_map()
     rom_region = memory_map.get_boot_memory()
@@ -89,7 +89,7 @@ def connect_test(board):
     def test_connect(halt_on_connect, expected_state, resume):
         print("Connecting with halt_on_connect=%s" % halt_on_connect)
         live_session = ConnectHelper.session_with_chosen_probe(
-                        board_id=board_id,
+                        unique_id=board_id,
                         init_board=False,
                         halt_on_connect=halt_on_connect,
                         resume_on_disconnect=resume,

--- a/test/connect_test.py
+++ b/test/connect_test.py
@@ -81,6 +81,7 @@ def connect_test(board):
 
     # Install binary.
     live_session = ConnectHelper.session_with_chosen_probe(unique_id=board_id, **get_session_options())
+    live_session.open()
     live_board = live_session.board
     memory_map = board.target.get_memory_map()
     rom_region = memory_map.get_boot_memory()

--- a/test/connect_test.py
+++ b/test/connect_test.py
@@ -184,7 +184,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(level=level)
-    session = ConnectHelper.session_with_chosen_probe(open_session=False, **get_session_options())
+    session = ConnectHelper.session_with_chosen_probe(**get_session_options())
     test = ConnectTest()
     result = [test.run(session.board)]
     test.print_perf_info(result)

--- a/test/cortex_test.py
+++ b/test/cortex_test.py
@@ -97,7 +97,7 @@ def test_function(session, function):
     return (stop - start) / float(TEST_COUNT)
 
 def cortex_test(board_id):
-    with ConnectHelper.session_with_chosen_probe(board_id=board_id, **get_session_options()) as session:
+    with ConnectHelper.session_with_chosen_probe(unique_id=board_id, **get_session_options()) as session:
         board = session.board
         target_type = board.target_type
 

--- a/test/debug_context_test.py
+++ b/test/debug_context_test.py
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=level)
     DAPAccess.set_args(args.daparg)
     # Set to debug to print some of the decisions made while flashing
-    session = ConnectHelper.session_with_chosen_probe(unique_id='0240000029164e4500440012706e0007f301000097969900',open_session=False, **get_session_options())
+    session = ConnectHelper.session_with_chosen_probe(**get_session_options())
     test = DebugContextTest()
     result = [test.run(session.board)]
 

--- a/test/flash_loader_test.py
+++ b/test/flash_loader_test.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=level)
     DAPAccess.set_args(args.daparg)
     # Set to debug to print some of the decisions made while flashing
-    session = ConnectHelper.session_with_chosen_probe(open_session=False, **get_session_options())
+    session = ConnectHelper.session_with_chosen_probe(**get_session_options())
     test = FlashLoaderTest()
     result = [test.run(session.board)]
 

--- a/test/flash_test.py
+++ b/test/flash_test.py
@@ -406,7 +406,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=level)
     DAPAccess.set_args(args.daparg)
     # Set to debug to print some of the decisions made while flashing
-    session = ConnectHelper.session_with_chosen_probe(open_session=False, **get_session_options())
+    session = ConnectHelper.session_with_chosen_probe(**get_session_options())
     test = FlashTest()
     result = [test.run(session.board)]
     test.print_perf_info(result)

--- a/test/flash_test.py
+++ b/test/flash_test.py
@@ -118,7 +118,7 @@ class FlashTest(Test):
 
 
 def flash_test(board_id):
-    with ConnectHelper.session_with_chosen_probe(board_id=board_id, **get_session_options()) as session:
+    with ConnectHelper.session_with_chosen_probe(unique_id=board_id, **get_session_options()) as session:
         board = session.board
         target_type = board.target_type
 

--- a/test/gdb_test.py
+++ b/test/gdb_test.py
@@ -92,7 +92,7 @@ TEST_RESULT_KEYS = [
 def test_gdb(board_id=None, n=0):
     temp_test_elf_name = None
     result = GdbTestResult()
-    with ConnectHelper.session_with_chosen_probe(board_id=board_id, **get_session_options()) as session:
+    with ConnectHelper.session_with_chosen_probe(unique_id=board_id, **get_session_options()) as session:
         board = session.board
         memory_map = board.target.get_memory_map()
         ram_region = memory_map.get_first_region_of_type(MemoryType.RAM)

--- a/test/parallel_test.py
+++ b/test/parallel_test.py
@@ -87,7 +87,7 @@ def search_and_lock(board_id):
         device = DAPAccess.get_device(board_id)
         device.open()
         device.close()
-        with ConnectHelper.session_with_chosen_probe(board_id=board_id):
+        with ConnectHelper.session_with_chosen_probe(unique_id=board_id):
             pass
 
 

--- a/test/speed_test.py
+++ b/test/speed_test.py
@@ -235,7 +235,7 @@ if __name__ == "__main__":
     level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(level=level)
     DAPAccess.set_args(args.daparg)
-    session = ConnectHelper.session_with_chosen_probe(open_session=False, **get_session_options())
+    session = ConnectHelper.session_with_chosen_probe(**get_session_options())
     test = SpeedTest()
     result = [test.run(session.board)]
     test.print_perf_info(result)

--- a/test/speed_test.py
+++ b/test/speed_test.py
@@ -80,7 +80,7 @@ class SpeedTest(Test):
 
 
 def speed_test(board_id):
-    with ConnectHelper.session_with_chosen_probe(board_id=board_id, **get_session_options()) as session:
+    with ConnectHelper.session_with_chosen_probe(unique_id=board_id, **get_session_options()) as session:
         board = session.board
         target_type = board.target_type
 

--- a/test/unit/test_semihosting.py
+++ b/test/unit/test_semihosting.py
@@ -35,6 +35,7 @@ def tgt(request):
     if session is None:
         pytest.skip("No probe present")
         return
+    session.open()
     board = session.board
     session.options['resume_on_disconnect'] = False
     board.target.reset_and_halt()


### PR DESCRIPTION
The primary purpose of this change set is to make sessions automatically open when used as context managers. Previously it was `ConnectHelper.session_with_chosen_probe()` that would call `Session.open()` for the caller.

You can set the _auto_open_ parameter on the `Session` constructor to False to prevent opening the session when used as a context manager. In this case, you would have to call `open()` yourself inside the **with** block.

In addition, `ConnectHelper` was refactored a bit and docs updated.