### PR TITLE
Notification improvements

### DIFF
--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -138,7 +138,7 @@ class CoreSightTarget(Target, GraphNode):
             ('create_cores',        self.create_cores),
             ('create_components',   self.create_components),
             ('check_for_cores',     self.check_for_cores),
-            ('notify',              lambda : self.notify(Target.EVENT_POST_CONNECT, self))
+            ('notify',              lambda : self.session.notify(Target.EVENT_POST_CONNECT, self))
             )
         
         return seq
@@ -234,7 +234,7 @@ class CoreSightTarget(Target, GraphNode):
                 raise exceptions.DebugError("No cores were discovered!")
 
     def disconnect(self, resume=True):
-        self.notify(Target.EVENT_PRE_DISCONNECT, self)
+        self.session.notify(Target.EVENT_PRE_DISCONNECT, self)
         self.call_delegate('will_disconnect', target=self, resume=resume)
         for core in self.cores.values():
             core.disconnect(resume)

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -54,7 +54,6 @@ class CoreSightTarget(Target, GraphNode):
     def __init__(self, session, memoryMap=None):
         Target.__init__(self, session, memoryMap)
         GraphNode.__init__(self)
-        self.root_target = self
         self.part_number = self.__class__.__name__
         self.cores = {}
         self.dp = dap.DebugPort(session.probe, self)

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -138,7 +138,7 @@ class CoreSightTarget(Target, GraphNode):
             ('create_cores',        self.create_cores),
             ('create_components',   self.create_components),
             ('check_for_cores',     self.check_for_cores),
-            ('notify',              lambda : self.notify(Notification(event=Target.EVENT_POST_CONNECT, source=self)))
+            ('notify',              lambda : self.notify(Target.EVENT_POST_CONNECT, self))
             )
         
         return seq
@@ -234,7 +234,7 @@ class CoreSightTarget(Target, GraphNode):
                 raise exceptions.DebugError("No cores were discovered!")
 
     def disconnect(self, resume=True):
-        self.notify(Notification(event=Target.EVENT_PRE_DISCONNECT, source=self))
+        self.notify(Target.EVENT_PRE_DISCONNECT, self)
         self.call_delegate('will_disconnect', target=self, resume=resume)
         for core in self.cores.values():
             core.disconnect(resume)

--- a/pyocd/core/memory_interface.py
+++ b/pyocd/core/memory_interface.py
@@ -40,7 +40,7 @@ class MemoryInterface(object):
         raise NotImplementedError()
   
     def write32(self, addr, value):
-        ## @brief Shorthand to write a 32-bit word.
+        """! @brief Shorthand to write a 32-bit word."""
         self.write_memory(addr, value, 32)
 
     def write16(self, addr, value):

--- a/pyocd/core/options_manager.py
+++ b/pyocd/core/options_manager.py
@@ -18,25 +18,61 @@ import logging
 import six
 import yaml
 import os
+from functools import partial
+from collections import namedtuple
 
 from .options import OPTIONS_INFO
+from ..utility.notification import Notifier
 
 LOG = logging.getLogger(__name__)
 
-class OptionsManager(object):
+## @brief Data for an option value change notification.
+#
+# Instances of this class are used for the data attribute of the @ref
+# pyocd.utility.notification.Notification "Notification" sent to subscribers when an option's value
+# is changed.
+#
+# An instance of this class has two attributes:
+# - `new_value`: The new, current value of the option.
+# - `old_value`: The previous value of the option.
+OptionChangeInfo = namedtuple('OptionChangeInfo', 'new_value old_value')
+
+class OptionsManager(Notifier):
     """! @brief Handles user option management for a session.
     
-    The option manager supports multiple layers of option priority. When an option's value is
+    The options manager supports multiple layers of option priority. When an option's value is
     accessed, the highest priority layer that contains a value for the option is used. This design
     makes it easy to load options from multiple sources. The default value specified for an option
     in the OPTIONS_INFO dictionary provides a layer with an infinitely low priority.
+    
+    Users can subscribe to notifications for changes to option values by calling the subscribe()
+    method. The notification events are the option names themselves. The source for notifications is
+    always the options manager instance. The notification data is an instance of OptionChangeInfo
+    with `new_value` and `old_value` attributes. If the option was not previously set, then the
+    old value is the option's default.
     """
 
-    def __init__(self, session):
+    def __init__(self):
         """! @brief Option manager constructor.
         """
-        self._session = session
+        super(OptionsManager, self).__init__()
         self._layers = []
+    
+    def _update_layers(self, new_options, update_operation):
+        """! @brief Internal method to add a new layer dictionary.
+        
+        @param self
+        @param new_options Dictionary of option values.
+        @param update_operation Callable to add the layer. Must accept a single parameter, which is
+            the filtered _new_options_ dictionary.
+        """
+        if new_options is None:
+            return
+        filtered_options = self._convert_options(new_options)
+        previous_values = {name: self.get(name) for name in filtered_options.keys()}
+        update_operation(filtered_options)
+        new_values = {name: self.get(name) for name in filtered_options.keys()}
+        self._notify_changes(previous_values, new_values)
 
     def add_front(self, new_options):
         """! @brief Add a new highest priority layer of option values.
@@ -44,9 +80,7 @@ class OptionsManager(object):
         @param self
         @param new_options Dictionary of option values.
         """
-        if new_options is None:
-            return
-        self._layers.insert(0, self._convert_options(new_options))
+        self._update_layers(new_options, partial(self._layers.insert, 0))
     
     def add_back(self, new_options):
         """! @brief Add a new lowest priority layer of option values.
@@ -54,9 +88,7 @@ class OptionsManager(object):
         @param self
         @param new_options Dictionary of option values.
         """
