### PR TITLE
Some nRF52 family fixes, plus docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Configuration and customization is supported through [config files](docs/configu
 Requirements
 ------------
 
-- Python 2.7.9 or later, or Python 3.6.0 or later
+- Python 3.6.0 or later (preferred), or Python 2.7.9 or later
 - macOS, Linux, or Windows 7 or newer
 - Microcontroller with an Arm Cortex-M CPU
 - Supported debug probe
@@ -56,7 +56,7 @@ Requirements
     such as:
     - Cypress KitProg3
     - Keil ULINKplus
-  - STLinkV2, either on-board or the standalone version.
+  - STLinkV2 or STLinkV3, either on-board or the standalone versions.
 
 
 Status
@@ -225,4 +225,4 @@ License
 PyOCD is licensed with the permissive Apache 2.0 license. See the [LICENSE](LICENSE) file for the
 full text of the license.
 
-Copyright © 2006-2019 Arm Ltd
+Copyright © 2006-2019 Arm Ltd and others (see individual source files)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,16 +5,25 @@
 
 ### User documentation
 
+#### Introduction
+
 - [Terminology](terminology.md)
 - [Target support](target_support.md)
 - [Configuration](configuration.md)
 - [User scripts](user_scripts.md)
+
+#### Advanced
+
 - [Configuring logging](configuring_logging.md)
 - [Debugging multicore devices](multicore_debug.md)
+- [Target security features](security.md)
+
+#### Python API
 - [Introduction to the pyOCD Python API](python_api.md)
 - [Python API examples](api_examples.md)
+
+#### Miscellaneous
 - [Installing on non-x86 platforms](installing_on_non_x86.md)
-- [Target Security Features](security.md)
 
 ### Developer documentation
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,8 +1,20 @@
 # Security and Protection Features
 
 Many targets support some way of disabling JTAG/SWD access or protecting the flash from read-back or write.
+In the text below, this is called a "locked" target, though each silicon vendor tends to have their
+own terminology for this feature.
 
-If you attempt to run pyOCD against a locked target, you'll encounter a message like this:
+## Supported Targets
+
+pyOCD currently supports the security features of these target families:
+- NXP Kinetis
+- Nordic Semiconductor nRF52 families
+
+Both built-in and CMSIS-Pack based targets from these families support security features.
+
+## Connecting to a locked target
+
+If you attempt to run pyOCD Commander against a locked target, you'll encounter a message like this:
 
 ``` bash
 (venv) ~/devel/contrib/pyocd$ pyocd commander --target nrf52
@@ -26,24 +38,29 @@ pyocd.core.exceptions.DebugError: No cores were discovered!
 
 pyOCD has noticed that the chip is locked. It attempts routine initialization anyway, but fails to find any cores.
 
-## Supported Targets
+For all other pyOCD commands that connect to the target, pyOCD will, by default, attempt to
+automatically unlock the target.
 
-pyOCD currently supports the security features of the NXP Kinetis and Nordic Semiconductor nRF52 families. 
+Disabling the security features on supported targets is very straight-forward. It typically requires
+performing a mass erase of all device memory. For those pyOCD targets with support for security
+features, pyOCD can perform this unlock procedure for you.
 
-Disabling the security features on supported targets is very straight-forward.
+***WARNING:** Unlocking a locked device will erase all data on the chip!*
 
-*WARNING: **This will erase all data on the chip***
-
-You can add the option`auto_unlock` to your [configuration](/configuration.md):
+You can add the option `auto_unlock` to your [configuration](/configuration.md):
 
 ```bash
 (venv) ~/devel/contrib/pyocd$ pyocd commander --target nrf52 -O auto_unlock
 0000264:WARNING:target_nRF52:NRF52832 APPROTECT enabled: will try to unlock via mass erase
 Connected to NRF52832 [Halted]: I3FSNZOV
->>> 
+>>>
 ```
 
-You can also do this interactively with *pyOCD commander*:
+Note that the default for `auto_unlock` is True. Only in pyOCD Commander is this default changed,
+because of how Commander is intended to be used for low-level interaction and inspection of the
+target.
+
+You can also do this interactively with pyOCD Commander:
 
 ```
 (venv) $ pyocd commander --target nrf52840 -N
@@ -65,25 +82,27 @@ An explanation of some of the commands and options appears below.
 
 ## Unsupported targets
 
-If pyOCD doesn't support the security features of your MCU, you can still likely access them with pyOCD commander with
-the `no-init` option. A common pattern is that the security function locks out the fully-functional AP, but leaves a second,
-proprietary AP unlocked. The second AP usually has very few functions, mostly related to management (reset) or erase/unlock
-of the chip.
+If pyOCD doesn't support the security features of your MCU, you can still likely access them with
+pyOCD Commander with the `no-init` option. A common pattern is that the security function locks out
+the fully-functional AHB-AP, but leaves a second, proprietary AP unlocked. The second AP usually has
+very few functions, mostly related to management (reset) or erase/unlock of the chip. Another method
+used by some device families is to use only the standard AHB-AP, but when the device is locked the
+accessible address range is limited to a small handful of registers.
 
-Starting pyocd commander in `--no-init` mode is intended to help in these situations. It intentionally doesn't attempt
-to interact with the target on startup. Without initialization, most commands will not work. You'll need to do some 
+Starting pyOCD Commander in `--no-init` mode is intended to help in these situations. It intentionally doesn't attempt
+to interact with the target on startup. Without initialization, most commands will not work. You'll need to do some
 manual initialization.
 
-The usefulness of `--no-init` mode is that it allows *commander* to start when initialization would
+The usefulness of `--no-init` mode is that it allows Commander to start when initialization would
 normally fail due to missing support for the target or security features of the MCU.
 
 ### Useful Options
 
-Once you've started commander `--no-init`, the following options are most useful.
+Once you've started Commander `--no-init`, the following commands are most useful.
 
 <dl>
 <dt><em>initdp</em></dt>
-<dd>Powers on and initializes the on-chip *Debug Port*, allowing commander to issue commands to the
+<dd>Powers on and initializes the on-chip *Debug Port*, allowing Commander to issue commands to the
 target</dd>
 
 <dt><em>makeap &lt;ap num&gt;</em></dt>
@@ -98,13 +117,13 @@ for certain functions to proceed *even if AP #0 is locked*.</dd>
 <dd>Write to an AP register</dd>
 
 <dt><em>status</em></dt>
-<dd>Will show security status for supported targets. If the target is unlocked and the AHB-AP is 
+<dd>Will show security status for supported targets. If the target is unlocked and the AHB-AP is
 initialized, it will also show status for any cores detected (Running, Halted, &c)</dd>
 
 <dt><em>reinit</em></dt>
 <dd>This command will attempt to perform the normal initialization steps for the selected target. If you
 manually unlock a target, you may want to run `reinit` so that the cores are accessible *without* restarting
-commander in normal mode (without `--no-init`)</dd>
+Commander in normal mode (without `--no-init`)</dd>
 </dl>
 
 ### Example
@@ -119,10 +138,10 @@ unlock the target:
 ```
 We use `initdp` to initialize the *Debug Port* and power on the on-chip debug hardware.
 
-The [nRF52 Product Specification](https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.1.pdf) says that the chip has a 
-*CTRL-AP* at index 1 that supports a few operations even if the main AP is locked.
+The [nRF52 Product Specification](https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.1.pdf) says that the chip has a
+proprietary *CTRL-AP* at index 1 that supports a few operations even if the main AP is locked.
 
-Let's let pyOCD know about it with `makeap`
+Let's let pyOCD know about it with `makeap`:
 
 ```
 >>> makeap 1
@@ -136,7 +155,7 @@ The IDR register matches the datasheet! The datasheet says that CTRL-AP (AP #1) 
 <dd>Writing 1 to this register asserts reset on the chip. Writing 0 takes is out of reset</dd>
 
 <dt><em>ERASEALL</em> (0x004)</dt>
-<dd>Writing 1 to this register starts a mass erase of the chip *and removes APPROTECT* unlocking the chip</dd>
+<dd>Writing 1 to this register starts a mass erase of the chip <i>and removes APPROTECT</i> unlocking the chip</dd>
 
 <dt><em>ERASEALLSTATUS</em> (0x008)</dt>
 <dd>While the chip is busy doing a mass erase, this register will read 1. When the mass erase is complete, the register
@@ -189,6 +208,6 @@ Core 0 status:  Halted
 >>>
 ```
 
-The security was unlocked, but there are no cores (many commands like halt, reset, &c need a core). It doesn't exist
-since we started commander in `no-init` mode. Running `reinit` from the CLI finishes the initialization that's 
+The security was unlocked, but there are no cores (many commands like halt, reset, and so on need a core). It doesn't exist
+since we started Commander in `no-init` mode. Running `reinit` from the CLI finishes the initialization that's
 possible now that the chip is unlocked.

--- a/pyocd/target/family/__init__.py
+++ b/pyocd/target/family/__init__.py
@@ -18,7 +18,9 @@ import re
 from collections import namedtuple
 
 from . import target_kinetis
+from . import target_nRF52
 
+## @brief Container for family matching information.
 FamilyInfo = namedtuple("FamilyInfo", "vendor matches klass")
 
 ## @brief Lookup table to convert from CMSIS-Pack family names to a family class.
@@ -27,7 +29,9 @@ FamilyInfo = namedtuple("FamilyInfo", "vendor matches klass")
 # element.
 #
 # At least one of the regexes must match the entirety of either the CMSIS-Pack 'Dfamily' or
-# 'DsubFamily' (if present) attributes.
+# 'DsubFamily' (if present) attributes, or the 'Dname' part number. The comparisons are performed in
+# order from specific to general, starting with the part number.
 FAMILIES = [
-    FamilyInfo("NXP",   [re.compile(r'MK[LEVWS]?.*')],              target_kinetis.Kinetis),
+    FamilyInfo("NXP",                   re.compile(r'MK[LEVWS]?.*'),    target_kinetis.Kinetis  ),
+    FamilyInfo("Nordic Semiconductor",  re.compile(r'nRF52[0-9]+.*'),   target_nRF52.NRF52      ),
     ]

--- a/pyocd/target/family/target_nRF52.py
+++ b/pyocd/target/family/target_nRF52.py
@@ -66,7 +66,7 @@ class NRF52(CoreSightTarget):
 
         # Must check whether security is enabled, and potentially auto-unlock, before
         # any init tasks that require system bus access.
-        seq.insert_before('init_ap_roms',
+        seq.insert_before('find_components',
                           ('check_ctrl_ap_idr', self.check_ctrl_ap_idr),
                           ('check_flash_security', self.check_flash_security),
                           )

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -125,13 +125,12 @@ class PackTargets(object):
             if dev.vendor != familyInfo.vendor:
                 continue
 
-            # Scan each level of families
-            for familyName in dev.families:
-                for regex in familyInfo.matches:
-                    # Require the regex to match the entire family name.
-                    match = regex.match(familyName)
-                    if match and match.span() == (0, len(familyName)):
-                        return familyInfo.klass
+            # Scan each level of family plus part number, from specific to generic.
+            for compare_name in reversed(dev.families + [dev.part_number]):
+                # Require the regex to match the entire family name.
+                match = familyInfo.matches.match(compare_name)
+                if match and match.span() == (0, len(compare_name)):
+                    return familyInfo.klass
         else:
             # Default target superclass.
             return CoreSightTarget


### PR DESCRIPTION
- Fixed a reference to an init task in the just-merged nRF52 family class that was changed recently, causing an exception.
- General improvements to family matching for CMSIS-Pack based targets.
- Added an nRF52 family matcher that enables the security features in the nRF52 family class for CMSIS-Pack based nRF52 targets.
- Some docs updates, including updates to the new security features doc.