### PR TITLE
Catching more USB related exceptions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,3 @@
-include pytest.ini
-include Doxyfile
 include dev-requirements.txt
 include pyocd/debug/svd/*.zip
 recursive-include docs *

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -279,7 +279,7 @@ class FindDap(object):
                 LOG.debug("Error accessing USB device (VID=%04x PID=%04x): %s",
                     dev.idVendor, dev.idProduct, error)
             return False
-        except (IndexError, NotImplementedError) as error:
+        except (IndexError, NotImplementedError, ValueError, UnicodeDecodeError) as error:
             LOG.debug("Error accessing USB device (VID=%04x PID=%04x): %s", dev.idVendor, dev.idProduct, error)
             return False
 

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -343,7 +343,7 @@ class HasCmsisDapv2Interface(object):
                 else:
                     LOG.debug(msg)
             return False
-        except (IndexError, NotImplementedError, ValueError) as error:
+        except (IndexError, NotImplementedError, ValueError, UnicodeDecodeError) as error:
             return False
 
         if cmsis_dap_interface is None:


### PR DESCRIPTION
During testing, some cases were seen while matching USB devices where `ValueError` or `UnicodeDecodeError` was raised by PyUSB but not caught.

(Also tossed in a tiny change to clean up stale `MANIFEST.in` lines.)