-        if new_options is None:
-            return
-        self._layers.append(self._convert_options(new_options))
+        self._update_layers(new_options, self._layers.append)
     
     def _convert_options(self, new_options):
         """! @brief Prepare a dictionary of user options for use by the manager.
@@ -74,16 +106,33 @@ class OptionsManager(object):
                 output[name] = value
         return output
 
+    def is_set(self, key):
+        """! @brief Return whether a value is set for the specified option.
+        
+        This method returns True as long as any layer has a value set for the option, even if the
+        value is the same as the default value. If the option is not set in any layer, then False is
+        returned regardless of whether the default value is None.
+        """
+        for layer in self._layers:
+            if key in layer:
+                return True
+        else:
+            return False
+
+    def get_default(self, key):
+        """! @brief Return the default value for the specified option."""
+        if key in OPTIONS_INFO:
+            return OPTIONS_INFO[key].default
+        else:
+            return None
+
     def get(self, key):
         """! @brief Return the highest priority value for the option, or its default."""
         for layer in self._layers:
             if key in layer:
                 return layer[key]
         else:
-            if key in OPTIONS_INFO:
-                return OPTIONS_INFO[key].default
-            else:
-                return None
+            return self.get_default(key)
     
     def set(self, key, value):
         """! @brief Set an option in the current highest priority layer."""
@@ -91,15 +140,21 @@ class OptionsManager(object):
     
     def update(self, new_options):
         """! @brief Set multiple options in the current highest priority layer."""
-        self._layers[0].update(self._convert_options(new_options))
+        filtered_options = self._convert_options(new_options)
+        previous_values = {name: self.get(name) for name in filtered_options.keys()}
+        self._layers[0].update(filtered_options)
+        self._notify_changes(previous_values, filtered_options)
+    
+    def _notify_changes(self, previous, options):
+        """! @brief Send notifications that the specified options have changed."""
+        for name, new_value in options.items():
+            previous_value = previous[name]
+            if new_value != previous_value:
+                self.notify(name, data=OptionChangeInfo(new_value, previous_value))
 
     def __contains__(self, key):
         """! @brief Returns whether the named option has a non-default value."""
-        for layer in self._layers:
-            if key in layer:
-                return True
-        else:
-            return False
+        return self.is_set(key)
         
     def __getitem__(self, key):
         """! @brief Return the highest priority value for the option, or its default."""

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -29,6 +29,7 @@ except ImportError:
 
 from .options_manager import OptionsManager
 from ..board.board import Board
+from ..utility.notification import Notifier
 
 LOG = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ _USER_SCRIPT_NAMES = [
         ".pyocd_user.py",
     ]
 
-class Session(object):
+class Session(Notifier):
     """! @brief Top-level object for a debug session.
     
     This class represents a debug session with a single debug probe. It is the root of the object
@@ -119,6 +120,8 @@ class Session(object):
             defaults for option if they are not set through any other method.
         @param kwargs User options passed as keyword arguments.
         """
+        super(Session, self).__init__()
+        
         Session._current_session = weakref.ref(self)
         
         self._probe = probe

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -130,7 +130,7 @@ class Session(Notifier):
         self._user_script_proxy = None
         self._delegate = None
         self._auto_open = auto_open
-        self._options = OptionsManager(self)
+        self._options = OptionsManager()
         
         # Update options.
         self._options.add_front(kwargs)

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -91,7 +91,6 @@ class Target(MemoryInterface):
     def __init__(self, session, memoryMap=None):
         self._session = session
         self._delegate = None
-        self.root_target = None
         self.vendor = self.VENDOR
         self.part_families = []
         self.part_number = ""

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -15,11 +15,10 @@
 # limitations under the License.
 
 from .memory_interface import MemoryInterface
-from ..utility.notification import Notifier
 from .memory_map import MemoryMap
 from enum import Enum
 
-class Target(MemoryInterface, Notifier):
+class Target(MemoryInterface):
 
     TARGET_RUNNING = 1   # Core is executing code.
     TARGET_HALTED = 2    # Core is halted in debug mode.
@@ -90,7 +89,6 @@ class Target(MemoryInterface, Notifier):
     VENDOR = "Generic"
 
     def __init__(self, session, memoryMap=None):
-        super(Target, self).__init__()
         self._session = session
         self._delegate = None
         self.root_target = None

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -637,10 +637,10 @@ class CortexM(Target, CoreSightCoreComponent):
     def halt(self):
         """! @brief Halt the core
         """
-        self.notify(Target.EVENT_PRE_HALT, self, Target.HALT_REASON_USER)
+        self.session.notify(Target.EVENT_PRE_HALT, self, Target.HALT_REASON_USER)
         self.write_memory(CortexM.DHCSR, CortexM.DBGKEY | CortexM.C_DEBUGEN | CortexM.C_HALT)
         self.flush()
-        self.notify(Target.EVENT_POST_HALT, self, Target.HALT_REASON_USER)
+        self.session.notify(Target.EVENT_POST_HALT, self, Target.HALT_REASON_USER)
 
     def step(self, disable_interrupts=True, start=0, end=0):
         """! @brief Perform an instruction level step.
@@ -654,7 +654,7 @@ class CortexM(Target, CoreSightCoreComponent):
             LOG.error('cannot step: target not halted')
             return
 
-        self.notify(Target.EVENT_PRE_RUN, self, Target.RUN_TYPE_STEP)
+        self.session.notify(Target.EVENT_PRE_RUN, self, Target.RUN_TYPE_STEP)
 
         self.clear_debug_cause_bits()
 
@@ -698,7 +698,7 @@ class CortexM(Target, CoreSightCoreComponent):
 
         self._run_token += 1
 
-        self.notify(Target.EVENT_POST_RUN, self, Target.RUN_TYPE_STEP)
+        self.session.notify(Target.EVENT_POST_RUN, self, Target.RUN_TYPE_STEP)
 
     def clear_debug_cause_bits(self):
         self.write_memory(CortexM.DFSR, CortexM.DFSR_VCATCH | CortexM.DFSR_DWTTRAP | CortexM.DFSR_BKPT | CortexM.DFSR_HALTED)
@@ -853,7 +853,7 @@ class CortexM(Target, CoreSightCoreComponent):
         
         After a call to this function, the core is running.
         """
-        self.notify(Target.EVENT_PRE_RESET, self)
+        self.session.notify(Target.EVENT_PRE_RESET, self)
 
         reset_type = self._get_actual_reset_type(reset_type)
 
@@ -878,7 +878,7 @@ class CortexM(Target, CoreSightCoreComponent):
                     self.flush()
                     sleep(0.01)
 
-        self.notify(Target.EVENT_POST_RESET, self)
+        self.session.notify(Target.EVENT_POST_RESET, self)
 
     def reset_and_halt(self, reset_type=None):
         """! @brief Perform a reset and stop the core on the reset handler.
