### PR TITLE
Set correct size for nRF52x UICR.

### DIFF
--- a/pyocd/target/builtin/target_nRF52832_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52832_xxAA.py
@@ -48,7 +48,7 @@ class NRF52832(NRF52):
         FlashRegion(    start=0x0,         length=0x80000,      blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO),
         # User Information Configation Registers (UICR) as a flash region
-        FlashRegion(    start=0x10001000,  length=0x100,        blocksize=0x100, is_testable=False,
+        FlashRegion(    start=0x10001000,  length=0x400,        blocksize=0x400, is_testable=False,
             algo=FLASH_ALGO),
         RamRegion(      start=0x20000000,  length=0x10000)
         )

--- a/pyocd/target/builtin/target_nRF52840_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52840_xxAA.py
@@ -49,7 +49,7 @@ class NRF52840(NRF52):
         FlashRegion(    start=0x0,         length=0x100000,     blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO),
         # User Information Configation Registers (UICR) as a flash region
-        FlashRegion(    start=0x10001000,  length=0x100,        blocksize=0x100, is_testable=False,
+        FlashRegion(    start=0x10001000,  length=0x400,        blocksize=0x400, is_testable=False,
             algo=FLASH_ALGO),
         RamRegion(      start=0x20000000,  length=0x40000)
         )


### PR DESCRIPTION
The UICR flash region on nRF52 is bigger than 0x100 bytes. This PR raises it to 0x400, which is the smallest multiple of 0x100 that covers all registers in the docs. This allows flashing these special registers with pyOCD.

Tested working on a real hardware nRF52840.

Relevant docs:

nrf52840: https://infocenter.nordicsemi.com/topic/ps_nrf52840/uicr.html?cp=4_0_0_3_4_0#topic
nrf52832: https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/uicr.html?cp=4_2_0_13_0#topic

