### PR TITLE
Add micro:bit board ID 9901.

### DIFF
--- a/pyocd/board/board_ids.py
+++ b/pyocd/board/board_ids.py
@@ -192,7 +192,8 @@ BOARD_ID_TO_INFO = {
     "9009": BoardInfo(  "Arch BLE",             "nrf51",            "l1_nrf51.bin",         ),
     "9012": BoardInfo(  "Seeed Tiny BLE",       "nrf51",            "l1_nrf51.bin",         ),
     "9014": BoardInfo(  "Seeed 96Boards Nitrogen", "nrf52",         "l1_nrf52-dk.bin",      ),
-    "9900": BoardInfo(  "Microbit",             "nrf51",            "l1_microbit.bin",      ),
+    "9900": BoardInfo(  "micro:bit",            "nrf51",            "l1_microbit.bin",      ),
+    "9901": BoardInfo(  "micro:bit",            "nrf51",            "l1_microbit.bin",      ),
     "C004": BoardInfo(  "tinyK20",              "k20d50m",          "l1_k20d50m.bin",       ),
     "C006": BoardInfo(  "VBLUno51",             "nrf51",            "l1_nrf51.bin",         ),
 }


### PR DESCRIPTION
When the micro:bit v1.5 revision was released it had a new ID assigned in DAPLink: https://github.com/ARMmbed/DAPLink/blob/0711f11391de54b13dc8a628c80617ca5d25f070/source/board/microbit.c#L28

This PR adds the new ID and fixes the name of the board.