### PR TITLE
Fix choose probe quit option, plus some related improvements

### DIFF
--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -20,6 +20,7 @@ from ..probe.aggregator import DebugProbeAggregator
 from time import sleep
 import colorama
 import six
+import prettytable
 
 # Init colorama here since this is currently the only module that uses it.
 colorama.init()
@@ -87,7 +88,11 @@ class ConnectHelper(object):
                 break
             else:
                 if print_wait_message and not printedMessage:
-                    print(colorama.Fore.YELLOW + "Waiting for a debug probe to be connected..." + colorama.Style.RESET_ALL)
+                    if unique_id is None:
+                        msg = "Waiting for a debug probe to be connected..."
+                    else:
+                        msg = "Waiting for a debug probe matching unique ID '%s' to be connected..." % unique_id
+                    print(colorama.Fore.YELLOW + msg + colorama.Style.RESET_ALL)
                     printedMessage = True
                 sleep(0.01)
             assert len(sortedProbes) == 0
@@ -146,9 +151,10 @@ class ConnectHelper(object):
         # Return if no boards are connected.
         if allProbes is None or len(allProbes) == 0:
             if unique_id is None:
-                print("No connected debug probes")
+                print(colorama.Fore.RED + "No connected debug probes" + colorama.Style.RESET_ALL)
             else:
-                print("A debug probe matching unique ID '%s' is not connected, or no connected probe matches" % unique_id)
+                print(colorama.Fore.RED + "No connected debug probe matches unique ID '%s'" %
+                    unique_id + colorama.Style.RESET_ALL)
             return None # No boards to close so it is safe to return
 
         # Select first board
@@ -158,10 +164,9 @@ class ConnectHelper(object):
         # Ask user to select boards if there is more than 1 left
         if len(allProbes) > 1:
             ConnectHelper._print_probe_list(allProbes)
-            print(colorama.Fore.RED + " q => Quit")
             while True:
                 print(colorama.Style.RESET_ALL)
-                print("Enter the number of the debug probe to connect:")
+                print("Enter the number of the debug probe or 'q' to quit", end='')
                 line = six.moves.input("> ")
                 valid = False
                 if line.strip().lower() == 'q':
@@ -174,7 +179,6 @@ class ConnectHelper(object):
                 if not valid:
                     print(colorama.Fore.YELLOW + "Invalid choice: %s\n" % line)
                     Session._print_probe_list(allProbes)
-                    print(colorama.Fore.RED + " q => Exit" + colorama.Style.RESET_ALL)
                 else:
                     break
             allProbes = allProbes[ch:ch + 1]
@@ -238,9 +242,18 @@ class ConnectHelper(object):
 
     @staticmethod
     def _print_probe_list(probes):
-        print(colorama.Fore.BLUE + "## => Board Name | Unique ID")
-        print("-- -- ----------------------")
+        pt = prettytable.PrettyTable(["#", "Probe", "Unique ID"])
+        pt.align = 'l'
+        pt.header = True
+        pt.border = True
+        pt.hrules = prettytable.HEADER
+        pt.vrules = prettytable.NONE
+
         for index, probe in enumerate(probes):
-            print(colorama.Fore.GREEN + "%2d => %s | " % (index, probe.description) +
-                colorama.Fore.CYAN + probe.unique_id + colorama.Style.RESET_ALL)
+            pt.add_row([
+                colorama.Fore.YELLOW + str(index),
+                colorama.Fore.GREEN + probe.description,
+                colorama.Fore.CYAN + probe.unique_id,
+                ])
+        print(pt)
         print(colorama.Style.RESET_ALL, end='')

--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -231,7 +231,10 @@ class ConnectHelper(object):
                     return_first=return_first,
                     unique_id=unique_id,
                     )
-        return Session(probe, auto_open=auto_open, options=options, **kwargs)
+        if probe is None:
+            return None
+        else:
+            return Session(probe, auto_open=auto_open, options=options, **kwargs)
 
     @staticmethod
     def _print_probe_list(probes):

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -163,7 +163,6 @@ class CMSISDAPProbe(DebugProbe):
     #          Target control functions
     # ------------------------------------------- #
     def connect(self, protocol=None):
-        """! @brief Initialize DAP IO pins for JTAG or SWD"""
         # Convert protocol to port enum.
         if protocol is not None:
             port = self.PORT_MAP[protocol]
@@ -183,14 +182,12 @@ class CMSISDAPProbe(DebugProbe):
 
     # TODO remove
     def swj_sequence(self):
-        """! @brief Send sequence to activate JTAG or SWD on the target"""
         try:
             self._link.swj_sequence()
         except DAPAccess.Error as exc:
             six.raise_from(self._convert_exception(exc), exc)
 
     def disconnect(self):
-        """! @brief Deinitialize the DAP I/O pins"""
         try:
             self._link.disconnect()
             self._protocol = None
@@ -199,17 +196,12 @@ class CMSISDAPProbe(DebugProbe):
             six.raise_from(self._convert_exception(exc), exc)
 
     def set_clock(self, frequency):
-        """! @brief Set the frequency for JTAG and SWD in Hz
-
-        This function is safe to call before connect is called.
-        """
         try:
             self._link.set_clock(frequency)
         except DAPAccess.Error as exc:
             six.raise_from(self._convert_exception(exc), exc)
 
     def reset(self):
-        """! @brief Reset the target"""
         try:
             self._invalidate_cached_registers()
             self._link.reset()
