### PR TITLE
Couple bug fixes

### DIFF
--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -1181,7 +1181,7 @@ class CortexM(Target, CoreSightCoreComponent):
 
     @property
     def available_breakpoint_count(self):
-        return self.fpb.available_breakpoints()
+        return self.fpb.available_breakpoints
 
     def find_watchpoint(self, addr, size, type):
         return self.dwt.find_watchpoint(addr, size, type)

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -411,6 +411,15 @@ class CmsisPackDevice(object):
                 length = nextStart - start
                 start += region.start
                 
+                # Limit page size.
+                if page_size > sector_size:
+                    region_page_size = sector_size
+                    LOG.warning("Page size (%d) is larger than sector size (%d) for flash region %s; "
+                                "reducing page size to %d", page_size, sector_size, region.name,
+                                region_page_size)
+                else:
+                    region_page_size = page_size
+                
                 # If we don't have a boot memory yet, pick the first flash.
                 if not self._saw_startup:
                     isBoot = True
@@ -424,7 +433,7 @@ class CmsisPackDevice(object):
                                 start=start,
                                 length=length,
                                 sector_size=sector_size,
-                                page_size=page_size,
+                                page_size=region_page_size,
                                 flm=packAlgo,
                                 algo=algo,
                                 erased_byte_value=packAlgo.flash_info.value_empty,


### PR DESCRIPTION
1. Added a workaround for .FLM flash algos (i.e., from CMSIS-Packs) that specify a page size larger than the sector size. Specifically, this fixes flash programming with certain pack-based targets such as the STM32L072/073.
2. Fixed the `CortexM.available_breakpoint_count` property.