@@ -952,12 +952,12 @@ class CortexM(Target, CoreSightCoreComponent):
         if self.get_state() != Target.TARGET_HALTED:
             LOG.debug('cannot resume: target not halted')
             return
-        self.notify(Target.EVENT_PRE_RUN, self, Target.RUN_TYPE_RESUME)
+        self.session.notify(Target.EVENT_PRE_RUN, self, Target.RUN_TYPE_RESUME)
         self._run_token += 1
         self.clear_debug_cause_bits()
         self.write_memory(CortexM.DHCSR, CortexM.DBGKEY | CortexM.C_DEBUGEN)
         self.flush()
-        self.notify(Target.EVENT_POST_RUN, self, Target.RUN_TYPE_RESUME)
+        self.session.notify(Target.EVENT_POST_RUN, self, Target.RUN_TYPE_RESUME)
 
     def find_breakpoint(self, addr):
         return self.bp_manager.find_breakpoint(addr)

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -637,10 +637,10 @@ class CortexM(Target, CoreSightCoreComponent):
     def halt(self):
         """! @brief Halt the core
         """
-        self.notify(Notification(event=Target.EVENT_PRE_HALT, source=self, data=Target.HALT_REASON_USER))
+        self.notify(Target.EVENT_PRE_HALT, self, Target.HALT_REASON_USER)
         self.write_memory(CortexM.DHCSR, CortexM.DBGKEY | CortexM.C_DEBUGEN | CortexM.C_HALT)
         self.flush()
-        self.notify(Notification(event=Target.EVENT_POST_HALT, source=self, data=Target.HALT_REASON_USER))
+        self.notify(Target.EVENT_POST_HALT, self, Target.HALT_REASON_USER)
 
     def step(self, disable_interrupts=True, start=0, end=0):
         """! @brief Perform an instruction level step.
@@ -654,7 +654,7 @@ class CortexM(Target, CoreSightCoreComponent):
             LOG.error('cannot step: target not halted')
             return
 
-        self.notify(Notification(event=Target.EVENT_PRE_RUN, source=self, data=Target.RUN_TYPE_STEP))
+        self.notify(Target.EVENT_PRE_RUN, self, Target.RUN_TYPE_STEP)
 
         self.clear_debug_cause_bits()
 
@@ -698,7 +698,7 @@ class CortexM(Target, CoreSightCoreComponent):
 
         self._run_token += 1
 
-        self.notify(Notification(event=Target.EVENT_POST_RUN, source=self, data=Target.RUN_TYPE_STEP))
+        self.notify(Target.EVENT_POST_RUN, self, Target.RUN_TYPE_STEP)
 
     def clear_debug_cause_bits(self):
         self.write_memory(CortexM.DFSR, CortexM.DFSR_VCATCH | CortexM.DFSR_DWTTRAP | CortexM.DFSR_BKPT | CortexM.DFSR_HALTED)
@@ -853,7 +853,7 @@ class CortexM(Target, CoreSightCoreComponent):
         
         After a call to this function, the core is running.
         """
-        self.notify(Notification(event=Target.EVENT_PRE_RESET, source=self))
+        self.notify(Target.EVENT_PRE_RESET, self)
 
         reset_type = self._get_actual_reset_type(reset_type)
 
@@ -878,7 +878,7 @@ class CortexM(Target, CoreSightCoreComponent):
                     self.flush()
                     sleep(0.01)
 
-        self.notify(Notification(event=Target.EVENT_POST_RESET, source=self))
+        self.notify(Target.EVENT_POST_RESET, self)
 
     def reset_and_halt(self, reset_type=None):
         """! @brief Perform a reset and stop the core on the reset handler.
@@ -952,12 +952,12 @@ class CortexM(Target, CoreSightCoreComponent):
         if self.get_state() != Target.TARGET_HALTED:
             LOG.debug('cannot resume: target not halted')
             return
-        self.notify(Notification(event=Target.EVENT_PRE_RUN, source=self, data=Target.RUN_TYPE_RESUME))
+        self.notify(Target.EVENT_PRE_RUN, self, Target.RUN_TYPE_RESUME)
         self._run_token += 1
         self.clear_debug_cause_bits()
         self.write_memory(CortexM.DHCSR, CortexM.DBGKEY | CortexM.C_DEBUGEN)
         self.flush()
-        self.notify(Notification(event=Target.EVENT_POST_RUN, source=self, data=Target.RUN_TYPE_RESUME))
+        self.notify(Target.EVENT_POST_RUN, self, Target.RUN_TYPE_RESUME)
 
     def find_breakpoint(self, addr):
         return self.bp_manager.find_breakpoint(addr)

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -391,7 +391,7 @@ class CortexM(Target, CoreSightCoreComponent):
     def factory(cls, ap, cmpid, address):
         # Create a new core instance.
         root = ap.dp.target
-        core = cls(root, ap, root.memory_map, root._new_core_num, cmpid, address)
+        core = cls(root.session, ap, root.memory_map, root._new_core_num, cmpid, address) 
         
         # Associate this core with the AP.
         if ap.core is not None:
@@ -405,11 +405,10 @@ class CortexM(Target, CoreSightCoreComponent):
         
         return core
 
-    def __init__(self, rootTarget, ap, memoryMap=None, core_num=0, cmpid=None, address=None):
-        Target.__init__(self, rootTarget.session, memoryMap)
+    def __init__(self, session, ap, memoryMap=None, core_num=0, cmpid=None, address=None):
+        Target.__init__(self, session, memoryMap)
         CoreSightCoreComponent.__init__(self, ap, cmpid, address)
 
-        self.root_target = rootTarget
         self.arch = 0
         self.core_type = 0
         self.has_fpu = False
@@ -1296,8 +1295,8 @@ class CortexM(Target, CoreSightCoreComponent):
         else:
             irq_num = exc_num - len(self.CORE_EXCEPTION)
             name = None
-            if self.root_target.irq_table:
-                name = self.root_target.irq_table.get(irq_num)
+            if self.session.target.irq_table:
+                name = self.session.target.irq_table.get(irq_num)
             if name is not None:
                 return "Interrupt[%s]" % name
             else:

--- a/pyocd/debug/breakpoints/manager.py
+++ b/pyocd/debug/breakpoints/manager.py
@@ -54,8 +54,8 @@ class BreakpointManager(object):
         self._ignore_notifications = False
 
         # Subscribe to some notifications.
-        self._core.subscribe(self._pre_run_handler, Target.EVENT_PRE_RUN)
-        self._core.subscribe(self._pre_disconnect_handler, Target.EVENT_PRE_DISCONNECT)
+        self._session.subscribe(self._pre_run_handler, Target.EVENT_PRE_RUN)
+        self._session.subscribe(self._pre_disconnect_handler, Target.EVENT_PRE_DISCONNECT)
 
     def add_provider(self, provider):
         self._providers[provider.bp_type] = provider

--- a/pyocd/debug/breakpoints/manager.py
+++ b/pyocd/debug/breakpoints/manager.py
@@ -54,8 +54,8 @@ class BreakpointManager(object):
         self._ignore_notifications = False
 
         # Subscribe to some notifications.
-        self._core.subscribe(Target.EVENT_PRE_RUN, self._pre_run_handler)
-        self._core.subscribe(Target.EVENT_PRE_DISCONNECT, self._pre_disconnect_handler)
+        self._core.subscribe(self._pre_run_handler, Target.EVENT_PRE_RUN)
+        self._core.subscribe(self._pre_disconnect_handler, Target.EVENT_PRE_DISCONNECT)
 
     def add_provider(self, provider):
         self._providers[provider.bp_type] = provider

--- a/pyocd/flash/flash_builder.py
+++ b/pyocd/flash/flash_builder.py
@@ -378,7 +378,7 @@ class FlashBuilder(object):
         """
 
         # Send notification that we're about to program flash.
