### PR TITLE
fix crash with zephyr threading

### DIFF
--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -222,8 +222,8 @@ class ZephyrThread(TargetThread):
         return self._name
 
     @property
-    def description(self):
-        return "%s; Priority %d" % (self.STATE_NAMES[self.state], self.priority)
+    def description(self):  
+        return "%s; Priority %d" % (self.STATE_NAMES.get(self.state, "UNKNOWN"), self.priority)
 
     @property
     def is_current(self):

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -222,7 +222,7 @@ class ZephyrThread(TargetThread):
         return self._name
 
     @property
-    def description(self):  
+    def description(self):
         return "%s; Priority %d" % (self.STATE_NAMES.get(self.state, "UNKNOWN"), self.priority)
 
     @property


### PR DESCRIPTION
If running in eclipse or vscode, pyocd would throw an exception on connect, if early in the launch cycle of the app on the target because ZephyrThread.description would reference an invalid state index, causing a failure, make default return UNKNOWN string if there is a garbage state value.