### PR TITLE
STLinkV3 support

### DIFF
--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -74,11 +74,12 @@ class DebugProbe(object):
     def create_associated_board(self, session):
         """! @brief Create a board instance representing the board of which the probe is a component.
         
-        If the probe is part of a board, then this property will be a Board instance that represents
-        the associated board. Usually, for an on-board debug probe, this would be the Board that
-        the probe physically is part of. If the probe does not have an associated board, then this
-        method returns None.
+        If the probe is part of a board, then this method will create a Board instance that
+        represents the associated board. Usually, for an on-board debug probe, this would be the
+        Board that the probe physically is part of, and will also set the target type. If the probe
+        does not have an associated board, then this method returns None.
         
+        @param self
         @param session Session to pass to the board upon construction.
         """
         return None
@@ -93,7 +94,7 @@ class DebugProbe(object):
     #          Target control functions
     # ------------------------------------------- #
     def connect(self, protocol=None):
-        """! @brief Initailize DAP IO pins for JTAG or SWD"""
+        """! @brief Initialize DAP IO pins for JTAG or SWD"""
         raise NotImplementedError()
 
     def disconnect(self):


### PR DESCRIPTION
This PR adds STLinkV3 debug probe support. The main changes were handling the version 3 hardware in version checks, and using the new SET_COM_FREQ command to change SWD and JTAG clock frequencies. GET_COM_FREQ is also implemented, but is not currently used by pyOCD.

Closes #447 