-        self.flash.target.notify(Target.EVENT_PRE_FLASH_PROGRAM, self)
+        self.flash.target.session.notify(Target.EVENT_PRE_FLASH_PROGRAM, self)
 
         # Examples
         # - lpc4330     -Non 0 base address
@@ -506,7 +506,7 @@ class FlashBuilder(object):
                     ((self.program_byte_count/1024) / self.perf.program_time))
 
         # Send notification that we're done programming flash.
-        self.flash.target.notify(Target.EVENT_POST_FLASH_PROGRAM, self)
+        self.flash.target.session.notify(Target.EVENT_POST_FLASH_PROGRAM, self)
 
         return self.perf
 

--- a/pyocd/flash/flash_builder.py
+++ b/pyocd/flash/flash_builder.py
@@ -378,7 +378,7 @@ class FlashBuilder(object):
         """
 
         # Send notification that we're about to program flash.
-        self.flash.target.notify(Notification(event=Target.EVENT_PRE_FLASH_PROGRAM, source=self))
+        self.flash.target.notify(Target.EVENT_PRE_FLASH_PROGRAM, self)
 
         # Examples
         # - lpc4330     -Non 0 base address
@@ -506,7 +506,7 @@ class FlashBuilder(object):
                     ((self.program_byte_count/1024) / self.perf.program_time))
 
         # Send notification that we're done programming flash.
-        self.flash.target.notify(Notification(event=Target.EVENT_POST_FLASH_PROGRAM, source=self))
+        self.flash.target.notify(Target.EVENT_POST_FLASH_PROGRAM, self)
 
         return self.perf
 

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -322,7 +322,7 @@ class GDBServer(threading.Thread):
         # Read back bound port in case auto-assigned (port 0)
         self.port = self.abstract_socket.port
 
-        self.target.subscribe(self.event_handler, Target.EVENT_POST_RESET)
+        self.session.subscribe(self.event_handler, Target.EVENT_POST_RESET)
 
         # Init semihosting and telnet console.
         if self.semihost_use_syscalls:

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -322,7 +322,7 @@ class GDBServer(threading.Thread):
         # Read back bound port in case auto-assigned (port 0)
         self.port = self.abstract_socket.port
 
-        self.target.subscribe(Target.EVENT_POST_RESET, self.event_handler)
+        self.target.subscribe(self.event_handler, Target.EVENT_POST_RESET)
 
         # Init semihosting and telnet console.
         if self.semihost_use_syscalls:

--- a/pyocd/rtos/argon.py
+++ b/pyocd/rtos/argon.py
@@ -350,8 +350,8 @@ class ArgonThreadProvider(ThreadProvider):
 
         self._all_threads = self.g_ar_objects + ALL_OBJECTS_THREADS_OFFSET
 
-        self._target.root_target.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
-        self._target.subscribe(self.event_handler, Target.EVENT_POST_RESET)
+        self._target.session.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
+        self._target.session.subscribe(self.event_handler, Target.EVENT_POST_RESET)
 
         return True
 

--- a/pyocd/rtos/argon.py
+++ b/pyocd/rtos/argon.py
@@ -350,8 +350,8 @@ class ArgonThreadProvider(ThreadProvider):
 
         self._all_threads = self.g_ar_objects + ALL_OBJECTS_THREADS_OFFSET
 
-        self._target.root_target.subscribe(Target.EVENT_POST_FLASH_PROGRAM, self.event_handler)
-        self._target.subscribe(Target.EVENT_POST_RESET, self.event_handler)
+        self._target.root_target.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
+        self._target.subscribe(self.event_handler, Target.EVENT_POST_RESET)
 
         return True
 

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -369,8 +369,8 @@ class FreeRTOSThreadProvider(ThreadProvider):
             return False
         LOG.debug("FreeRTOS: number of priorities is %d", self._total_priorities)
 
-        self._target.root_target.subscribe(Target.EVENT_POST_FLASH_PROGRAM, self.event_handler)
-        self._target.subscribe(Target.EVENT_POST_RESET, self.event_handler)
+        self._target.root_target.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
+        self._target.subscribe(self.event_handler, Target.EVENT_POST_RESET)
 
         return True
 

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -369,8 +369,8 @@ class FreeRTOSThreadProvider(ThreadProvider):
             return False
         LOG.debug("FreeRTOS: number of priorities is %d", self._total_priorities)
 
-        self._target.root_target.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
-        self._target.subscribe(self.event_handler, Target.EVENT_POST_RESET)
+        self._target.session.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
+        self._target.session.subscribe(self.event_handler, Target.EVENT_POST_RESET)
 
         return True
 

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -334,8 +334,8 @@ class RTX5ThreadProvider(ThreadProvider):
         self._threads = {}
         self._current = None
         self._current_id = None
-        self._target.root_target.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
-        self._target.subscribe(self.event_handler, Target.EVENT_POST_RESET)
+        self._target.session.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
+        self._target.session.subscribe(self.event_handler, Target.EVENT_POST_RESET)
         return True
 
     def get_threads(self):

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -334,8 +334,8 @@ class RTX5ThreadProvider(ThreadProvider):
         self._threads = {}
         self._current = None
         self._current_id = None
-        self._target.root_target.subscribe(Target.EVENT_POST_FLASH_PROGRAM, self.event_handler)
-        self._target.subscribe(Target.EVENT_POST_RESET, self.event_handler)
+        self._target.root_target.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
+        self._target.subscribe(self.event_handler, Target.EVENT_POST_RESET)
         return True
 
     def get_threads(self):

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -278,8 +278,8 @@ class ZephyrThreadProvider(ThreadProvider):
             return False
 
         self._update()
-        self._target.root_target.subscribe(Target.EVENT_POST_FLASH_PROGRAM, self.event_handler)
-        self._target.subscribe(Target.EVENT_POST_RESET, self.event_handler)
+        self._target.root_target.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
+        self._target.subscribe(self.event_handler, Target.EVENT_POST_RESET)
 
         return True
 

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -278,8 +278,8 @@ class ZephyrThreadProvider(ThreadProvider):
             return False
 
         self._update()
-        self._target.root_target.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
-        self._target.subscribe(self.event_handler, Target.EVENT_POST_RESET)
+        self._target.session.subscribe(self.event_handler, Target.EVENT_POST_FLASH_PROGRAM)
+        self._target.session.subscribe(self.event_handler, Target.EVENT_POST_RESET)
 
         return True
 

--- a/pyocd/target/builtin/target_CY8C6xx7.py
+++ b/pyocd/target/builtin/target_CY8C6xx7.py
@@ -233,7 +233,7 @@ class CY8C6xx7(CoreSightTarget):
 
 class CortexM_CY8C6xx7(CortexM):
     def reset(self, reset_type=None):
-        self.notify(Notification(event=Target.EVENT_PRE_RESET, source=self))
+        self.notify(Target.EVENT_PRE_RESET, self)
 
         self._run_token += 1
 
@@ -269,7 +269,7 @@ class CortexM_CY8C6xx7(CortexM):
                     self._ap.dp.power_up_debug()
                     sleep(0.01)
 
-        self.notify(Notification(event=Target.EVENT_POST_RESET, source=self))
+        self.notify(Target.EVENT_POST_RESET, self)
 
     def wait_halted(self):
         with Timeout(5.0) as t_o:

--- a/pyocd/target/builtin/target_CY8C6xx7.py
+++ b/pyocd/target/builtin/target_CY8C6xx7.py
@@ -233,7 +233,7 @@ class CY8C6xx7(CoreSightTarget):
 
 class CortexM_CY8C6xx7(CortexM):
     def reset(self, reset_type=None):
-        self.notify(Target.EVENT_PRE_RESET, self)
+        self.session.notify(Target.EVENT_PRE_RESET, self)
 
         self._run_token += 1
 
@@ -269,7 +269,7 @@ class CortexM_CY8C6xx7(CortexM):
                     self._ap.dp.power_up_debug()
                     sleep(0.01)
 
-        self.notify(Target.EVENT_POST_RESET, self)
+        self.session.notify(Target.EVENT_POST_RESET, self)
 
     def wait_halted(self):
         with Timeout(5.0) as t_o:

--- a/pyocd/target/builtin/target_CY8C6xxA.py
+++ b/pyocd/target/builtin/target_CY8C6xxA.py
@@ -424,7 +424,7 @@ class CY8C6xxA(CoreSightTarget):
 
 class CortexM_CY8C6xxA(CortexM):
     def reset(self, reset_type=None):
-        self.notify(Notification(event=Target.EVENT_PRE_RESET, source=self))
+        self.notify(Target.EVENT_PRE_RESET, self)
 
         self._run_token += 1
 
@@ -460,7 +460,7 @@ class CortexM_CY8C6xxA(CortexM):
                     self._ap.dp.power_up_debug()
                     sleep(0.01)
 
-        self.notify(Notification(event=Target.EVENT_POST_RESET, source=self))
+        self.notify(Target.EVENT_POST_RESET, self)
 
     def wait_halted(self):
         with Timeout(5.0) as t_o:

--- a/pyocd/target/builtin/target_CY8C6xxA.py
+++ b/pyocd/target/builtin/target_CY8C6xxA.py
@@ -424,7 +424,7 @@ class CY8C6xxA(CoreSightTarget):
 
 class CortexM_CY8C6xxA(CortexM):
     def reset(self, reset_type=None):
-        self.notify(Target.EVENT_PRE_RESET, self)
+        self.session.notify(Target.EVENT_PRE_RESET, self)
 
         self._run_token += 1
 
@@ -460,7 +460,7 @@ class CortexM_CY8C6xxA(CortexM):
                     self._ap.dp.power_up_debug()
                     sleep(0.01)
 
-        self.notify(Target.EVENT_POST_RESET, self)
+        self.session.notify(Target.EVENT_POST_RESET, self)
 
     def wait_halted(self):
         with Timeout(5.0) as t_o:

--- a/pyocd/target/builtin/target_MKL28Z512xxx7.py
+++ b/pyocd/target/builtin/target_MKL28Z512xxx7.py
@@ -132,11 +132,12 @@ class Flash_kl28z(Flash_Kinetis):
         self._saved_firccsr = 0
         self._saved_rccr = 0
 
-    ##
-    # This function sets up target clocks to ensure that flash is clocked at the maximum
-    # of 24MHz. Doing so gets the best flash programming performance. The FIRC clock source
-    # is used so that there is no dependency on an external crystal frequency.
     def prepare_target(self, operation, address=None, clock=0, reset=True):
+        """!
+        This function sets up target clocks to ensure that flash is clocked at the maximum
+        of 24MHz. Doing so gets the best flash programming performance. The FIRC clock source
+        is used so that there is no dependency on an external crystal frequency.
+        """
         super(Flash_kl28z, self).init(operation, address, clock, reset)
 
         # Enable FIRC.
@@ -154,9 +155,8 @@ class Flash_kl28z(Flash_Kinetis):
         csr = self.target.read32(SCG_CSR)
         LOG.debug("SCG_CSR = 0x%08x", csr)
 
-    ##
-    # Restore clock registers to original values.
     def restore_target(self):
+        """! Restore clock registers to original values."""
         self.target.write32(SCG_FIRCCSR, self._saved_firccsr)
         self.target.write32(SCG_RCCR, self._saved_rccr)
 
@@ -206,8 +206,8 @@ class KL28x(Kinetis):
 
         return seq
 
-    ## @brief Set the fixed list of valid AP numbers for KL28.
     def create_kl28_aps(self):
+        """! @brief Set the fixed list of valid AP numbers for KL28."""
         self.dp.valid_aps = [0, 1, 2]
         
     def detect_dual_core(self):

--- a/pyocd/trace/swv.py
+++ b/pyocd/trace/swv.py
@@ -81,7 +81,7 @@ class SWVReader(threading.Thread):
         self._shutdown_event = threading.Event()
         self._swo_clock = 0
         
-        self._session.target.cores[core_number].subscribe(Target.EVENT_POST_RESET, self._reset_handler)
+        self._session.target.cores[core_number].subscribe(self._reset_handler, Target.EVENT_POST_RESET)
         
     def init(self, sys_clock, swo_clock, console):
         """! @brief Configures trace graph and starts thread.

