### PR TITLE
Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
+  - "3.8"
 # command to install dependencies
 install:
   - pip install -r dev-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: trusty
-sudo: false
 language: python
 python:
   - "2.7"

--- a/pyocd/debug/svd/parser.py
+++ b/pyocd/debug/svd/parser.py
@@ -100,7 +100,7 @@ class SVDParser(object):
         msb = _get_int(field_node, 'msb')
         lsb = _get_int(field_node, 'lsb')
         if bit_range is not None:
-            m = re.search('\[([0-9]+):([0-9]+)\]', bit_range)
+            m = re.search(r'\[([0-9]+):([0-9]+)\]', bit_range)
             bit_offset = int(m.group(2))
             bit_width = 1 + (int(m.group(1)) - int(m.group(2)))
         elif msb is not None:

--- a/pyocd/gdbserver/syscall.py
+++ b/pyocd/gdbserver/syscall.py
@@ -102,7 +102,7 @@ class GDBSyscallIOHandler(SemihostIOHandler):
     def seek(self, fd, pos):
         fd -= FD_OFFSET
         result, self._errno = self._server.syscall('lseek,%x,%x,0' % (fd, pos))
-        return 0 if result is not -1 else -1
+        return 0 if result != -1 else -1
 
     def flen(self, fd):
         fd -= FD_OFFSET

--- a/pyocd/utility/sequencer.py
+++ b/pyocd/utility/sequencer.py
@@ -14,8 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import (OrderedDict, Callable)
 import logging
+from collections import OrderedDict
+
+# Collection ABCs accessible directly from collections are deprecated and will be removed in
+# Python 3.9.
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 
 LOG = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Debuggers",
         "Topic :: Software Development :: Embedded Systems",
     ],


### PR DESCRIPTION
Corrected a syntax warning and two deprecation warnings.

Now testing 3.7 and 3.8 in Travis-CI. Added 3.8 to the list of supported versions in the classifiers in `setup.py`.