### PR TITLE
Merged CPUID constants

### DIFF
--- a/pyocd/coresight/core_ids.py
+++ b/pyocd/coresight/core_ids.py
@@ -1,0 +1,43 @@
+# pyOCD debugger
+# Copyright (c) 019 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid_name
+
+# CPUID PARTNO values
+ARM_CortexM0 = 0xC20
+ARM_CortexM1 = 0xC21
+ARM_CortexM3 = 0xC23
+ARM_CortexM4 = 0xC24
+ARM_CortexM7 = 0xC27
+ARM_CortexM0p = 0xC60
+ARM_CortexM23 = 0xD20
+ARM_CortexM33 = 0xD21
+ARM_CortexM35P = 0xD22
+
+# pylint: enable=invalid_name
+
+## @brief User-friendly names for core types.
+CORE_TYPE_NAME = {
+                 ARM_CortexM0 : "Cortex-M0",
+                 ARM_CortexM1 : "Cortex-M1",
+                 ARM_CortexM3 : "Cortex-M3",
+                 ARM_CortexM4 : "Cortex-M4",
+                 ARM_CortexM7 : "Cortex-M7",
+                 ARM_CortexM0p : "Cortex-M0+",
+                 ARM_CortexM23 : "Cortex-M23",
+                 ARM_CortexM33 : "Cortex-M33",
+                 ARM_CortexM35P : "Cortex-M35P",
+               }

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+from time import (time, sleep)
+from xml.etree.ElementTree import (Element, SubElement, tostring)
+
 from ..core.target import Target
 from ..core import exceptions
 from ..utility import (cmdline, conversion, timeout)
@@ -21,35 +25,11 @@ from ..utility.notification import Notification
 from .component import CoreSightCoreComponent
 from .fpb import FPB
 from .dwt import DWT
+from .core_ids import CORE_TYPE_NAME
 from ..debug.breakpoints.manager import BreakpointManager
 from ..debug.breakpoints.software import SoftwareBreakpointProvider
-import logging
-from time import (time, sleep)
-from xml.etree.ElementTree import (Element, SubElement, tostring)
 
 LOG = logging.getLogger(__name__)
-
-# pylint: disable=invalid_name
-
-# CPUID PARTNO values
-ARM_CortexM0 = 0xC20
-ARM_CortexM1 = 0xC21
-ARM_CortexM3 = 0xC23
-ARM_CortexM4 = 0xC24
-ARM_CortexM7 = 0xC27
-ARM_CortexM0p = 0xC60
-
-# pylint: enable=invalid_name
-
-## @brief User-friendly names for core types.
-CORE_TYPE_NAME = {
-                 ARM_CortexM0 : "Cortex-M0",
-                 ARM_CortexM1 : "Cortex-M1",
-                 ARM_CortexM3 : "Cortex-M3",
-                 ARM_CortexM4 : "Cortex-M4",
-                 ARM_CortexM7 : "Cortex-M7",
-                 ARM_CortexM0p : "Cortex-M0+",
-               }
 
 ## @brief Map from register name to DCRSR register index.
 #

--- a/pyocd/coresight/cortex_m_v8m.py
+++ b/pyocd/coresight/cortex_m_v8m.py
@@ -14,28 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .cortex_m import CortexM
-from ..core import exceptions
-from ..core.target import Target
 import logging
 
+from .cortex_m import CortexM
+from .core_ids import CORE_TYPE_NAME
+from ..core import exceptions
+from ..core.target import Target
+
 LOG = logging.getLogger(__name__)
-
-# pylint: disable=invalid_name
-
-# CPUID PARTNO values
-ARM_CortexM23 = 0xD20
-ARM_CortexM33 = 0xD21
-ARM_CortexM35P = 0xD22
-
-# pylint: enable=invalid_name
-
-# User-friendly names for core types.
-CORE_TYPE_NAME = {
-                 ARM_CortexM23 : "Cortex-M23",
-                 ARM_CortexM33 : "Cortex-M33",
-                 ARM_CortexM35P : "Cortex-M35P",
-               }
 
 class CortexM_v8M(CortexM):
     """! @brief Component class for a v8-M architecture Cortex-M core."""

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -1568,7 +1568,7 @@ class PyOCDCommander(object):
             print("Cores:        %d" % len(self.target.cores))
             for i, c in enumerate(self.target.cores):
                 core = self.target.cores[c]
-                print("Core %d type:  %s" % (i, coresight.cortex_m.CORE_TYPE_NAME[core.core_type]))
+                print("Core %d type:  %s" % (i, coresight.core_ids.CORE_TYPE_NAME[core.core_type]))
 
     def handle_show_map(self, args):
         pt = prettytable.PrettyTable(["Region", "Start", "End", "Size", "Access", "Sector", "Page"])


### PR DESCRIPTION
- Merged CPUID constants and core type names that were split between v6/7-M and v8-M.
- Moved these constants to new `core_ids.py` module.

The most noticeable effect of this change is that it fixes an issue in Commander where it failed to print v8-M core names due to the split `CORE_TYPE_NAME` dicts.