### PR TITLE
Fix a few exception creation issues

### DIFF
--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -178,7 +178,7 @@ class AccessPort(object):
         # no AP present, so we return None.
         idr = dp.read_ap((ap_num << APSEL_SHIFT) | AP_IDR)
         if idr == 0:
-            raise exceptions.TargetError("Invalid APSEL=%d", ap_num)
+            raise exceptions.TargetError("Invalid APSEL=%d" % ap_num)
         
         # Extract IDR fields used for lookup.
         designer = (idr & AP_IDR_JEP106_MASK) >> AP_IDR_JEP106_SHIFT

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -1378,13 +1378,13 @@ class PyOCDCommander(object):
             try:
                 wptype = WATCHPOINT_FUNCTION_NAME_MAP[args[1]]
             except KeyError:
-                raise ToolError("unsupported watchpoint type '%s'", args[1])
+                raise ToolError("unsupported watchpoint type '%s'" % args[1])
         else:
             wptype = Target.Watchpoint.READ_WRITE
         if len(args) > 2:
             sz = self.convert_value(args[2])
             if sz not in (1, 2, 4):
-                raise ToolError("unsupported watchpoint size (%d)", sz)
+                raise ToolError("unsupported watchpoint size (%d)" % sz)
         else:
             sz = 4
         if self.target.set_watchpoint(addr, sz, wptype):


### PR DESCRIPTION
There are a few cases where a value is passed as an extra parameter to an exception constructor rather than being interpolated in the exception description string.