--- a/pyocd/trace/swv.py
+++ b/pyocd/trace/swv.py
@@ -81,7 +81,7 @@ class SWVReader(threading.Thread):
         self._shutdown_event = threading.Event()
         self._swo_clock = 0
         
-        self._session.target.cores[core_number].subscribe(self._reset_handler, Target.EVENT_POST_RESET)
+        self._session.subscribe(self._reset_handler, Target.EVENT_POST_RESET, self._session.target.cores[core_number])
         
     def init(self, sys_clock, swo_clock, console):
         """! @brief Configures trace graph and starts thread.

--- a/pyocd/utility/notification.py
+++ b/pyocd/utility/notification.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2016 Arm Limited
+# Copyright (c) 2016-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,8 @@ TRACE = LOG.getChild("trace")
 TRACE.setLevel(logging.CRITICAL)
 
 class Notification(object):
-    """!@brief Class that holds information about a notification to subscribers."""
+    """!@brief Holds information about a notification to subscribers."""
+
     def __init__(self, event, source, data=None):
         self._event = event
         self._source = source
@@ -44,26 +45,125 @@ class Notification(object):
         return "<Notification@0x%08x event=%s source=%s data=%s>" % (id(self), repr(self.event), repr(self.source), repr(self.data))
 
 class Notifier(object):
-    """!@brief Mix-in class that provides notification capabilities."""
+    """!@brief Mix-in class that provides notification broadcast capabilities.
+    
+    In this notification model, subscribers register callbacks for one or more events. The events
+    are simply a Python object of any kind, as long as it is hashable. Typically integers or Enums
+    are used. Subscriptions can be registered for any sender of an event, or be filtered by the
+    sender (called the source).
+    
+    When a notification is sent to the callback, it is wrapped up as a Notification object. Along
+    with the notification, an optional, arbitrary data value can be sent. This allows for further
+    specifying the event, or passing related values (or anything else you can think of).
+    """
+    
     def __init__(self):
+        ## Dict of subscribers for particular events and sources.
+        #
+        # One subscriber can appear in multiple places in the dict.
+        #
+        # Schema:
+        # ```
+        # {
+        #   event : ( [ subscribers-for-any-source ],
+        #               {
+        #                   source : [ subscribers ],
+        #               } ),
+        # }
+        # ```
         self._subscribers = {}
 
-    def subscribe(self, events, cb):
-        if not type(events) in (list, tuple):
+    def subscribe(self, cb, events, source=None):
+        """!@brief Subscribe to selection of events from an optional source.
+        
+        @param self
+        @param cb The callable that will be invoked when a matching notification is sent. Must
+            accept a single parameter, a Notification instance.
+        @param events Either a single event or an iterable of events. Events must be a hashable, and
+            are usually just integers.
+        @param source Optional notifier object. If not None, the callback is only invoked if one
+            of the events is sent from the specified source. If a matching event is sent from
+            another source, no action is taken.
+        """
+        if not isinstance(events, (tuple, list, set)):
             events = [events]
+        
         for event in events:
-            if event in self._subscribers:
-                self._subscribers[event].append(cb)
+            if event not in self._subscribers:
+                self._subscribers[event] = ([], {})
+            event_info = self._subscribers[event]
+            
+            if source is None:
+                event_info[0].append(cb)
             else:
-                self._subscribers[event] = [cb]
+                if source not in event_info[1]:
+                    event_info[1][source] = []
+                event_info[1][source].append(cb)
 
-    def unsubscribe(self, events, cb):
-        pass
+    def unsubscribe(self, cb, events=None):
+        """!@brief Remove a callback from the subscribers list.
+        
+        @param self
+        @param cb The callback to remove from all subscriptions.
+        @param events Optional. May be a single event or an iterable of events. If specified, the
+            _cb_ will be removed only from those events.
+        """
+        if (events is not None) and (not isinstance(events, (tuple, list, set))):
+            events = [events]
+        
+        for event, event_info in self._subscribers.items():
+            # Skip this event if it's not one on the removal list.
+            if (events is not None) and (event not in events):
+                continue
+            
+            # Remove callback from all-sources list.
+            if cb in event_info[0]:
+                event_info[0].remove(cb)
+            
+            # Scan source-specific subscribers.
+            for source_info in event_info[1].values():
+                if cb in source_info:
+                    source_info.remove(cb)
 
-    def notify(self, *notifications):
-        for note in notifications:
-            TRACE.debug("Sending notification: %s", repr(note))
-            for cb in self._subscribers.get(note.event, []):
-                cb(note)
+    def notify(self, event, source=None, data=None):
+        """!@brief Notify subscribers of an event.
+        
+        @param self
+        @param event Event to send. Must be a hashable object. It is acceptable to notify for an
+            event for which there are no subscribers.
+        @param source The object sending the notification. If not set, the source defaults to self,
+            the object on which the notify() method was called.
+        @param data Optional data value to send with the notification.
+        """
+        # Look up subscribers for this event.
+        try:
+            event_info = self._subscribers[event]
+        except KeyError:
+            # Nobody has subscribed to this event, so nothing to do.
+            TRACE.debug("Not sending notification because no subscribers: event=%s", event)
+            return
+        
+        # Look up subscribers for this event + source combo.
+        try:
+            source_subscribers = event_info[1][source]
+        except KeyError:
+            # No source-specific subscribers.
+            source_subscribers = []
+        
+        # Create combined subscribers list. Exit if no subscribers matched.
+        subscribers = event_info[0] + source_subscribers
+        if not subscribers:
+            TRACE.debug("Not sending notification because no matching subscribers: event=%s", event)
+            return
+        
+        # Create the notification object now that we know there are some subscribers.
+        if source is None:
+            source = self
+        note = Notification(event, source, data)
+        TRACE.debug("Sending notification to %d subscribers: %s", len(subscribers), note)
+        
+        # Tell everyone!
+        for cb in subscribers:
+            cb(note)
 
 

--- a/test/automated_test.py
+++ b/test/automated_test.py
@@ -149,22 +149,23 @@ def print_board_header(outputFile, board, n, includeDividers=True, includeLeadin
     if includeDividers:
         print(divider + "\n", file=outputFile)
 
-## @brief Run all tests on a given board.
-#
-# When multiple test jobs are being used, this function is the entry point executed in
-# child processes.
-#
-# Always writes both stdout and log messages of tests to a board-specific log file, and saves
-# the output for each test to a string that is stored in the TestResult object. Depending on
-# the logToConsole and commonLogFile parameters, output may also be copied to the console
-# (sys.stdout) and/or a common log file for all boards.
-#
-# @param board_id Unique ID of the board to test.
-# @param n Unique index of the test run.
-# @param loglevel Log level passed to logger instance. Usually INFO or DEBUG.
-# @param logToConsole Boolean indicating whether output should be copied to sys.stdout.
-# @param commonLogFile If not None, an open file object to which output should be copied.
 def test_board(board_id, n, loglevel, logToConsole, commonLogFile):
+    """! @brief Run all tests on a given board.
+    
+    When multiple test jobs are being used, this function is the entry point executed in
+    child processes.
+    
+    Always writes both stdout and log messages of tests to a board-specific log file, and saves
+    the output for each test to a string that is stored in the TestResult object. Depending on
+    the logToConsole and commonLogFile parameters, output may also be copied to the console
+    (sys.stdout) and/or a common log file for all boards.
+    
+    @param board_id Unique ID of the board to test.
+    @param n Unique index of the test run.
+    @param loglevel Log level passed to logger instance. Usually INFO or DEBUG.
+    @param logToConsole Boolean indicating whether output should be copied to sys.stdout.
+    @param commonLogFile If not None, an open file object to which output should be copied.
+    """
     probe = DebugProbeAggregator.get_probe_with_id(board_id)
     assert probe is not None
     session = Session(probe, **get_session_options())

--- a/test/unit/test_notification.py
+++ b/test/unit/test_notification.py
@@ -1,0 +1,113 @@
+# pyOCD debugger
+# Copyright (c) 2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import six
+from enum import Enum
+from pyocd.utility.notification import (Notification, Notifier)
+
+# Test both int and string events.
+EVENT_A = 1
+EVENT_B = "foo"
+
+class Subscriber(object):
+    def __init__(self):
+        self.was_called = False
+        self.last_note = None
+    
+    def cb(self, note):
+        self.was_called = True
+        self.last_note = note
+
+@pytest.fixture
+def notifier():
+    return Notifier()
+
+@pytest.fixture
+def subscriber():
+    return Subscriber()
+
+class TestNotification(object):
+    def test_basic_sub_and_send_a(self, notifier, subscriber):
+        notifier.subscribe(subscriber.cb, EVENT_A)
+        notifier.notify(EVENT_A, self)
+        assert subscriber.was_called
+        assert subscriber.last_note.event == EVENT_A
+        assert subscriber.last_note.source == self
+        assert subscriber.last_note.data == None
+
+    def test_basic_sub_and_send_b(self, notifier, subscriber):
+        notifier.subscribe(subscriber.cb, EVENT_B)
+        notifier.notify(EVENT_B, self)
+        assert subscriber.was_called
+        assert subscriber.last_note.event == EVENT_B
+        assert subscriber.last_note.source == self
+        assert subscriber.last_note.data == None
+
+    def test_unsub(self, notifier, subscriber):
+        notifier.subscribe(subscriber.cb, EVENT_A)
+        notifier.unsubscribe(subscriber.cb)
+        notifier.notify(EVENT_A, self)
+        assert not subscriber.was_called
+
+    def test_unsub2(self, notifier, subscriber):
+        notifier.subscribe(subscriber.cb, EVENT_A)
+        notifier.unsubscribe(subscriber.cb, events=[EVENT_B])
+        notifier.notify(EVENT_A, self)
+        assert subscriber.was_called
+
+    def test_multiple_sub(self, notifier, subscriber):
+        notifier.subscribe(subscriber.cb, (EVENT_A, EVENT_B))
+        notifier.notify(EVENT_A, self)
+        assert subscriber.was_called
+        assert subscriber.last_note.event == EVENT_A
+        assert subscriber.last_note.source == self
+        assert subscriber.last_note.data == None
+        notifier.notify(EVENT_B, self)
+        assert subscriber.was_called
+        assert subscriber.last_note.event == EVENT_B
+        assert subscriber.last_note.source == self
+        assert subscriber.last_note.data == None
+
+    def test_diff_sub(self, notifier, subscriber):
+        s2 = Subscriber()
+        notifier.subscribe(subscriber.cb, EVENT_A)
+        notifier.subscribe(s2.cb, EVENT_B)
+        notifier.notify(EVENT_B, self)
+        assert not subscriber.was_called
+        assert s2.was_called
+        assert s2.last_note.event == EVENT_B
+
+    def test_src_sub(self, notifier, subscriber):
+        notifier.subscribe(subscriber.cb, EVENT_A, source=self)
+        notifier.notify(EVENT_A, self)
+        assert subscriber.was_called
+        assert subscriber.last_note.event == EVENT_A
+        assert subscriber.last_note.source == self
+        assert subscriber.last_note.data == None
+
+    def test_src_sub2(self, notifier, subscriber):
+        notifier.subscribe(subscriber.cb, EVENT_A, source=self)
+        notifier.notify(EVENT_A, notifier)
+        assert not subscriber.was_called
+
+    def test_unsub_src(self, notifier, subscriber):
+        notifier.subscribe(subscriber.cb, EVENT_A, source=self)
+        notifier.unsubscribe(subscriber.cb)
+        notifier.notify(EVENT_A, self)
+        assert not subscriber.was_called
+
+        

--- a/test/unit/test_options_manager.py
+++ b/test/unit/test_options_manager.py
@@ -1,0 +1,124 @@
+# pyOCD debugger
+# Copyright (c) 2019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import six
+
+from pyocd.core.options_manager import OptionsManager
+from pyocd.core.options import OPTIONS_INFO
+
+@pytest.fixture(scope='function')
+def mgr():
+    return OptionsManager()
+
+@pytest.fixture(scope='function')
+def layer1():
+    return {
+            'foo': 1,
+            'bar': 2,
+            'baz': 3,
+            'auto_unlock': False,
+        }
+
+@pytest.fixture(scope='function')
+def layer2():
+    return {
+            'baz': 33,
+            'dogcow': 777,
+        }
+
+class TestOptionsManager(object):
+    def test_defaults(self, mgr):
+        assert mgr.get('auto_unlock') == OPTIONS_INFO['auto_unlock'].default
+        assert mgr['auto_unlock'] == OPTIONS_INFO['auto_unlock'].default
+        assert 'auto_unlock' not in mgr
+        assert mgr.get_default('auto_unlock') == OPTIONS_INFO['auto_unlock'].default
+
+    def test_a(self, mgr, layer1):
+        mgr.add_front(layer1)
+        assert 'auto_unlock' in mgr
+        assert mgr.get('auto_unlock') == False
+
+    def test_b(self, mgr, layer1):
+        mgr.add_front(layer1)
+        mgr.add_front({'auto_unlock': True})
+        assert 'auto_unlock' in mgr
+        assert mgr.get('auto_unlock') == True
+
+    def test_c(self, mgr, layer1):
+        mgr.add_front(layer1)
+        mgr.add_back({'auto_unlock': True})
+        assert 'auto_unlock' in mgr
+        assert mgr.get('auto_unlock') == False
+
+    def test_none_value(self, mgr):
+        mgr.add_back({'auto_unlock': None})
+        assert 'auto_unlock' not in mgr
+        assert mgr.get('auto_unlock') == True
+
+    def test_convert_double_underscore(self, mgr):
+        mgr.add_back({'debug__traceback': False})
+        assert 'debug.traceback' in mgr
+        assert mgr.get('debug.traceback') == False
+        
+    def test_set(self, mgr, layer1):
+        mgr.add_front(layer1)
+        mgr.set('buzz', 1234)
+        assert mgr['buzz'] == 1234
+        mgr.add_front({'buzz': 4321})
+        assert mgr.get('buzz') == 4321
+        
+    def test_update(self, mgr, layer1, layer2):
+        mgr.add_front(layer1)
+        mgr.add_front(layer2)
+        mgr.update({'foo': 888, 'debug__traceback': False})
+        assert mgr['foo'] == 888
+        assert mgr.get('debug.traceback') == False
+
+    def test_notify_set(self, mgr, layer1):
+        mgr.add_front(layer1)
+        flag = [False]
+        def cb(note):
+            flag[0] = True
+            assert note.event == 'foo'
+            assert note.source == mgr
+            assert note.data.new_value == 100 and note.data.old_value == 1
+        mgr.subscribe(cb, 'foo')
+        mgr.set('foo', 100)
+        assert flag[0] == True
+
+    def test_notify_layer(self, mgr, layer1, layer2):
+        mgr.add_front(layer1)
+        flag = [False]
+        def cb(note):
+            flag[0] = True
+            assert note.event == 'baz'
+            assert note.source == mgr
+            assert note.data.new_value == 33 and note.data.old_value == 3
+        mgr.subscribe(cb, 'baz')
+        mgr.add_front(layer2)
+        assert flag[0] == True
+
+    def test_notify_back_layer(self, mgr, layer1, layer2):
+        mgr.add_front(layer1)
+        flag = [False]
+        def cb(note):
+            flag[0] = True
+        mgr.subscribe(cb, 'baz')
+        mgr.add_back(layer2)
+        assert flag[0] == False
+
+        

--- a/test/unit/test_semihosting.py
+++ b/test/unit/test_semihosting.py
@@ -94,11 +94,12 @@ NOP = 0x46c0
 BKPT_00 = 0xbe00
 BKPT_AB = 0xbeab
 
-## @brief Semihost IO handler that records output.
-#
-# This handler is only meant to be used for console I/O since it doesn't implement
-# open() or close().
 class RecordingSemihostIOHandler(semihost.SemihostIOHandler):
+    """! @brief Semihost IO handler that records output.
+    
+    This handler is only meant to be used for console I/O since it doesn't implement
+    open() or close().
+    """
     def __init__(self):
         self._out_data = {}
         self._in_data = {}
@@ -137,8 +138,8 @@ class RecordingSemihostIOHandler(semihost.SemihostIOHandler):
         else:
             return -1
 
-## @brief Utility to build code and set registers to perform a semihost request.
 class SemihostRequestBuilder:
+    """! @brief Utility to build code and set registers to perform a semihost request."""
     def __init__(self, tgt, semihostagent, ramrgn):
         self.tgt = tgt
         self.ctx = tgt.get_target_context()
@@ -319,8 +320,8 @@ def delete_testfile(request):
             pass
     request.addfinalizer(delete_it)
 
-## @brief Tests for semihost requests.
 class TestSemihosting:
+    """! @brief Tests for semihost requests."""
     def test_open_stdio(self, semihost_builder):
         fd = semihost_builder.do_open(":tt", 'r') # stdin
         assert fd == 1


### PR DESCRIPTION
- Reworked and improved the notification API.
- All target-related notifications now go through the session. This allowed for removing the `root_target` attribute on `Target`, since that was primarily used as a workaround for not having a session object back when notifications were first added.
- Users can subscribe to notifications for user option value changes. In this case, the options manager is the notifier. Example: `session.options.subscribe('auto_unlock', my_unlock_change_handler)`.