### PR TITLE
JSON features and options list

### DIFF
--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -259,6 +259,8 @@ class PyOCDTool(object):
             help="List all known targets.")
         group.add_argument('-b', '--boards', action='store_true',
             help="List all known boards.")
+        group.add_argument('-f', '--features', action='store_true',
+            help="List available features and options.")
         jsonParser.set_defaults(verbose=0, quiet=0)
 
         # Create *list* subcommand parser.
@@ -427,7 +429,7 @@ class PyOCDTool(object):
     def do_json(self):
         """! @brief Handle 'json' subcommand."""
         # Default to listing probes.
-        if not any((self._args.probes, self._args.targets, self._args.boards)):
+        if not any((self._args.probes, self._args.targets, self._args.boards, self._args.features)):
             self._args.probes = True
         
         # Create a session with no device so we load any config.
@@ -450,6 +452,8 @@ class PyOCDTool(object):
             obj = ListGenerator.list_targets()
         elif self._args.boards:
             obj = ListGenerator.list_boards()
+        elif self._args.features:
+            obj = ListGenerator.list_features()
         else:
             assert False
         print(json.dumps(obj, indent=4))

--- a/pyocd/tools/lists.py
+++ b/pyocd/tools/lists.py
@@ -20,6 +20,7 @@ import six
 from .. import __version__
 from ..core.session import Session
 from ..core.helpers import ConnectHelper
+from ..core import options
 from ..target import TARGET
 from ..target.builtin import BUILTIN_TARGETS
 from ..board.board_ids import BOARD_ID_TO_INFO
@@ -179,4 +180,41 @@ class ListGenerator(object):
                 except KeyError:
                     pass
 
+        return obj
+        
+    @staticmethod
+    def list_features():
+        """! @brief Generate dictionary with info about supported features and options.
+        
+        Output version history:
+        - 1.0, initial version
+        """
+        # Features list is empty right now. It will be populated as new features are added that
+        # external hosts might depend on.
+        options_list = []
+        obj = {
+            'pyocd_version' : __version__,
+            'version' : { 'major' : 1, 'minor' : 0 },
+            'status' : 0,
+            'features' : [],
+            'options' : options_list,
+            }
+        
+        # Add options
+        for option_name in options.OPTIONS_INFO.keys():
+            info = options.OPTIONS_INFO[option_name]
+            option_dict = {
+                        'name' : option_name,
+                        'default' : info.default,
+                        'description' : info.help,
+                        }
+            try:
+                types_list = []
+                for t in info.type:
+                    types_list.append(t.__name__)
+            except TypeError:
+                types_list = [info.type.__name__]
+            option_dict['type'] = types_list
+            options_list.append(option_dict)
+        
         return obj

--- a/test/gdb_server_json_test.py
+++ b/test/gdb_server_json_test.py
@@ -185,7 +185,7 @@ def gdb_server_json_test(board_id, testing_standalone=False):
 
     result = GdbServerJsonTestResult()
 
-    print("\n\n----- TESTING BOARDS LIST -----")
+    print("\n\n----- TESTING PROBES LIST -----")
     out = subprocess.check_output(['pyocd', 'json', '--probes'])
     data = json.loads(out)
     test_count += 2
@@ -201,6 +201,22 @@ def gdb_server_json_test(board_id, testing_standalone=False):
     if validate_basic_keys(data, minor_version=2):
         test_pass_count += 1
     if validate_targets(data):
+        test_pass_count += 1
+
+    # Doesn't actually verify returned probes, simply makes sure it doesn't crash.
+    print("\n\n----- TESTING BOARDS LIST -----")
+    out = subprocess.check_output(['pyocd', 'json', '--boards'])
+    data = json.loads(out)
+    test_count += 1
+    if validate_basic_keys(data, minor_version=1):
+        test_pass_count += 1
+
+    # Doesn't actually verify returned features and options, simply makes sure it doesn't crash.
+    print("\n\n----- TESTING FEATURES LIST -----")
+    out = subprocess.check_output(['pyocd', 'json', '--features'])
+    data = json.loads(out)
+    test_count += 1
+    if validate_basic_keys(data, minor_version=0):
         test_pass_count += 1
 
     result.passed = test_count == test_pass_count


### PR DESCRIPTION
This PR adds a new JSON data output from `pyocd json`. Right now it contains only a list of information about available user options plus an empty features list. No features are defined yet. In the future this will provide a programmatic method of determining whether the pyOCD version supports a particular feature without relying on version number comparison. The use case is mostly for IDEs that may wish to disable or display different controls based on presence of certain features.

Updated the `gdb_server_json_test.py` function test to verify that all JSON outputs can be generated without crashing.

Threw in an improvement where a missing `svd_data.zip` in the pyocd install will be handled gracefully with a logged warning.