### PR TITLE
DWTv2 support and watchpoint improvements

### DIFF
--- a/pyocd/coresight/component_ids.py
+++ b/pyocd/coresight/component_ids.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 from .cortex_m import CortexM
 from .cortex_m_v8m import CortexM_v8M
 from .fpb import FPB
-from .dwt import DWT
+from .dwt import (DWT, DWTv2)
 from .itm import ITM
 from .tpiu import TPIU
 from .gpr import GPR
@@ -78,11 +78,11 @@ COMPONENT_MAP = {
     (ARM_ID, CORESIGHT_CLASS, 0x9a9, 0x11, 0)      : CmpInfo('TPIU-M7',   TPIU.factory    ),
     (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x11, 0)      : CmpInfo('TPIU-M23',  TPIU.factory    ),
     (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x13, 0)      : CmpInfo('ETM-M23',   None            ),
-    (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x00, 0x1a02) : CmpInfo('DWT',       DWT.factory     ), # M23
+    (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x00, 0x1a02) : CmpInfo('DWT',       DWTv2.factory   ), # M23
     (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x00, 0x1a03) : CmpInfo('BPU',       FPB.factory     ), # M23
     (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x00, 0x2a04) : CmpInfo('SCS-M23',   CortexM_v8M.factory ), # M23
     (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x43, 0x1a01) : CmpInfo('ITM',       ITM.factory     ), # M33
-    (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x00, 0x1a02) : CmpInfo('DWT',       DWT.factory     ), # M33
+    (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x00, 0x1a02) : CmpInfo('DWT',       DWTv2.factory   ), # M33
     (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x00, 0x1a03) : CmpInfo('BPU',       FPB.factory     ), # M33
     (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x14, 0x1a14) : CmpInfo('CTI',       None            ), # M33
     (ARM_ID, CORESIGHT_CLASS, 0xd21, 0x00, 0x2a04) : CmpInfo('SCS-M33',   CortexM_v8M.factory ), # M33

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -420,6 +420,8 @@ class CortexM(Target, CoreSightCoreComponent):
         self._supports_vectreset = False
         self._reset_catch_delegate_result = False
         self._reset_catch_saved_demcr = 0
+        self.fpb = None
+        self.dwt = None
         
         # Default to software reset using the default software reset method.
         self._default_reset_type = Target.ResetType.SW
@@ -504,7 +506,8 @@ class CortexM(Target, CoreSightCoreComponent):
         if not self.call_delegate('will_stop_debug_core', core=self):
             # Remove breakpoints and watchpoints.
             self.bp_manager.remove_all_breakpoints()
-            self.dwt.remove_all_watchpoints()
+            if self.dwt is not None:
+                self.dwt.remove_all_watchpoints()
 
             # Disable other debug blocks.
             self.write32(CortexM.DEMCR, 0)
@@ -1212,17 +1215,20 @@ class CortexM(Target, CoreSightCoreComponent):
         return self.fpb.available_breakpoints
 
     def find_watchpoint(self, addr, size, type):
-        return self.dwt.find_watchpoint(addr, size, type)
+        if self.dwt is not None:
+            return self.dwt.find_watchpoint(addr, size, type)
 
     def set_watchpoint(self, addr, size, type):
         """! @brief Set a hardware watchpoint.
         """
-        return self.dwt.set_watchpoint(addr, size, type)
+        if self.dwt is not None:
+            return self.dwt.set_watchpoint(addr, size, type)
 
     def remove_watchpoint(self, addr, size, type):
         """! @brief Remove a hardware watchpoint.
         """
-        return self.dwt.remove_watchpoint(addr, size, type)
+        if self.dwt is not None:
+            return self.dwt.remove_watchpoint(addr, size, type)
 
     @staticmethod
     def _map_to_vector_catch_mask(mask):

--- a/pyocd/coresight/dwt.py
+++ b/pyocd/coresight/dwt.py
@@ -26,9 +26,6 @@ LOG = logging.getLogger(__name__)
 DEMCR = 0xE000EDFC
 # DWTENA in armv6 architecture reference manual
 DEMCR_TRCENA = (1 << 24)
-DEMCR_VC_HARDERR = (1 << 10)
-DEMCR_VC_BUSERR = (1 << 8)
-DEMCR_VC_CORERESET = (1 << 0)
 
 class Watchpoint(HardwareBreakpoint):
     def __init__(self, comp_register_addr, provider):
@@ -38,7 +35,7 @@ class Watchpoint(HardwareBreakpoint):
         self.func = 0
 
 class DWT(CoreSightComponent):
-    """! @brief Data Watchpoint and Trace unit"""
+    """! @brief Data Watchpoint and Trace version 1.0"""
     
     # DWT registers
     #
@@ -97,7 +94,7 @@ class DWT(CoreSightComponent):
     def init(self):
         """! @brief Inits the DWT.
         
-        Reads the number of hardware watchpoints available on the core  and makes sure that they
+        Reads the number of hardware watchpoints available on the core and makes sure that they
         are all disabled and ready for future use.
         """
         # Make sure trace is enabled.
@@ -106,21 +103,21 @@ class DWT(CoreSightComponent):
             demcr |= DEMCR_TRCENA
             self.ap.write_memory(DEMCR, demcr)
         
-        dwt_ctrl = self.ap.read_memory(self.address + DWT.DWT_CTRL)
-        watchpoint_count = (dwt_ctrl & DWT.DWT_CTRL_NUM_COMP_MASK) >> DWT.DWT_CTRL_NUM_COMP_SHIFT
+        dwt_ctrl = self.ap.read_memory(self.address + self.DWT_CTRL)
+        watchpoint_count = (dwt_ctrl & self.DWT_CTRL_NUM_COMP_MASK) >> self.DWT_CTRL_NUM_COMP_SHIFT
         LOG.info("%d hardware watchpoints", watchpoint_count)
         for i in range(watchpoint_count):
-            comparatorAddress = self.address + DWT.DWT_COMP_BASE + DWT.DWT_COMP_BLOCK_SIZE * i
+            comparatorAddress = self.address + self.DWT_COMP_BASE + self.DWT_COMP_BLOCK_SIZE * i
             self.watchpoints.append(Watchpoint(comparatorAddress, self))
-            self.ap.write_memory(comparatorAddress + DWT.DWT_FUNCTION_OFFSET, 0)
+            self.ap.write_memory(comparatorAddress + self.DWT_FUNCTION_OFFSET, 0)
         
         # Enable cycle counter.
-        self.ap.write32(self.address + DWT.DWT_CTRL, DWT.DWT_CTRL_CYCCNTENA_MASK)
+        self.ap.write32(self.address + self.DWT_CTRL, self.DWT_CTRL_CYCCNTENA_MASK)
         self.dwt_configured = True
 
     def find_watchpoint(self, addr, size, type):
         for watch in self.watchpoints:
-            if watch.addr == addr and watch.size == size and watch.func == DWT.WATCH_TYPE_TO_FUNCT[type]:
+            if watch.addr == addr and watch.size == size and watch.func == self.WATCH_TYPE_TO_FUNCT[type]:
                 return watch
         return None
 
@@ -130,31 +127,31 @@ class DWT(CoreSightComponent):
             self.init()
 
         watch = self.find_watchpoint(addr, size, type)
-        if watch != None:
+        if watch is not None:
             return True
 
-        if type not in DWT.WATCH_TYPE_TO_FUNCT:
+        if type not in self.WATCH_TYPE_TO_FUNCT:
             LOG.error("Invalid watchpoint type %i", type)
             return False
 
         for watch in self.watchpoints:
             if watch.func == 0:
                 watch.addr = addr
-                watch.func = DWT.WATCH_TYPE_TO_FUNCT[type]
+                watch.func = self.WATCH_TYPE_TO_FUNCT[type]
                 watch.size = size
 
-                if size not in DWT.WATCH_SIZE_TO_MASK:
+                if size not in self.WATCH_SIZE_TO_MASK:
                     LOG.error('Watchpoint of size %d not supported by device', size)
                     return False
 
-                mask = DWT.WATCH_SIZE_TO_MASK[size]
-                self.ap.write_memory(watch.comp_register_addr + DWT.DWT_MASK_OFFSET, mask)
-                if self.ap.read_memory(watch.comp_register_addr + DWT.DWT_MASK_OFFSET) != mask:
+                mask = self.WATCH_SIZE_TO_MASK[size]
+                self.ap.write_memory(watch.comp_register_addr + self.DWT_MASK_OFFSET, mask)
+                if self.ap.read_memory(watch.comp_register_addr + self.DWT_MASK_OFFSET) != mask:
                     LOG.error('Watchpoint of size %d not supported by device', size)
                     return False
 
                 self.ap.write_memory(watch.comp_register_addr, addr)
-                self.ap.write_memory(watch.comp_register_addr + DWT.DWT_FUNCTION_OFFSET, watch.func)
+                self.ap.write_memory(watch.comp_register_addr + self.DWT_FUNCTION_OFFSET, watch.func)
                 self.watchpoint_used += 1
                 return True
 
@@ -168,19 +165,84 @@ class DWT(CoreSightComponent):
             return
 
         watch.func = 0
-        self.ap.write_memory(watch.comp_register_addr + DWT.DWT_FUNCTION_OFFSET, 0)
+        self.ap.write_memory(watch.comp_register_addr + self.DWT_FUNCTION_OFFSET, 0)
         self.watchpoint_used -= 1
     
     def remove_all_watchpoints(self):
         for watch in self.watchpoints:
             if watch.func != 0:
-                self.remove_watchpoint(watch.addr, watch.size, DWT.WATCH_TYPE_TO_FUNCT[watch.func])
+                self.remove_watchpoint(watch.addr, watch.size, self.WATCH_TYPE_TO_FUNCT[watch.func])
     
     @property
     def cycle_count(self):
-        return self.ap.read32(self.address + DWT.DWT_CYCCNT)
+        return self.ap.read32(self.address + self.DWT_CYCCNT)
     
     @cycle_count.setter
     def cycle_count(self, value):
-        self.ap.write32(self.address + DWT.DWT_CYCCNT, value)
+        self.ap.write32(self.address + self.DWT_CYCCNT, value)
+
+class DWTv2(DWT):
+    """! @brief Data Watchpoint and Trace version 2.x
+    
+    This version is present in v8-M platforms.
+    
+    - DWT 2.0 appears in v8.0-M
+    - DWT 2.1 appears in v8.1-M and adds the VMASKn registers.
+    """
+    
+    DWT_ACTION_DEBUG_EVENT = 0x00000010
+    
+    ## Map from watchpoint type to FUNCTIONn.MATCH field value.
+    WATCH_TYPE_TO_FUNCT = {
+                            Target.WATCHPOINT_READ: 0b0110,
+                            Target.WATCHPOINT_WRITE: 0b0101,
+                            Target.WATCHPOINT_READ_WRITE: 0b0100,
+                            0b0110: Target.WATCHPOINT_READ,
+                            0b0101: Target.WATCHPOINT_WRITE,
+                            0b0100: Target.WATCHPOINT_READ_WRITE,
+                            }
+    
+    ## Map from data access size to pre-shifted DATAVSIZE field value.
+    DATAVSIZE_MAP = {
+                        1: (0 << 10),
+                        2: (1 << 10),
+                        4: (2 << 10),
+                    }
+    
+    def set_watchpoint(self, addr, size, type):
+        """! @brief Set a hardware watchpoint."""
+        if self.dwt_configured is False:
+            self.init()
+
+        watch = self.find_watchpoint(addr, size, type)
+        if watch is not None:
+            return True
+
+        if type not in self.WATCH_TYPE_TO_FUNCT:
+            LOG.error("Invalid watchpoint type %i", type)
+            return False
+        
+        # Only support sizes that can be handled with a single comparator.
+        if size not in (1, 2, 4):
+            LOG.error("Invalid watchpoint size %d", size)
+            return False
+
+        for watch in self.watchpoints:
+            if watch.func == 0:
+                watch.addr = addr
+                watch.func = self.WATCH_TYPE_TO_FUNCT[type]
+                watch.size = size
+
+                # Build FUNCTIONn register value.
+                value = self.DATAVSIZE_MAP[size] | self.DWT_ACTION_DEBUG_EVENT | watch.func
+
+                self.ap.write_memory(watch.comp_register_addr, addr)
+                self.ap.write_memory(watch.comp_register_addr + self.DWT_FUNCTION_OFFSET, value)
+                self.watchpoint_used += 1
+                return True
+
+        LOG.error('No more watchpoints are available, dropped watchpoint at 0x%08x', addr)
+        return False
+
+
 

--- a/pyocd/coresight/dwt.py
+++ b/pyocd/coresight/dwt.py
@@ -90,6 +90,10 @@ class DWT(CoreSightComponent):
         self.watchpoints = []
         self.watchpoint_used = 0
         self.dwt_configured = False
+    
+    @property
+    def watchpoint_count(self):
+        return len(self.watchpoints)
 
     def init(self):
         """! @brief Inits the DWT.
@@ -172,6 +176,9 @@ class DWT(CoreSightComponent):
         for watch in self.watchpoints:
             if watch.func != 0:
                 self.remove_watchpoint(watch.addr, watch.size, self.WATCH_TYPE_TO_FUNCT[watch.func])
+    
+    def get_watchpoints(self):
+        return [watch for watch in self.watchpoints if watch.func != 0]
     
     @property
     def cycle_count(self):


### PR DESCRIPTION
The primary purpose of this PR is to add support for version 2 of the DWT as present in v8-M.

In addition, watchpoint related commands were added to the commander, and DWT gained a couple APIs used by those commands.

The new commander commands are:
- `watch`
- `rmwatch`
- `lswatch`

An unlikely but possible bug was fixed in `CortexM`, where it would attempt to use the DWT object even if it didn't exist (i.e. not included in the MCU).