### PR TITLE
AP improvements

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,6 +134,9 @@ processed.
 - `pack`: (str or list of str) Path or list of paths to CMSIS Device Family Packs. Devices defined
     in the pack(s) are added to the list of available targets.
 
+- `probe_all_aps`: (bool) Controls whether all 256 ADIv5 AP addresses will be probed. Default is
+    False.
+
 - `project_dir`: (str) Path to the session's project directory. Defaults to the working directory
     when the pyocd tool was executed.
 

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -142,7 +142,7 @@ class CoreSightTarget(Target, GraphNode):
             ('power_up',            self.dp.power_up_debug),
             ('find_aps',            self.dp.find_aps),
             ('create_aps',          self.dp.create_aps),
-            ('init_ap_roms',        self.dp.init_ap_roms),
+            ('find_components',     self.dp.find_components),
             ('create_cores',        self.create_cores),
             ('create_components',   self.create_components),
             ('check_for_cores',     self.check_for_cores),

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -60,6 +60,8 @@ OPTIONS_INFO = {
     'pack': OptionInfo('pack', (str, list), None,
         "Path or list of paths to CMSIS Device Family Packs. Devices defined in the pack(s) are "
         "added to the list of available targets."),
+    'probe_all_aps': OptionInfo('scan_all_aps', bool, False,
+        "Controls whether all 256 ADIv5 AP addresses will be probed. Default is False."),
     'project_dir': OptionInfo('project_dir', str, None,
         "Path to the session's project directory. Defaults to the working directory when the pyocd "
         "tool was executed."),

--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -513,6 +513,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
             raise
         TRACE.debug("write_mem:%06d }", num)
 
+    @_locked
     def _read_memory(self, addr, transfer_size=32, now=True):
         """! @brief Read a memory location.
         

--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -192,7 +192,6 @@ class AccessPort(object):
     def __init__(self, dp, ap_num, idr=None, name=""):
         self.dp = dp
         self.ap_num = ap_num
-        self.link = dp.link
         self.idr = idr
         self.type_name = name
         self.rom_addr = 0
@@ -302,7 +301,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         # Ask the probe for an accelerated memory interface for this AP. If it provides one,
         # then bind our memory interface APIs to its methods. Otherwise use our standard
         # memory interface based on AP register accesses.
-        memoryInterface = self.dp.link.get_memory_interface_for_ap(self.ap_num)
+        memoryInterface = self.dp.probe.get_memory_interface_for_ap(self.ap_num)
         if memoryInterface is not None:
             LOG.debug("Using accelerated memory access interface")
             self.write_memory = memoryInterface.write_memory
@@ -594,7 +593,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         self.write_reg(MEM_AP_CSW, self._csw | CSW_SIZE32)
         self.write_reg(MEM_AP_TAR, addr)
         try:
-            self.link.write_ap_multiple((self.ap_num << APSEL_SHIFT) | MEM_AP_DRW, data)
+            self.dp.probe.write_ap_multiple((self.ap_num << APSEL_SHIFT) | MEM_AP_DRW, data)
         except exceptions.TransferFaultError as error:
             # Annotate error with target address.
             self._handle_error(error, num)
@@ -619,7 +618,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         self.write_reg(MEM_AP_CSW, self._csw | CSW_SIZE32)
         self.write_reg(MEM_AP_TAR, addr)
         try:
-            resp = self.link.read_ap_multiple((self.ap_num << APSEL_SHIFT) | MEM_AP_DRW, size)
+            resp = self.dp.probe.read_ap_multiple((self.ap_num << APSEL_SHIFT) | MEM_AP_DRW, size)
         except exceptions.TransferFaultError as error:
             # Annotate error with target address.
             self._handle_error(error, num)

--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -135,7 +135,7 @@ DEMCR = 0xE000EDFC
 DEMCR_TRCENA = (1 << 24)
 
 def _locked(func):
-    """! Decorator to automatically lock an AccessPort method."""
+    """! @brief Decorator to automatically lock an AccessPort method."""
     def _locking(self, *args, **kwargs):
         try:
             self.lock()
@@ -145,13 +145,18 @@ def _locked(func):
     return _locking
 
 class AccessPort(object):
-    """! @brief Determine if an AP exists with the given AP number.
-    @param dp DebugPort instance.
-    @param ap_num The AP number (APSEL) to probe.
-    @return Boolean indicating if a valid AP exists with APSEL=ap_num.
-    """
+    """! @brief Base class for a CoreSight Access Port (AP) instance."""
+
     @staticmethod
     def probe(dp, ap_num):
+        """! @brief Determine if an AP exists with the given AP number.
+        
+        Only applicable for ADIv5.
+        
+        @param dp DebugPort instance.
+        @param ap_num The AP number (APSEL) to probe.
+        @return Boolean indicating if a valid AP exists with APSEL=ap_num.
+        """
         idr = dp.read_ap((ap_num << APSEL_SHIFT) | AP_IDR)
         return idr != 0
     

--- a/pyocd/coresight/component.py
+++ b/pyocd/coresight/component.py
@@ -32,7 +32,7 @@ class CoreSightComponent(GraphNode):
         super(CoreSightComponent, self).__init__()
         self._ap = ap
         self._cmpid = cmpid
-        self._address = addr or (cmpid.address if cmpid else None)
+        self._address = addr if (addr is not None) else (cmpid.address if cmpid else None)
     
     @property
     def ap(self):

--- a/pyocd/coresight/component_ids.py
+++ b/pyocd/coresight/component_ids.py
@@ -52,9 +52,11 @@ FSL_ID = 0x00e
 #  0x21 = ETB
 #  0x12 = Trace funnel (CSFT)
 #  0x13 = CPU trace source (ETM, MTB?)
+#  0x16 = PMU
 #  0x43 = ITM
 #  0x14 = ECT/CTI/CTM
 #  0x31 = MTB
+#  0x32 = TMC
 #  0x34 = Granular Power Requestor
 
 ## Pairs a component name with a factory method.
@@ -71,10 +73,21 @@ COMPONENT_MAP = {
     (ARM_ID, CORESIGHT_CLASS, 0x924, 0x13, 0)      : CmpInfo('ETM-M3',    None            ),
     (ARM_ID, CORESIGHT_CLASS, 0x925, 0x13, 0)      : CmpInfo('ETM-M4',    None            ),
     (ARM_ID, CORESIGHT_CLASS, 0x932, 0x31, 0x0a31) : CmpInfo('MTB-M0+',   None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0x950, 0x13, 0)      : CmpInfo('PTM-A9',    None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0x961, 0x32, 0)      : CmpInfo('TMC',       None            ), # Trace Memory Controller
     (ARM_ID, CORESIGHT_CLASS, 0x975, 0x13, 0x4a13) : CmpInfo('ETM-M7',    None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0x9a0, 0x16, 0)      : CmpInfo('PMU-A9',    None            ),
     (ARM_ID, CORESIGHT_CLASS, 0x9a1, 0x11, 0)      : CmpInfo('TPIU-M4',   TPIU.factory    ),
+    (ARM_ID, CORESIGHT_CLASS, 0x9a3, 0x13, 0x0)    : CmpInfo('MTB-M0',    None            ),
     (ARM_ID, CORESIGHT_CLASS, 0x9a4, 0x34, 0x0a34) : CmpInfo('GPR',       GPR.factory     ), # Granular Power Requestor
     (ARM_ID, CORESIGHT_CLASS, 0x9a6, 0x14, 0x1a14) : CmpInfo('CTI',       None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0xc05, 0x15, 0)      : CmpInfo('CPU-A5',    None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0xc07, 0x15, 0)      : CmpInfo('CPU-A7',    None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0xc08, 0x15, 0)      : CmpInfo('CPU-A8',    None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0xc09, 0x15, 0)      : CmpInfo('CPU-A9',    None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0xc0d, 0x15, 0)      : CmpInfo('CPU-A12',   None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0xc0e, 0x15, 0)      : CmpInfo('CPU-A17',   None            ),
+    (ARM_ID, CORESIGHT_CLASS, 0xc0f, 0x15, 0)      : CmpInfo('CPU-A15',   None            ),
     (ARM_ID, CORESIGHT_CLASS, 0x9a9, 0x11, 0)      : CmpInfo('TPIU-M7',   TPIU.factory    ),
     (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x11, 0)      : CmpInfo('TPIU-M23',  TPIU.factory    ),
     (ARM_ID, CORESIGHT_CLASS, 0xd20, 0x13, 0)      : CmpInfo('ETM-M23',   None            ),

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -78,12 +78,16 @@ class DebugPort(object):
             'default': DebugProbe.Protocol.DEFAULT,
         }
     
-    def __init__(self, link, target):
-        self.link = link
+    def __init__(self, probe, target):
+        self._probe = probe
         self.target = target
         self.valid_aps = None
         self.aps = {}
         self._access_number = 0
+
+    @property
+    def probe(self):
+        return self._probe
 
     @property
     def next_access_number(self):
@@ -100,23 +104,23 @@ class DebugPort(object):
             "DebugProbe.Protocol" enums. If not provided, will default to the `protocol` setting.
         """
         protocol_name = self.target.session.options.get('dap_protocol').strip().lower()
-        send_swj = self.target.session.options.get('dap_enable_swj') and self.link.supports_swj_sequence
+        send_swj = self.target.session.options.get('dap_enable_swj') and self.probe.supports_swj_sequence
         use_deprecated = self.target.session.options.get('dap_use_deprecated_swj')
 
         # Convert protocol from setting if not passed as parameter.
         if protocol is None:
             protocol = self.PROTOCOL_NAME_MAP[protocol_name]
-            if protocol not in self.link.supported_wire_protocols:
+            if protocol not in self.probe.supported_wire_protocols:
                 raise exceptions.DebugError("requested wire protocol %s not supported by the debug probe" % protocol.name)
         if protocol != DebugProbe.Protocol.DEFAULT:
             LOG.debug("Using %s wire protocol", protocol.name)
             
         # Connect using the selected protocol.
-        self.link.connect(protocol)
+        self.probe.connect(protocol)
 
         # Log the actual protocol if selected was default.
         if protocol == DebugProbe.Protocol.DEFAULT:
-            LOG.debug("Default wire protocol selected; using %s", self.link.wire_protocol.name)
+            LOG.debug("Default wire protocol selected; using %s", self.probe.wire_protocol.name)
         
         # Multiple attempts to select protocol and read DP IDCODE.
         for attempt in range(4):
@@ -157,9 +161,9 @@ class DebugPort(object):
     def _swj_sequence(self, use_deprecated):
         """! @brief Send SWJ sequence to select chosen wire protocol."""
         # Not all probes support sending SWJ sequences.
-        if self.link.wire_protocol == DebugProbe.Protocol.SWD:
+        if self.probe.wire_protocol == DebugProbe.Protocol.SWD:
             self._switch_to_swd(use_deprecated)
-        elif self.link.wire_protocol == DebugProbe.Protocol.JTAG:
+        elif self.probe.wire_protocol == DebugProbe.Protocol.JTAG:
             self._switch_to_jtag(use_deprecated)
         else:
             assert False
@@ -170,31 +174,31 @@ class DebugPort(object):
             LOG.debug("Sending SWJ sequence to select SWD; using dormant state")
             
             # Ensure current debug interface is in reset state
-            self.link.swj_sequence(51, 0xffffffffffffff)
+            self.probe.swj_sequence(51, 0xffffffffffffff)
             
             # Send all this in one transfer:
             # Select Dormant State (from JTAG), 0xb3bbbbbaff
             # 8 cycles SWDIO/TMS HIGH, 0xff
             # Alert Sequence, 0x19bc0ea2e3ddafe986852d956209f392
             # 4 cycles SWDIO/TMS LOW + 8-Bit SWD Activation Code (0x1A), 0x01a0
-            self.link.swj_sequence(188, 0x01a019bc0ea2e3ddafe986852d956209f392ffb3bbbbbaff)
+            self.probe.swj_sequence(188, 0x01a019bc0ea2e3ddafe986852d956209f392ffb3bbbbbaff)
            
             # Enter SWD Line Reset State
-            self.link.swj_sequence(51, 0xffffffffffffff)  # > 50 cycles SWDIO/TMS High
-            self.link.swj_sequence(8,  0x00)                # At least 2 idle cycles (SWDIO/TMS Low)
+            self.probe.swj_sequence(51, 0xffffffffffffff)  # > 50 cycles SWDIO/TMS High
+            self.probe.swj_sequence(8,  0x00)                # At least 2 idle cycles (SWDIO/TMS Low)
         else:
             LOG.debug("Sending deprecated SWJ sequence to select SWD")
             
             # Ensure current debug interface is in reset state
-            self.link.swj_sequence(51, 0xffffffffffffff)
+            self.probe.swj_sequence(51, 0xffffffffffffff)
             
             # Execute SWJ-DP Switch Sequence JTAG to SWD (0xE79E)
             # Change if SWJ-DP uses deprecated switch code (0xEDB6)
-            self.link.swj_sequence(16, 0xe79e)
+            self.probe.swj_sequence(16, 0xe79e)
             
             # Enter SWD Line Reset State
-            self.link.swj_sequence(51, 0xffffffffffffff)  # > 50 cycles SWDIO/TMS High
-            self.link.swj_sequence(8,  0x00)                # At least 2 idle cycles (SWDIO/TMS Low)
+            self.probe.swj_sequence(51, 0xffffffffffffff)  # > 50 cycles SWDIO/TMS High
+            self.probe.swj_sequence(8,  0x00)                # At least 2 idle cycles (SWDIO/TMS Low)
     
     def _switch_to_jtag(self, use_deprecated):
         """! @brief Send SWJ sequence to select JTAG."""
@@ -202,28 +206,28 @@ class DebugPort(object):
             LOG.debug("Sending SWJ sequence to select JTAG ; using dormant state")
             
             # Ensure current debug interface is in reset state
-            self.link.swj_sequence(51, 0xffffffffffffff)
+            self.probe.swj_sequence(51, 0xffffffffffffff)
             
             # Select Dormant State (from SWD)
             # At least 8 cycles SWDIO/TMS HIGH, 0xE3BC
             # Alert Sequence, 0x19bc0ea2e3ddafe986852d956209f392
             # 4 cycles SWDIO/TMS LOW + 8-Bit JTAG Activation Code (0x0A), 0x00a0
-            self.link.swj_sequence(188, 0x00a019bc0ea2e3ddafe986852d956209f392ffe3bc)
+            self.probe.swj_sequence(188, 0x00a019bc0ea2e3ddafe986852d956209f392ffe3bc)
            
             # Ensure JTAG interface is reset
-            self.link.swj_sequence(6, 0x3f)
+            self.probe.swj_sequence(6, 0x3f)
         else:
             LOG.debug("Sending deprecated SWJ sequence to select JTAG")
             
             # Ensure current debug interface is in reset state
-            self.link.swj_sequence(51, 0xffffffffffffff)
+            self.probe.swj_sequence(51, 0xffffffffffffff)
             
             # Execute SWJ-DP Switch Sequence SWD to JTAG (0xE73C)
             # Change if SWJ-DP uses deprecated switch code (0xAEAE)
-            self.link.swj_sequence(16, 0xe73c)
+            self.probe.swj_sequence(16, 0xe73c)
             
             # Ensure JTAG interface is reset
-            self.link.swj_sequence(6, 0x3f)
+            self.probe.swj_sequence(6, 0x3f)
 
     def read_id_code(self):
         """! @brief Read ID register and get DP version"""
@@ -235,7 +239,7 @@ class DebugPort(object):
 
     def flush(self):
         try:
-            self.link.flush()
+            self.probe.flush()
         except exceptions.ProbeError as error:
             self._handle_error(error, self.next_access_number)
             raise
@@ -267,19 +271,19 @@ class DebugPort(object):
     def reset(self):
         for ap in self.aps.values():
             ap.reset_did_occur()
-        self.link.reset()
+        self.probe.reset()
 
     def assert_reset(self, asserted):
         if asserted:
             for ap in self.aps.values():
                 ap.reset_did_occur()
-        self.link.assert_reset(asserted)
+        self.probe.assert_reset(asserted)
 
     def is_reset_asserted(self):
-        return self.link.is_reset_asserted()
+        return self.probe.is_reset_asserted()
 
     def set_clock(self, frequency):
-        self.link.set_clock(frequency)
+        self.probe.set_clock(frequency)
         
     def find_aps(self):
         """! @brief Find valid APs.
@@ -345,7 +349,7 @@ class DebugPort(object):
         num = self.next_access_number
 
         try:
-            result_cb = self.link.read_dp(addr, now=False)
+            result_cb = self.probe.read_dp(addr, now=False)
         except exceptions.ProbeError as error:
             self._handle_error(error, num)
             raise
@@ -372,7 +376,7 @@ class DebugPort(object):
         # Write the DP register.
         try:
             TRACE.debug("write_dp:%06d (addr=0x%08x) = 0x%08x", num, addr, data)
-            self.link.write_dp(addr, data)
+            self.probe.write_dp(addr, data)
         except exceptions.ProbeError as error:
             self._handle_error(error, num)
             raise
@@ -385,7 +389,7 @@ class DebugPort(object):
 
         try:
             TRACE.debug("write_ap:%06d (addr=0x%08x) = 0x%08x", num, addr, data)
-            self.link.write_ap(addr, data)
+            self.probe.write_ap(addr, data)
         except exceptions.ProbeError as error:
             self._handle_error(error, num)
             raise
@@ -397,7 +401,7 @@ class DebugPort(object):
         num = self.next_access_number
 
         try:
-            result_cb = self.link.read_ap(addr, now=False)
+            result_cb = self.probe.read_ap(addr, now=False)
         except exceptions.ProbeError as error:
             self._handle_error(error, num)
             raise
@@ -428,7 +432,7 @@ class DebugPort(object):
             self.write_reg(DP_ABORT, ABORT_DAPABORT)
 
     def clear_sticky_err(self):
-        mode = self.link.wire_protocol
+        mode = self.probe.wire_protocol
         if mode == DebugProbe.Protocol.SWD:
             self.write_reg(DP_ABORT, ABORT_ORUNERRCLR | ABORT_WDERRCLR | ABORT_STKERRCLR | ABORT_STKCMPCLR)
         elif mode == DebugProbe.Protocol.JTAG:

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -327,12 +327,12 @@ class DebugPort(object):
         except exceptions.Error as e:
             LOG.error("Exception reading AP#%d IDR: %s", ap_num, e)
     
-    def init_ap_roms(self):
-        """! @brief Init task that generates a call sequence to init all AP ROMs."""
+    def find_components(self):
+        """! @brief Init task that generates a call sequence to ask each AP to find its components."""
         seq = CallSequence()
         for ap in [x for x in self.aps.values() if x.has_rom_table]:
             seq.append(
-                ('init_ap.{}'.format(ap.ap_num), ap.init_rom_table)
+                ('init_ap.{}'.format(ap.ap_num), ap.find_components)
                 )
         return seq
 

--- a/pyocd/target/builtin/target_LPC55S69JBD100.py
+++ b/pyocd/target/builtin/target_LPC55S69JBD100.py
@@ -161,7 +161,7 @@ class LPC55S69JBD100(CoreSightTarget):
     def create_init_sequence(self):
         seq = super(LPC55S69JBD100, self).create_init_sequence()
         
-        seq.wrap_task('init_ap_roms', self._modify_ap1)
+        seq.wrap_task('find_components', self._modify_ap1)
         seq.replace_task('create_cores', self.create_lpc55s69_cores)
         seq.insert_before('create_components',
             ('enable_traceclk',        self._enable_traceclk),

--- a/pyocd/target/family/target_kinetis.py
+++ b/pyocd/target/family/target_kinetis.py
@@ -65,7 +65,7 @@ class Kinetis(CoreSightTarget):
         
         # Must check whether security is enabled, and potentially auto-unlock, before
         # any init tasks that require system bus access.
-        seq.insert_before('init_ap_roms',
+        seq.insert_before('find_components',
             ('check_mdm_ap_idr',        self.check_mdm_ap_idr),
             ('check_flash_security',    self.check_flash_security),
             )

--- a/pyocd/utility/mask.py
+++ b/pyocd/utility/mask.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import operator
+from functools import reduce
+
 def bitmask(*args):
     """! @brief Returns a mask with specified bit ranges set.
     
@@ -41,13 +44,12 @@ def bitmask(*args):
     mask = 0
 
     for a in args:
-        if type(a) is tuple:
-            for b in range(a[1], a[0]+1):
-                mask |= 1 << b
-        elif type(a) is list:
-            for b in a:
-                mask |= 1 << b
-        elif type(a) is int:
+        if isinstance(a, tuple):
+            hi, lo = a
+            mask |= ((1 << (hi - lo + 1)) - 1) << lo
+        elif isinstance(a, (list, set)):
+            mask |= reduce(operator.or_, ((1 << b) for b in a))
+        elif isinstance(a, int):
             mask |= 1 << a
 
     return mask


### PR DESCRIPTION
- Add `probe_all_aps` setting to force scanning of all 256 APSEL values for existing APs.
- Support for the legacy AP `BASE` register format. This is seen on older SoCs, mostly Cortex-A, such as the Renesas RZ/A1H.
- Refactored so that only `MEM_AP` subclasses support ROM tables.
- Added a few CoreSight component IDs, mostly v7-A cores.
- Renamed the `link` attribute on `DebugPort` to `probe`, thus matching the rest of pyOCD.
- Merge AP names into `AP_TYPE_MAP`.
- Renamed `init_ap_roms` init task to `find_components`.
- Fixed missing lock on `MEM_AP._read_memory()`.
- Fixed expression error in `CoreSightComponent` constructor.