@@ -217,7 +209,6 @@ class CMSISDAPProbe(DebugProbe):
             six.raise_from(self._convert_exception(exc), exc)
 
     def assert_reset(self, asserted):
-        """! @brief Assert or de-assert target reset line"""
         try:
             self._invalidate_cached_registers()
             self._link.assert_reset(asserted)
@@ -225,14 +216,12 @@ class CMSISDAPProbe(DebugProbe):
             six.raise_from(self._convert_exception(exc), exc)
     
     def is_reset_asserted(self):
-        """! @brief Returns True if the target reset line is asserted or False if de-asserted"""
         try:
             return self._link.is_reset_asserted()
         except DAPAccess.Error as exc:
             six.raise_from(self._convert_exception(exc), exc)
 
     def flush(self):
-        """! @brief Write out all unsent commands"""
         try:
             self._link.flush()
         except DAPAccess.Error as exc:
@@ -243,14 +232,6 @@ class CMSISDAPProbe(DebugProbe):
     # ------------------------------------------- #
 
     def read_dp(self, addr, now=True):
-        """! @brief Read a DP register.
-        
-        @param self
-        @param addr Integer register address being one of (0x0, 0x4, 0x8, 0xC).
-        @param now
-        
-        @todo Handle auto DPBANKSEL.
-        """
         reg_id = self.REG_ADDR_TO_ID_MAP[self.DP, addr]
         
         try:
@@ -365,14 +346,12 @@ class CMSISDAPProbe(DebugProbe):
     # ------------------------------------------- #
 
     def has_swo(self):
-        """! @brief Returns bool indicating whether the link supports SWO."""
         try:
             return self._link.has_swo()
         except DAPAccess.Error as exc:
             six.raise_from(self._convert_exception(exc), exc)
 
     def swo_start(self, baudrate):
-        """! @brief Start receiving SWO data at the given baudrate."""
         try:
             self._link.swo_configure(True, baudrate)
             self._link.swo_control(True)
@@ -380,17 +359,12 @@ class CMSISDAPProbe(DebugProbe):
             six.raise_from(self._convert_exception(exc), exc)
 
     def swo_stop(self):
-        """! @brief Stop receiving SWO data."""
         try:
             self._link.swo_configure(False, 0)
         except DAPAccess.Error as exc:
             six.raise_from(self._convert_exception(exc), exc)
 
     def swo_read(self):
-        """! @brief Read buffered SWO data from the target.
-        
-        @eturn Bytearray of the received data.
-        """
         try:
             return self._link.swo_read()
         except DAPAccess.Error as exc:

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -77,7 +77,6 @@ class StlinkProbe(DebugProbe):
 
     @property
     def supported_wire_protocols(self):
-        """! @brief Only valid after opening."""
         return [DebugProbe.Protocol.DEFAULT, DebugProbe.Protocol.SWD, DebugProbe.Protocol.JTAG]
 
     @property
@@ -110,17 +109,14 @@ class StlinkProbe(DebugProbe):
     #          Target control functions
     # ------------------------------------------- #
     def connect(self, protocol=None):
-        """! @brief Initialize DAP IO pins for JTAG or SWD"""
         self._link.enter_debug(STLink.Protocol.SWD)
         self._is_connected = True
 
     # TODO remove
     def swj_sequence(self):
-        """! @brief Send sequence to activate JTAG or SWD on the target"""
         pass
 
     def disconnect(self):
-        """! @brief Deinitialize the DAP I/O pins"""
         # TODO Close the APs. When this is attempted, we get an undocumented 0x1d error. Doesn't
         #      seem to be necessary, anyway.
         self._memory_interfaces = {}
@@ -129,27 +125,19 @@ class StlinkProbe(DebugProbe):
         self._is_connected = False
 
     def set_clock(self, frequency):
-        """! @brief Set the frequency for JTAG and SWD in Hz
-
-        This function is safe to call before connect is called.
-        """
         self._link.set_swd_frequency(frequency)
 
     def reset(self):
-        """! @brief Reset the target"""
         self._link.target_reset()
 
     def assert_reset(self, asserted):
-        """! @brief Assert or de-assert target reset line"""
         self._link.drive_nreset(asserted)
         self._nreset_state = asserted
     
     def is_reset_asserted(self):
-        """! @brief Returns True if the target reset line is asserted or False if de-asserted"""
         return self._nreset_state
 
     def flush(self):
-        """! @brief Write out all unsent commands"""
         pass
 
     # ------------------------------------------- #
@@ -200,22 +188,15 @@ class StlinkProbe(DebugProbe):
         return self._memory_interfaces[apsel]
 
     def has_swo(self):
-        """! @brief Returns bool indicating whether the link supports SWO."""
         return True
 
     def swo_start(self, baudrate):
-        """! @brief Start receiving SWO data at the given baudrate."""
         self._link.swo_start(baudrate)
 
     def swo_stop(self):
-        """! @brief Stop receiving SWO data."""
         self._link.swo_stop()
 
     def swo_read(self):
-        """! @brief Read as much buffered SWO data from the target as possible.
-        
-        @eturn Bytearray of the received data.
-        """
         return self._link.swo_read()
 
 class STLinkMemoryInterface(MemoryInterface):


### PR DESCRIPTION
This patch fixes exceptions that would be reported if you entered 'q' when asked to choose one of the connected probes.

Also updated the probe selection display a little to use `PrettyTable`, tweaked some messages printed by `ConnectHelper`, and threw in some additional documentation of DebugProbe methods.