### PR TITLE
Fix issue #826. More robust detection of FreeRTOS

### DIFF
--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -86,8 +86,9 @@ class CoreSightTarget(Target, GraphNode):
             self._elf = None
         else:
             self._elf = ELFBinaryFile(filename, self.memory_map)
-            self.cores[0].elf = self._elf
-            self.cores[0].set_target_context(ElfReaderContext(self.cores[0].get_target_context(), self._elf))
+        for core_number, core in self.cores.items():
+            self.cores[core_number].elf = self._elf
+            self.cores[core_number].set_target_context(ElfReaderContext(self.cores[core_number].get_target_context(), self._elf))
 
     def select_core(self, num):
         """! @note Deprecated."""

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -86,7 +86,7 @@ class CoreSightTarget(Target, GraphNode):
             self._elf = None
         else:
             self._elf = ELFBinaryFile(filename, self.memory_map)
-        for core_number, core in self.cores.items():
+        for core_number in range(len(self.cores)):
             self.cores[core_number].elf = self._elf
             self.cores[core_number].set_target_context(ElfReaderContext(self.cores[core_number].get_target_context(), self._elf))
 

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -86,9 +86,9 @@ class CoreSightTarget(Target, GraphNode):
             self._elf = None
         else:
             self._elf = ELFBinaryFile(filename, self.memory_map)
-        for core_number in range(len(self.cores)):
-            self.cores[core_number].elf = self._elf
-            self.cores[core_number].set_target_context(ElfReaderContext(self.cores[core_number].get_target_context(), self._elf))
+            for core_number in range(len(self.cores)):
+                self.cores[core_number].elf = self._elf
+                self.cores[core_number].set_target_context(ElfReaderContext(self.cores[core_number].get_target_context(), self._elf))
 
     def select_core(self, num):
         """! @note Deprecated."""

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -1291,7 +1291,7 @@ class CortexM(Target, CoreSightCoreComponent):
         if mask & CortexM.DEMCR_VC_BUSERR:
             result |= Target.VectorCatch.BUS_FAULT
         if mask & CortexM.DEMCR_VC_MMERR:
-            result |= TargetVectorCatch.MEM_FAULT
+            result |= Target.TargetVectorCatch.MEM_FAULT
         if mask & CortexM.DEMCR_VC_INTERR:
             result |= Target.VectorCatch.INTERRUPT_ERR
         if mask & CortexM.DEMCR_VC_STATERR:

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -510,20 +510,21 @@ class FreeRTOSThreadProvider(ThreadProvider):
         return self._target_context.read32(self._symbols['xSchedulerRunning']) != 0
 
     def _get_elf_symbol_size(self, name, addr, defValue):
-        if (self._target.elf is not None):
+        if self._target.elf is not None:
             symInfo = None
             try:
                 symInfo = self._target.elf.symbol_decoder.get_symbol_for_name(name)
             except:
-                LOG.debug("FreeRTOS Ooops, elf symbol query failed with an exception")
-            # TODO: remove most/all the debug stuff when we are comfortable. Not for performance but for code cleanup
+                LOG.error("FreeRTOS elf symbol query failed for (%s) with an exception.",
+                    name, exc_info=self._target.session.log_tracebacks)
+
+            # Simple checks to make sure gdb is looking at the same executable we are
             if symInfo is None:
                 LOG.debug("FreeRTOS symbol '%s' not found in elf file", name)
             elif symInfo.address != addr:
-                # If address does not match, chances are gdb and us are not looking at the same executable
                 LOG.debug("FreeRTOS symbol '%s' address mismatch elf=0x%08x, gdb=0x%08x", name, symInfo.address, addr)
             else:
-                if (defValue != symInfo.size):
+                if defValue != symInfo.size:
                     LOG.info("FreeRTOS symbol '%s' size from elf (%ld) != calculated size (%ld). Using elf value.",
                         name, symInfo.size, defValue)
                 else:

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -509,7 +509,7 @@ class FreeRTOSThreadProvider(ThreadProvider):
             return False
         return self._target_context.read32(self._symbols['xSchedulerRunning']) != 0
 
-    def _get_elf_symbol_size(self, name, addr, default):
+    def _get_elf_symbol_size(self, name, addr, defValue):
         if (self._target.elf is not None):
             symInfo = None
             try:
@@ -523,10 +523,10 @@ class FreeRTOSThreadProvider(ThreadProvider):
                 # If address does not match, chances are gdb and us are not looking at the same executable
                 LOG.debug("FreeRTOS symbol '%s' address mismatch elf=0x%08x, gdb=0x%08x", name, symInfo.address, addr)
             else:
-                if (default != symInfo.size):
+                if (defValue != symInfo.size):
                     LOG.info("FreeRTOS symbol '%s' size from elf (%ld) != calculated size (%ld). Using elf value.",
-                        name, symInfo.size, default)
+                        name, symInfo.size, defValue)
                 else:
-                    LOG.debug("FreeRTOS symbol '%s' size (%ld) from elf file matches calculated value", name, default)
+                    LOG.debug("FreeRTOS symbol '%s' size (%ld) from elf file matches calculated value", name, defValue)
                 return symInfo.size
-        return default
+        return defValue

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -289,6 +289,8 @@ class GDBServerTool(object):
                     if self.args.elf:
                         session.board.target.elf = self.args.elf
                     for core_number, core in session.board.target.cores.items():
+                        if self.args.elf:
+                            session.board.target.cores[core_number].elf = session.board.target.elf
                         gdb = GDBServer(session,
                             core=core_number,
                             server_listening_callback=self.server_listening)

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -289,8 +289,6 @@ class GDBServerTool(object):
                     if self.args.elf:
                         session.board.target.elf = self.args.elf
                     for core_number, core in session.board.target.cores.items():
-                        if self.args.elf:
-                            session.board.target.cores[core_number].elf = session.board.target.elf
                         gdb = GDBServer(session,
                             core=core_number,
                             server_listening_callback=self.server_listening)


### PR DESCRIPTION
Fixes #826

We were relying on the compiler/linker placing the symbols in the order they are declared and packed. I have simple executables that are jumbling up the FreeRTOS symbols we are interested in almost random ways. This makes it impossible to detect proper FreeRTOS and also a chance for improperly identifying the FreeRTOS data.

Since the user has the option of supplying an elf file, we can use it to check symbol sizes. We also make sure the address matches what gdb tells us via the `qSymbol` query as a backup because we want to have one version of the truth and cross-check the gdb vs elf versions

A couple of other changes I made
* When user supplies an elf file, we were setting the elf object only on core[0]. They should be set for all cores. In my case, what I was interested was in core#1. I verified that we can now do that for all cores. This change is very much needed for the fix
* A change I made that was not needed in pyocd/coresight/cortex_m.py . When I ran pylint, it found an undefined variable. It had to be a typo/oversight, so I fixed it.

Note: OpenOCD uses a symbol named `uxTopUsedPriority` as a workaround. The problem with using that method is that it has been long been deprecated by FreeRTOS and defining and making it survive the compiler/linker is super difficult. I think what I implemented is a much better method.