### PR TITLE
Fix lpc55s69 print

### DIFF
--- a/pyocd/flash/flash_builder.py
+++ b/pyocd/flash/flash_builder.py
@@ -617,18 +617,19 @@ class FlashBuilder(object):
         """
         analyze_start = time()
         
-        # Analyze pages using either CRC32 analyzer or partial reads.
-        if self.flash.get_flash_info().crc_supported:
-            self._analyze_pages_with_crc32(fast_verify)
-            self.perf.analyze_type = FlashBuilder.FLASH_ANALYSIS_CRC32
-        elif self.flash.region.is_readable:
-            self._analyze_pages_with_partial_read()
-            self.perf.analyze_type = FlashBuilder.FLASH_ANALYSIS_PARTIAL_PAGE_READ
-        else:
-            # The CRC analyzer isn't supported and flash isn't directly readable, so
-            # just mark all pages as needing programming. This will also prevent
-            # _scan_pages_for_same() from trying to read flash.
-            self._mark_all_pages_for_programming()
+        # Analyze unknown pages using either CRC32 analyzer or partial reads.
+        if any(page.same is None for page in self.page_list):
+            if self.flash.get_flash_info().crc_supported:
+                self._analyze_pages_with_crc32(fast_verify)
+                self.perf.analyze_type = FlashBuilder.FLASH_ANALYSIS_CRC32
+            elif self.flash.region.is_readable:
+                self._analyze_pages_with_partial_read()
+                self.perf.analyze_type = FlashBuilder.FLASH_ANALYSIS_PARTIAL_PAGE_READ
+            else:
+                # The CRC analyzer isn't supported and flash isn't directly readable, so
+                # just mark all pages as needing programming. This will also prevent
+                # _scan_pages_for_same() from trying to read flash.
+                self._mark_all_pages_for_programming()
 
         # Put together page and time estimate.
         sector_erase_count = 0

--- a/pyocd/target/builtin/target_LPC55S69JBD100.py
+++ b/pyocd/target/builtin/target_LPC55S69JBD100.py
@@ -238,10 +238,8 @@ class CortexM_LPC55S69(CortexM_v8M):
             # If the processor is in Secure state, we have to access the flash controller
             # through the secure alias.
             if self.get_security_state() == Target.SecurityState.SECURE:
-                print("Secure")
                 base = PERIPHERAL_BASE_S
             else:
-                print("Non-Secure")
                 base = PERIPHERAL_BASE_NS
             
             # Use the flash programming model to check if the first flash page is readable, since


### PR DESCRIPTION
Remove accidentally included debug `print()` call in LPC55S69 support.

Also includes a tiny change to perform an up-front check of whether any pages have an unknown state prior to calling the analysis routine during flash programming.