### PR TITLE
Fixed regressions introduced in #706

### DIFF
--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -105,7 +105,7 @@ class Target(MemoryInterface):
         self.part_number = ""
         # Make a target-specific copy of the memory map. This is safe to do without locking
         # because the memory map may not be mutated until target initialization.
-        self.memory_map = (copy.deepcopy(memoryMap)) if memoryMap else MemoryMap()
+        self.memory_map = memoryMap.clone() if memoryMap else MemoryMap()
         self._svd_location = None
         self._svd_device = None
 

--- a/pyocd/debug/elf/elf.py
+++ b/pyocd/debug/elf/elf.py
@@ -121,7 +121,7 @@ class ELFBinaryFile(object):
 
     def __del__(self):
         """! @brief Close the ELF file if it is owned by this instance."""
-        if self._owns_file:
+        if hasattr(self, '_owns_file') and self._owns_file:
             self.close()
 
     def _extract_sections(self):

--- a/test/unit/test_memory_map.py
+++ b/test/unit/test_memory_map.py
@@ -298,17 +298,16 @@ class TestMemoryRegion:
         assert ramcpy.name == ram1.name
         assert ramcpy == ram1
     
-    def test_deepcopy_ram(self, ram1):
-        ramcpy = copy.deepcopy(ram1)
-        assert ramcpy == ram1
-    
     def test_copy_flash(self, flash):
         flashcpy = copy.copy(flash)
         assert flashcpy == flash
     
-    def test_deepcopy_flash(self, flash):
-        flashcpy = copy.deepcopy(flash)
-        assert flashcpy == flash
+    def test_eq(self, flash, ram1):
+        assert flash != ram1
+        
+        a = RamRegion(name='a', start=0x1000, length=0x2000)
+        b = RamRegion(name='a', start=0x1000, length=0x2000)
+        assert a == b
 
 
 # MemoryMap test cases.
@@ -398,15 +397,16 @@ class TestMemoryMap:
     def test_alias(self, memmap2, ram2, ram_alias):
         assert ram_alias.alias is ram2
     
-    def test_copy(self, memmap):
-        mapcpy = copy.copy(memmap)
-        assert id(mapcpy) != id(memmap)
-        assert id(mapcpy.get_first_region_of_type(MemoryType.RAM)) == \
-            id(memmap.get_first_region_of_type(MemoryType.RAM))
-        assert mapcpy == memmap
+    def test_index_by_num(self, memmap, flash, ram2):
+        assert memmap[0] == flash
+        assert memmap[3] == ram2
+
+    def test_index_by_name(self, memmap, rom, ram2):
+        assert memmap['rom'] == rom
+        assert memmap['ram2'] == ram2
     
-    def test_deep_copy(test, memmap):
-        mapcpy = copy.deepcopy(memmap)
+    def test_clone(self, memmap):
+        mapcpy = memmap.clone()
         assert id(mapcpy) != id(memmap)
         assert id(mapcpy.get_first_region_of_type(MemoryType.RAM)) != \
             id(memmap.get_first_region_of_type(MemoryType.RAM))


### PR DESCRIPTION
Deep copies were getting tripped up on ELF files from pack-based targets. Added `MemoryMap.clone()` method instead of using deep copy and removed deep copy support for memory regions.

Plus some little goodies:
- Added equality operator for `MemoryRegion` that also compares type and attributes.
- Added indexing operator for `MemoryMap`.
- Finally fixed `ELFBinaryFile` __del__ issue with _owns_file attribute by adding a call to `hasattr()`.