### PR TITLE
Fixed regression in connect_test.py.

### DIFF
--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -908,7 +908,7 @@ class CortexM(Target, CoreSightCoreComponent):
         """! @brief Disable halt on reset."""
         self.call_delegate('clear_reset_catch', core=self, reset_type=reset_type)
 
-        if self._reset_catch_delegate_result:
+        if not self._reset_catch_delegate_result:
             # restore vector catch setting
             self.write_memory(CortexM.DEMCR, self._reset_catch_saved_demcr)
 


### PR DESCRIPTION
`connect_test.py` was failing the first check to make sure the target was running after reset, prior to testing connect/disconnect option combinations. The cause was some incorrectly inverted logic in `CortexM.clear_reset_catch()` that had been refactored as part of the `connect_mode` option support.