### PR TITLE
Tilde expansion for ELF file paths and related bug fix

### DIFF
--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -571,7 +571,7 @@ class PyOCDTool(object):
             with session:
                 # Set ELF if provided.
                 if self._args.elf:
-                    session.board.target.elf = self._args.elf
+                    session.board.target.elf = os.path.expanduser(self._args.elf)
                 for core_number, core in session.board.target.cores.items():
                     gdb = GDBServer(session,
                         core=core_number,

--- a/pyocd/debug/elf/elf.py
+++ b/pyocd/debug/elf/elf.py
@@ -104,12 +104,12 @@ class ELFBinaryFile(object):
     """
     
     def __init__(self, elf, memory_map=None):
+        self._owns_file = False
         if isinstance(elf, six.string_types):
             self._file = open(elf, 'rb')
             self._owns_file = True
         else:
             self._file = elf
-            self._owns_file = False
         self._elf = ELFFile(self._file)
         self._memory_map = memory_map or MemoryMap()
 

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -761,7 +761,7 @@ class PyOCDCommander(object):
 
         # Set elf file if provided.
         if self.args.elf:
-            self.target.elf = self.args.elf
+            self.target.elf = os.path.expanduser(self.args.elf)
             self.elf = self.target.elf
         else:
             self.elf = None


### PR DESCRIPTION
ELF file paths provided through the `--elf` argument are run through tilde expansion.

Also fixed an undefined attribute exception raised by invalid ELF paths. You now get the expected "No such file or directory" error instead.