### PR TITLE
Fix reset vector catch clearing on LPC1768

### DIFF
--- a/pyocd/target/builtin/target_LPC1768.py
+++ b/pyocd/target/builtin/target_LPC1768.py
@@ -103,7 +103,7 @@ class LPC1768(CoreSightTarget):
 
         # Clear reset vector catch and remember whether it was set.
         self._saved_vc = self.get_vector_catch()
-        self.set_vector_catch(self._saved_vc & ~Target.CATCH_CORE_RESET)
+        self.set_vector_catch(self._saved_vc & ~Target.VectorCatch.CORE_RESET)
         
         # Map flash to 0.
         self.map_flash()


### PR DESCRIPTION
This broke in e71f2c10581511371261127dd173410b5c77b326.