### PR TITLE
Fix SVD model handling of unset derived attributes.

### DIFF
--- a/pyocd/debug/svd/model.py
+++ b/pyocd/debug/svd/model.py
@@ -91,7 +91,7 @@ class SVDElement(object):
         # if there is a derivedFrom, check there first
         elif derived_from is not None:
             derived_value = getattr(derived_from, "_{}".format(attr), NOT_PRESENT)
-            if derived_value is not NOT_PRESENT:
+            if (derived_value is not NOT_PRESENT) and (derived_value is not None):
                 return derived_value
 
         # for some attributes, try to grab from parent


### PR DESCRIPTION
If a derived SVD model element did not have a value for an attribute, then  it would immediately return the attribute value from the element it  was derived from. However, certain attributes such as "interrupts" need to be converted from None to empty lists before being returned, and it was exiting prior to this conversion.

Thanks to @wnts for the report and initial debugging!

Closes #688 