### PR TITLE
CMSIS-DAP USB backend fixes and improvements

### DIFF
--- a/pyocd/probe/pydapaccess/interface/common.py
+++ b/pyocd/probe/pydapaccess/interface/common.py
@@ -14,9 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import usb.util
+
 # USB class codes.
 USB_CLASS_COMPOSITE = 0x00
 USB_CLASS_COMMUNICATIONS = 0x02
+USB_CLASS_HID = 0x03
 USB_CLASS_MISCELLANEOUS = 0xef
 USB_CLASS_VENDOR_SPECIFIC = 0xff
 
@@ -75,3 +78,8 @@ def filter_device_by_usage_page(vid, pid, usage_page):
     return ((vid, pid) == NXP_LPCLINK2_ID) \
         and (usage_page != CMSIS_DAP_HID_USAGE_PAGE)
 
+def check_ep(interface, ep_index, ep_dir, ep_type):
+    """! @brief Tests an endpoint type and direction."""
+    ep = interface[ep_index]
+    return (usb.util.endpoint_direction(ep.bEndpointAddress) == ep_dir) \
+        and (usb.util.endpoint_type(ep.bmAttributes) == ep_type)

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -60,7 +60,6 @@ class HidApiUSB(Interface):
         devices = hid.enumerate()
 
         if not devices:
-            LOG.debug("No Mbed device connected")
             return []
 
         boards = []
@@ -100,17 +99,16 @@ class HidApiUSB(Interface):
     def write(self, data):
         """! @brief Write data on the OUT endpoint associated to the HID interface
         """
-        for _ in range(self.packet_size - len(data)):
-            data.append(0)
-        #logging.debug("send: %s", data)
+        data.extend([0] * (self.packet_size - len(data)))
+#         LOG.debug("snd>(%d) %s" % (len(data), ' '.join(['%02x' % i for i in data])))
         self.device.write([0] + data)
-        return
-
 
     def read(self, timeout=-1):
         """! @brief Read data on the IN endpoint associated to the HID interface
         """
-        return self.device.read(self.packet_size)
+        data = self.device.read(self.packet_size)
+#         LOG.debug("rcv<(%d) %s" % (len(data), ' '.join(['%02x' % i for i in data])))
+        return data
 
     def get_serial_number(self):
         return self.serial_number

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 from .interface import Interface
-from .common import (USB_CLASS_VENDOR_SPECIFIC, filter_device_by_class, is_known_cmsis_dap_vid_pid)
+from .common import (USB_CLASS_VENDOR_SPECIFIC, filter_device_by_class, is_known_cmsis_dap_vid_pid,
+                        check_ep)
 from ..dap_access_api import DAPAccessIntf
 from ... import common
 import logging
@@ -80,7 +81,7 @@ class PyUSBv2(Interface):
         config = dev.get_active_configuration()
 
         # Get CMSIS-DAPv2 interface
-        interface = usb.util.find_descriptor(config, custom_match=_match_cmsis_dap_interface)
+        interface = usb.util.find_descriptor(config, custom_match=_match_cmsis_dap_v2_interface)
         if interface is None:
             raise DAPAccessIntf.DeviceError("Device %s has no CMSIS-DAPv2 interface" %
                                             self.serial_number)
@@ -253,13 +254,7 @@ class PyUSBv2(Interface):
         self.intf_number = None
         self.thread = None
 
-def _check_ep(interface, ep_index, ep_dir, ep_type):
-    """! @brief Tests an endpoint type and direction."""
-    ep = interface[ep_index]
-    return (usb.util.endpoint_direction(ep.bEndpointAddress) == ep_dir) \
-        and (usb.util.endpoint_type(ep.bmAttributes) == ep_type)
-
-def _match_cmsis_dap_interface(interface):
+def _match_cmsis_dap_v2_interface(interface):
     """! @brief Returns true for a CMSIS-DAP v2 interface.
     
     This match function performs several tests on the provided USB interface descriptor, to
@@ -289,16 +284,16 @@ def _match_cmsis_dap_interface(interface):
             return False
         
         # Endpoint 0 must be bulk out.
-        if not _check_ep(interface, 0, usb.util.ENDPOINT_OUT, usb.util.ENDPOINT_TYPE_BULK):
+        if not check_ep(interface, 0, usb.util.ENDPOINT_OUT, usb.util.ENDPOINT_TYPE_BULK):
             return False
         
         # Endpoint 1 must be bulk in.
-        if not _check_ep(interface, 1, usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_BULK):
+        if not check_ep(interface, 1, usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_BULK):
             return False
         
         # Endpoint 2 is optional. If present it must be bulk in.
         if (interface.bNumEndpoints == 3) \
-            and not _check_ep(interface, 2, usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_BULK):
+            and not check_ep(interface, 2, usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_BULK):
             return False
         
         # All checks passed, this is a CMSIS-DAPv2 interface!
@@ -327,7 +322,7 @@ class HasCmsisDapv2Interface(object):
         
         try:
             config = dev.get_active_configuration()
-            cmsis_dap_interface = usb.util.find_descriptor(config, custom_match=_match_cmsis_dap_interface)
+            cmsis_dap_interface = usb.util.find_descriptor(config, custom_match=_match_cmsis_dap_v2_interface)
         except usb.core.USBError as error:
             # Produce a more helpful error message if we get a permissions error on Linux.
             if error.errno == errno.EACCES and platform.system() == "Linux" \


### PR DESCRIPTION
- pyusb backend properly handles USB devices with multiple HID interfaces, such as the NXP LPC-LinkII.
- pywinusb backend support for packets larger than 64 bytes. There may still be issues here.
- Some general cleanup and normalization across the backends.