### PR TITLE
Fix race caused by shared memory map

### DIFF
--- a/pyocd/core/memory_map.py
+++ b/pyocd/core/memory_map.py
@@ -239,18 +239,33 @@ class MemoryRegion(MemoryRangeBase):
             if callable(v):
                 v = v(self)
             return v
-    
-    def __deepcopy__(self, memo):
-        # Custom deep copy is required due to our __getattr__() method.
-        return self.__class__(**(copy.deepcopy(self._attributes)))
+
+    def __copy__(self):
+        # Custom copy is required due to our __getattr__() method.
+        return self.__class__(
+                # type=self.type,
+                start=self.start,
+                length=self.length,
+                **self._attributes
+                )
  
+    def __deepcopy__(self, memo):
+        # Same as __copy__ but with a deep copy of attributes.
+        return self.__class__(
+                # type=self.type,
+                start=self.start,
+                length=self.length,
+                **copy.deepcopy(self._attributes, memo)
+                )
+
     def __repr__(self):
         return "<%s@0x%x name=%s type=%s start=0x%x end=0x%x length=0x%x access=%s>" % (self.__class__.__name__, id(self), self.name, self.type, self.start, self.end, self.length, self.access)
 
 class RamRegion(MemoryRegion):
     """! @brief Contiguous region of RAM."""
     def __init__(self, start=0, end=0, length=None, **attrs):
-        super(RamRegion, self).__init__(type=MemoryType.RAM, start=start, end=end, length=length, **attrs)
+        attrs['type'] = MemoryType.RAM
+        super(RamRegion, self).__init__(start=start, end=end, length=length, **attrs)
 
 class RomRegion(MemoryRegion):
     """! @brief Contiguous region of ROM."""
@@ -262,7 +277,8 @@ class RomRegion(MemoryRegion):
         })
 
     def __init__(self, start=0, end=0, length=None, **attrs):
-        super(RomRegion, self).__init__(type=MemoryType.ROM, start=start, end=end, length=length, **attrs)
+        attrs['type'] = MemoryType.ROM
+        super(RomRegion, self).__init__(start=start, end=end, length=length, **attrs)
 
 class DefaultFlashWeights:
     """! @brief Default weights for flash programming operations."""
@@ -314,7 +330,8 @@ class FlashRegion(MemoryRegion):
         from ..flash.flash import Flash
 
         assert ('blocksize' in attrs) or ('sector_size' in attrs)
-        super(FlashRegion, self).__init__(type=MemoryType.FLASH, start=start, end=end, length=length, **attrs)
+        attrs['type'] = MemoryType.FLASH
+        super(FlashRegion, self).__init__(start=start, end=end, length=length, **attrs)
         self._algo = attrs.get('algo', None)
         self._flm = None
         self._flash = None
@@ -324,6 +341,16 @@ class FlashRegion(MemoryRegion):
             assert issubclass(self._flash_class, Flash)
         else:
             self._flash_class = Flash
+        
+        # Remove writable region attributes from attributes dict so there is only one copy.
+        try:
+            del self._attributes['algo']
+        except KeyError:
+            pass
+        try:
+            del self._attributes['flash_class']
+        except KeyError:
+            pass
     
     @property
     def algo(self):
@@ -369,6 +396,34 @@ class FlashRegion(MemoryRegion):
             if b != erasedByte:
                 return False
         return True
+    
+    def __copy__(self):
+        # Include the writable attributes in the copy.
+        clone = self.__class__(
+                # type=self.type,
+                start=self.start,
+                length=self.length,
+                algo=self._algo,
+                flash_class=self._flash_class,
+                **self._attributes
+                )
+        # Copy the FLM.
+        clone._flm = self._flm
+        return clone
+
+    def __deepcopy__(self, memo):
+        # Include deep copies of the writable attributes in the copy.
+        clone = self.__class__(
+                # type=self.type,
+                start=self.start,
+                length=self.length,
+                algo=copy.deepcopy(self._algo, memo),
+                flash_class=self._flash_class,
+                **copy.deepcopy(self._attributes, memo)
+                )
+        # Deep copy the FLM.
+        clone._flm = copy.deepcopy(self._flm, memo)
+        return clone
 
     def __repr__(self):
         return "<%s@0x%x name=%s type=%s start=0x%x end=0x%x length=0x%x access=%s blocksize=0x%x>" % (self.__class__.__name__, id(self), self.name, self.type, self.start, self.end, self.length, self.access, self.blocksize)
@@ -385,7 +440,8 @@ class DeviceRegion(MemoryRegion):
         })
 
     def __init__(self, start=0, end=0, length=None, **attrs):
-        super(DeviceRegion, self).__init__(type=MemoryType.DEVICE, start=start, end=end, length=length, **attrs)
+        attrs['type'] = MemoryType.DEVICE
+        super(DeviceRegion, self).__init__(start=start, end=end, length=length, **attrs)
 
 ## @brief Map from memory type to class.         
 MEMORY_TYPE_CLASS_MAP = {
@@ -473,6 +529,9 @@ class MemoryMap(object):
         for r in self.get_regions_of_type(type):
             return r
         return None
+    
+    def __eq__(self, other):
+        return isinstance(other, MemoryMap) and (self._regions == other._regions)
 
     def __iter__(self):
         """! @brief Enable iteration over the memory map."""

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import Enum
+import copy
+
 from .memory_interface import MemoryInterface
 from .memory_map import MemoryMap
-from enum import Enum
 
 class Target(MemoryInterface):
 
@@ -101,7 +103,9 @@ class Target(MemoryInterface):
         self.vendor = self.VENDOR
         self.part_families = []
         self.part_number = ""
-        self.memory_map = memoryMap or MemoryMap()
+        # Make a target-specific copy of the memory map. This is safe to do without locking
+        # because the memory map may not be mutated until target initialization.
+        self.memory_map = (copy.deepcopy(memoryMap)) if memoryMap else MemoryMap()
         self._svd_location = None
         self._svd_device = None
 


### PR DESCRIPTION
If multiple instances of the same target type were created in a single process, they would share a single memory map instance. This was fine in earlier times, but the memory map now holds some mutable state. With this patch, the memory map is copied for each target instance.

To support this, copy and deep copy support for `MemoryRegion` and `MemoryMap` was added. Unit tests for copies were added.

Closes #694