### PR TITLE
Fix bits vs bytes confusion in SWV.

### DIFF
--- a/pyocd/trace/swv.py
+++ b/pyocd/trace/swv.py
@@ -52,11 +52,11 @@ class SWVEventSink(TraceEventSink):
             return
         
         # Extract bytes.
-        if event.width == 8:
+        if event.width == 1:
             data = chr(event.data)
-        elif event.width == 16:
+        elif event.width == 2:
             data = chr(event.data & 0xff) + chr((event.data >> 8) & 0xff)
-        elif event.width == 32:
+        elif event.width == 4:
             data = (chr(event.data & 0xff)
                     + chr((event.data >> 8) & 0xff)
                     + chr((event.data >> 16) & 0xff)


### PR DESCRIPTION
SWV seems currently broken because it expects `width` to be in bits (8, 16, or 32) but the SWO code is providing it in bytes (1, 2, or 4).

This PR fixes that.

Tested working with real hardware.