### PR TITLE
pyDAPAccess error reporting improvements

### DIFF
--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -377,15 +377,15 @@ class CMSISDAPProbe(DebugProbe):
     @staticmethod
     def _convert_exception(exc):
         if isinstance(exc, DAPAccess.TransferFaultError):
-            return exceptions.TransferFaultError()
+            return exceptions.TransferFaultError(*exc.args)
         elif isinstance(exc, DAPAccess.TransferTimeoutError):
-            return exceptions.TransferTimeoutError()
+            return exceptions.TransferTimeoutError(*exc.args)
         elif isinstance(exc, DAPAccess.TransferError):
-            return exceptions.TransferError()
+            return exceptions.TransferError(*exc.args)
         elif isinstance(exc, (DAPAccess.DeviceError, DAPAccess.CommandError)):
-            return exceptions.ProbeError(str(exc))
+            return exceptions.ProbeError(*exc.args)
         elif isinstance(exc, DAPAccess.Error):
-            return exceptions.Error(str(exc))
+            return exceptions.Error(*exc.args)
         else:
             return exc
 

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2006-2013,2018 Arm Limited
+# Copyright (c) 2006-2013,2018-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,11 +105,17 @@ class DAPSWOStatus:
 DAP_OK = 0
 DAP_ERROR = 0xff
 
-# Responses to DAP_Transfer and DAP_TransferBlock
-DAP_TRANSFER_OK = 1
-DAP_TRANSFER_WAIT = 2
-DAP_TRANSFER_FAULT = 4
-DAP_TRANSFER_NO_ACK = 7
+class DAPTransferResponse:
+    """! Responses to DAP_Transfer and DAP_TransferBlock"""
+    ACK_MASK = 0x07 # Bits [2:0]
+    PROTOCOL_ERROR_MASK = 0x08 # Bit [3]
+    VALUE_MISMATCH_MASK = 0x08 # Bit [4]
+    
+    # Values for ACK bitfield.
+    ACK_OK = 1
+    ACK_WAIT = 2
+    ACK_FAULT = 4
+    ACK_NO_ACK = 7
 
 class CMSISDAPProtocol(object):
     """! @brief This class implements the CMSIS-DAP wire protocol."""

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2006-2013,2018 Arm Limited
+# Copyright (c) 2006-2013,2018-2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,23 +72,7 @@ class DAPAccessIntf(object):
 
     class TransferFaultError(TransferError):
         """! @brief A SWD Fault occurred"""
-        def __init__(self, faultAddress=None):
-            super(DAPAccessIntf.TransferFaultError, self).__init__(faultAddress)
-            self._address = faultAddress
-
-        @property
-        def fault_address(self):
-            return self._address
-
-        @fault_address.setter
-        def fault_address(self, addr):
-            self._address = addr
-
-        def __str__(self):
-            desc = "SWD/JTAG Transfer Fault"
-            if self._address is not None:
-                desc += " @ 0x%08x" % self._address
-            return desc
+        pass
 
     class TransferProtocolError(TransferError):
         """! @brief A SWD protocol error occurred"""


### PR DESCRIPTION
- "No ACK" and SWD protocol errors are reported as such using a `TransferError` with an appropriate message.
- Refactored `cmsis_dap_core.py` constants for transfer responses under a `DAPTransferResponse` namespace class.
- Removed fault address support from `DAPAccessIntf.TransferFaultError` that is now unused.
- Modified how `CMSISDAPProbe` passes exception arguments to the new exception class when converting exceptions.