### PR TITLE
Adds APPROTECT security check and unlock on nRF52

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 - [Introduction to the pyOCD Python API](python_api.md)
 - [Python API examples](api_examples.md)
 - [Installing on non-x86 platforms](installing_on_non_x86.md)
+- [Target Security Features](security.md)
 
 ### Developer documentation
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,194 @@
+# Security and Protection Features
+
+Many targets support some way of disabling JTAG/SWD access or protecting the flash from read-back or write.
+
+If you attempt to run pyOCD against a locked target, you'll encounter a message like this:
+
+``` bash
+(venv) ~/devel/contrib/pyocd$ pyocd commander --target nrf52
+0000265:WARNING:target_nRF52:NRF52832 APPROTECT enabled: not automatically unlocking
+Exception while initing board: No cores were discovered!
+Traceback (most recent call last):
+  File "devel/contrib/pyocd/pyocd/tools/pyocd.py", line 769, in connect
+    self.session.open(init_board=not self.args.no_init)
+  File "devel/contrib/pyocd/pyocd/core/session.py", line 371, in open
+    self._board.init()
+  File "devel/contrib/pyocd/pyocd/board/board.py", line 83, in init
+    self.target.init()
+  File "devel/contrib/pyocd/pyocd/core/coresight_target.py", line 164, in init
+    seq.invoke()
+  File "devel/contrib/pyocd/pyocd/utility/sequencer.py", line 208, in invoke
+    resultSequence = call()
+  File "devel/contrib/pyocd/pyocd/core/coresight_target.py", line 298, in check_for_cores
+    raise exceptions.DebugError("No cores were discovered!")
+pyocd.core.exceptions.DebugError: No cores were discovered!
+```
+
+pyOCD has noticed that the chip is locked. It attempts routine initialization anyway, but fails to find any cores.
+
+## Supported Targets
+
+pyOCD currently supports the security features of the NXP Kinetis and Nordic Semiconductor nRF52 families. 
+
+Disabling the security features on supported targets is very straight-forward.
+
+*WARNING: **This will erase all data on the chip***
+
+You can add the option`auto_unlock` to your [configuration](/configuration.md):
+
+```bash
+(venv) ~/devel/contrib/pyocd$ pyocd commander --target nrf52 -O auto_unlock
+0000264:WARNING:target_nRF52:NRF52832 APPROTECT enabled: will try to unlock via mass erase
+Connected to NRF52832 [Halted]: I3FSNZOV
+>>> 
+```
+
+You can also do this interactively with *pyOCD commander*:
+
+```
+(venv) $ pyocd commander --target nrf52840 -N
+>>> initdp
+>>> makeap 1
+>>> status
+Security:       Locked
+>>> unlock
+>>> status
+Security:       Unlocked
+>>> reinit
+>>> status
+Security:       Unlocked
+Core 0 status:  Halted
+>>>
+```
+
+An explanation of some of the commands and options appears below.
+
+## Unsupported targets
+
+If pyOCD doesn't support the security features of your MCU, you can still likely access them with pyOCD commander with
+the `no-init` option. A common pattern is that the security function locks out the fully-functional AP, but leaves a second,
+proprietary AP unlocked. The second AP usually has very few functions, mostly related to management (reset) or erase/unlock
+of the chip.
+
+Starting pyocd commander in `--no-init` mode is intended to help in these situations. It intentionally doesn't attempt
+to interact with the target on startup. Without initialization, most commands will not work. You'll need to do some 
+manual initialization.
+
+The usefulness of `--no-init` mode is that it allows *commander* to start when initialization would
+normally fail due to missing support for the target or security features of the MCU.
+
+### Useful Options
+
+Once you've started commander `--no-init`, the following options are most useful.
+
+<dl>
+<dt><em>initdp</em></dt>
+<dd>Powers on and initializes the on-chip *Debug Port*, allowing commander to issue commands to the
+target</dd>
+
+<dt><em>makeap &lt;ap num&gt;</em></dt>
+<dd>Targets have at least one, but sometimes more, *Access Ports*. Access port #0 is usually an AHB-AP that allows
+debugging of the target. Access port #1, if it exists, is often proprietary to the vendor and allows
+for certain functions to proceed *even if AP #0 is locked*.</dd>
+
+<dt><em>readap &lt;APSEL&gt; &lt;address&gt;</em></dt>
+<dd>Read from an AP register</dd>
+
+<dt><em>writeap &lt;APSEL&gt; &lt;address&gt; &lt;value&gt;</em></dt>
+<dd>Write to an AP register</dd>
+
+<dt><em>status</em></dt>
+<dd>Will show security status for supported targets. If the target is unlocked and the AHB-AP is 
+initialized, it will also show status for any cores detected (Running, Halted, &c)</dd>
+
+<dt><em>reinit</em></dt>
+<dd>This command will attempt to perform the normal initialization steps for the selected target. If you
+manually unlock a target, you may want to run `reinit` so that the cores are accessible *without* restarting
+commander in normal mode (without `--no-init`)</dd>
+</dl>
+
+### Example
+
+Let's pretend the nRF52 family is unsupported. Here's an example session where we'll use `no-init` mode to manually
+unlock the target:
+
+```
+(venv) nock@nocko-wired:~/devel/contrib/pyocd$ pyocd commander -N
+0000136:WARNING:board:Generic 'cortex_m' target type is selected; is this intentional? You will be able to debug but not program flash. To set the target type use the '--target' argument or 'target_override' option. Use 'pyocd list --targets' to see available targets types.
+>>> initdp
+```
+We use `initdp` to initialize the *Debug Port* and power on the on-chip debug hardware.
+
+The [nRF52 Product Specification](https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.1.pdf) says that the chip has a 
+*CTRL-AP* at index 1 that supports a few operations even if the main AP is locked.
+
+Let's let pyOCD know about it with `makeap`
+
+```
+>>> makeap 1
+AP#1 IDR = 0x02880000
+```
+
+The IDR register matches the datasheet! The datasheet says that CTRL-AP (AP #1) has the following registers:
+
+<dl>
+<dt><em>RESET</em> (0x000)</dt>
+<dd>Writing 1 to this register asserts reset on the chip. Writing 0 takes is out of reset</dd>
+
+<dt><em>ERASEALL</em> (0x004)</dt>
+<dd>Writing 1 to this register starts a mass erase of the chip *and removes APPROTECT* unlocking the chip</dd>
+
+<dt><em>ERASEALLSTATUS</em> (0x008)</dt>
+<dd>While the chip is busy doing a mass erase, this register will read 1. When the mass erase is complete, the register
+will read 0.</dd>
+
+<dt><em>APPROTECTSTATUS</em> (0x00C)</dt>
+<dd>If this register is 0, then APPROTECT is enabled (chip is locked), if 1 the chip is unlocked</dd>
+</dl>
+
+We can read the register value with `readap` and write a new value with `writeap`. Let's see if the chip is locked by
+reading *APPROTECTSTATUS* on AP #1:
+
+```
+>>> readap 1 0x00C
+AP register 0x100000c = 0x00000000
+```
+
+This chip is locked! Let's unlock it. We need to write a 1 to *ERASEALL* (on AP #1) to start the mass erase:
+
+```
+>>> writeap 1 0x004 1
+```
+
+Let's see if it has finished, by reading *ERASEALLSTATUS*:
+
+```
+>>> readap 1 0x008
+AP register 0x1000008 = 0x00000001
+>>> readap 1 0x008
+AP register 0x1000008 = 0x00000000
+```
+
+After the first `readap` it was still erasing, but by the time the second `readap` was issued it was complete.
+Let's check the security status by reading *APPROTECTSTATUS* again:
+
+```
+>>> readap 1 0x00C
+AP register 0x100000c = 0x00000001
+```
+
+It's unlocked! Let's check the `status`:
+
+```
+>>> status
+Security:       Unlocked
+>>> reinit
+>>> status
+Security:       Unlocked
+Core 0 status:  Halted
+>>>
+```
+
+The security was unlocked, but there are no cores (many commands like halt, reset, &c need a core). It doesn't exist
+since we started commander in `no-init` mode. Running `reinit` from the CLI finishes the initialization that's 
+possible now that the chip is unlocked.

--- a/pyocd/target/builtin/__init__.py
+++ b/pyocd/target/builtin/__init__.py
@@ -129,7 +129,7 @@ BUILTIN_TARGETS = {
           'mimxrt1050_hyperflash': target_MIMXRT1052xxxxB.MIMXRT1052xxxxB_hyperflash,
           'mimxrt1050': target_MIMXRT1052xxxxB.MIMXRT1052xxxxB_hyperflash, # Alias for default external flash.
           'nrf51': target_nRF51822_xxAA.NRF51,
-          'nrf52' : target_nRF52832_xxAA.NRF52,
+          'nrf52': target_nRF52832_xxAA.NRF52832,
           'nrf52840' : target_nRF52840_xxAA.NRF52840,
           'stm32f103rc': target_STM32F103RC.STM32F103RC,
           'stm32f051': target_STM32F051T8.STM32F051,

--- a/pyocd/target/builtin/target_nRF52832_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52832_xxAA.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
+from ..family.target_nRF52 import NRF52
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [
@@ -42,10 +42,8 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'analyzer_address' : 0x20004000  # Analyzer 0x20004000..0x20004600
               }
 
-class NRF52(CoreSightTarget):
+class NRF52832(NRF52):
 
-    VENDOR = "Nordic Semiconductor"
-    
     memoryMap = MemoryMap(
         FlashRegion(    start=0x0,         length=0x80000,      blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO),
@@ -56,8 +54,7 @@ class NRF52(CoreSightTarget):
         )
 
     def __init__(self, link):
-        super(NRF52, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile.from_builtin("nrf52.svd")
+        super(NRF52832, self).__init__(link, self.memoryMap)
 
     def resetn(self):
         """

--- a/pyocd/target/builtin/target_nRF52840_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52840_xxAA.py
@@ -18,6 +18,7 @@ from ...flash.flash import Flash
 from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
+from ..family.target_nRF52 import NRF52
 
 FLASH_ALGO = { 'load_address' : 0x20000000,
                'instructions' : [
@@ -42,10 +43,8 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
                'analyzer_address' : 0x20004000  # Analyzer 0x20004000..0x20004600
               }
 
-class NRF52840(CoreSightTarget):
+class NRF52840(NRF52):
 
-    VENDOR = "Nordic Semiconductor"
-    
     memoryMap = MemoryMap(
         FlashRegion(    start=0x0,         length=0x100000,     blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO),
@@ -57,7 +56,6 @@ class NRF52840(CoreSightTarget):
 
     def __init__(self, link):
         super(NRF52840, self).__init__(link, self.memoryMap)
-        self._svd_location = SVDFile.from_builtin("nrf52840.svd")
 
     def resetn(self):
         """

--- a/pyocd/target/family/target_nRF52.py
+++ b/pyocd/target/family/target_nRF52.py
@@ -1,0 +1,131 @@
+# pyOCD debugger
+# Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2019 Monadnock Systems Ltd.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ...core import exceptions
+from ...core.coresight_target import CoreSightTarget
+from ...debug.svd.loader import SVDFile
+from ...utility.timeout import Timeout
+import logging
+from time import sleep
+
+AHB_AP_NUM = 0x0
+CTRL_AP_NUM = 0x1
+
+CTRL_AP_RESET = 0x000
+CTRL_AP_ERASEALL = 0x004
+CTRL_AP_ERASEALLSTATUS = 0x008
+CTRL_AP_APPROTECTSTATUS = 0x00C
+CTRL_AP_IDR = 0x0FC
+
+CTRL_AP_ERASEALLSTATUS_READY = 0x0
+CTRL_AP_ERASEALLSTATUS_BUSY = 0x1
+
+CTRL_AP_APPROTECTSTATUS_ENABLED = 0x0
+CTRL_AP_APPROTECTSTATUS_DISABLED = 0x1
+
+CTRL_AP_RESET_NORESET = 0x0
+CTRL_AP_RESET_RESET = 0x1
+
+CTRL_AP_ERASEALL_NOOPERATION = 0x0
+CTRL_AP_ERASEALL_ERASE = 0x1
+
+CTRL_IDR_EXPECTED = 0x2880000
+CTRL_IDR_VERSION_MASK = 0xf0000000
+CTRL_IDR_VERSION_SHIFT = 28
+
+MASS_ERASE_TIMEOUT = 15.0
+
+LOG = logging.getLogger(__name__)
+
+
+class NRF52(CoreSightTarget):
+
+    VENDOR = "Nordic Semiconductor"
+
+    def __init__(self, link, memoryMap=None):
+        super(NRF52, self).__init__(link, memoryMap)
+        self._svd_location = SVDFile.from_builtin("nrf52.svd")
+        self.ctrl_ap = None
+
+    def create_init_sequence(self):
+        seq = super(NRF52, self).create_init_sequence()
+
+        # Must check whether security is enabled, and potentially auto-unlock, before
+        # any init tasks that require system bus access.
+        seq.insert_before('init_ap_roms',
+                          ('check_ctrl_ap_idr', self.check_ctrl_ap_idr),
+                          ('check_flash_security', self.check_flash_security),
+                          )
+
+        return seq
+
+    def check_ctrl_ap_idr(self):
+        self.ctrl_ap = self.dp.aps[CTRL_AP_NUM]
+
+        # Check CTRL-AP ID.
+        if (self.ctrl_ap.idr & ~CTRL_IDR_VERSION_MASK) != CTRL_IDR_EXPECTED:
+            LOG.error("%s: bad CTRL-AP IDR (is 0x%08x)", self.part_number, self.ctrl_ap.idr)
+
+        ctrl_ap_version = (self.ctrl_ap.idr & CTRL_IDR_VERSION_MASK) >> CTRL_IDR_VERSION_SHIFT
+        LOG.debug("CTRL-AP version %d", ctrl_ap_version)
+
+    def check_flash_security(self):
+        """! @brief Check security and unlock device.
+
+        This init task determines whether the device is locked (APPROTECT enabled). If it is,
+        and if auto unlock is enabled, then perform a mass erase to unlock the device.
+
+        This init task runs *before* cores are created.
+        """
+
+        if self.is_locked():
+            if self.session.options.get('auto_unlock'):
+                LOG.warning("%s APPROTECT enabled: will try to unlock via mass erase", self.part_number)
+
+                # Do the mass erase.
+                if not self.mass_erase():
+                    LOG.error("%s: mass erase failed", self.part_number)
+                    raise exceptions.TargetError("unable to unlock device")
+                # Cached badness from create_ap run during AP lockout prevents create_cores from
+                # succeeding.
+                self.dp.create_1_ap(AHB_AP_NUM)
+            else:
+                LOG.warning("%s APPROTECT enabled: not automatically unlocking", self.part_number)
+        else:
+            LOG.info("%s not in secure state", self.part_number)
+
+    def is_locked(self):
+        status = self.ctrl_ap.read_reg(CTRL_AP_APPROTECTSTATUS)
+        return status == CTRL_AP_APPROTECTSTATUS_ENABLED
+
+    def mass_erase(self):
+        # See Nordic Whitepaper nWP-027 for magic numbers and order of operations from the vendor
+        self.ctrl_ap.write_reg(CTRL_AP_ERASEALL, CTRL_AP_ERASEALL_ERASE)
+        with Timeout(MASS_ERASE_TIMEOUT) as to:
+            while to.check():
+                status = self.ctrl_ap.read_reg(CTRL_AP_ERASEALLSTATUS)
+                if status == CTRL_AP_ERASEALLSTATUS_READY:
+                    break
+                sleep(0.1)
+            else:
+                # Timed out
+                LOG.error("Mass erase timeout waiting for ERASEALLSTATUS")
+                return False
+        self.ctrl_ap.write_reg(CTRL_AP_RESET, CTRL_AP_RESET_RESET)
+        self.ctrl_ap.write_reg(CTRL_AP_RESET, CTRL_AP_RESET_NORESET)
+        self.ctrl_ap.write_reg(CTRL_AP_ERASEALL, CTRL_AP_ERASEALL_NOOPERATION)
+        return True


### PR DESCRIPTION
As discussed in #775 


With these changes, auto_unlock works with nRF52 targets:

``` bash
(venv) $ pyocd commander --target nrf52840
0000228:WARNING:target_nRF52:NRF52840 APPROTECT enabled: will try to unlock via mass erase
Connected to NRF52840 [Halted]: I3FSNZOV
>>> 
```
and the commander has reasonable UX around the function:

``` bash 
(venv) $ pyocd commander --target nrf52840 -N
>>> initdp
>>> status
Security:       Locked
>>> unlock
>>> status
Security:       Unlocked
>>> reinit
>>> status
Security:       Unlocked
Core 0 status:  Halted
>>> 
```

Tested locally against an nRF52 DK and and nRF52840 DK using CMSIS DAP.
