### PR TITLE
Fix some issues in commander when there are no cores

### DIFF
--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -283,7 +283,7 @@ class CoreSightTarget(Target, GraphNode):
     
     def _apply_to_all_components(self, action, filter=None):
         # Iterate over every top-level ROM table.
-        for ap in [x for x in self.dp.aps.values() if x.has_rom_table]:
+        for ap in [x for x in self.dp.aps.values() if (x.has_rom_table and x.rom_table is not None)]:
             ap.rom_table.for_each(action, filter)
 
     def check_for_cores(self):

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -670,7 +670,7 @@ class PyOCDCommander(object):
                         else:
                             try:
                                 status = CORE_STATUS_DESC[self.target.get_state()]
-                            except KeyError:
+                            except (AttributeError, KeyError):
                                 status = "<no core>"
 
                         # Say what we're connected to.
@@ -789,8 +789,13 @@ class PyOCDCommander(object):
         # Select the first core's MEM-AP by default.
         if not self.args.no_init:
             try:
-                self.selected_ap = self.target.selected_core.ap.ap_num
+                if self.target.selected_core is not None:
+                    self.selected_ap = self.target.selected_core.ap.ap_num
             except IndexError:
+                pass
+            
+            # Fall back to the first MEM-AP.
+            if self.selected_ap is None:
                 for ap_num in sorted(self.target.aps.keys()):
                     if isinstance(self.target.aps[ap_num], MEM_AP):
                         self.selected_ap = ap_num


### PR DESCRIPTION
Normally if no cores are detected, connect will fail. This can be overridden with the `allow_no_cores` option, and is useful in debugging pyocd, security, chip bringup.