### PR TITLE
Minor gdbserver improvements

### DIFF
--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -981,6 +981,8 @@ class GDBServer(threading.Thread):
                 resp = hex_encode(b"Erase successful\n")
             except exceptions.Error as e:
                 resp = hex_encode(to_bytes_safe("Error: " + str(e) + "\n"))
+        elif cmdList[0] == b'sync':
+            self.send_stop_notification()
         else:
             resultMask = 0x00
             if cmdList[0] == b'help':

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -162,7 +162,8 @@ class GDBServer(threading.Thread):
             semihost_io_handler = semihost.InternalSemihostIOHandler()
 
         if self.semihost_console_type == 'telnet':
-            self.telnet_server = StreamServer(self.telnet_port, self.serve_local_only, "Semihost", False)
+            self.telnet_server = StreamServer(self.telnet_port, self.serve_local_only, "Semihost",
+                False, extra_info=("core %d" % self.core))
             console_file = self.telnet_server
             semihost_console = semihost.ConsoleIOHandler(self.telnet_server)
         else:
@@ -265,7 +266,7 @@ class GDBServer(threading.Thread):
         self.current_thread_id = 0
 
     def run(self):
-        LOG.info('GDB server started on port %d', self.port)
+        LOG.info('GDB server started on port %d (core %d)', self.port, self.core)
 
         while True:
             try:

--- a/pyocd/utility/server.py
+++ b/pyocd/utility/server.py
@@ -32,7 +32,7 @@ class StreamServer(threading.Thread):
     server and its thread, call the stop() method.
     """
     
-    def __init__(self, port, serve_local_only=True, name=None, is_read_only=True):
+    def __init__(self, port, serve_local_only=True, name=None, is_read_only=True, extra_info=None):
         """! @brief Constructor.
         
         Starts the server immediately.
@@ -46,10 +46,12 @@ class StreamServer(threading.Thread):
         @param is_read_only If the server is read-only, from the perspective of the client,
             then any incoming data sent by the client is discarded. Otherwise it is buffered so
             it can be read with the read() methods.
+        @param extra_info Optional string with extra information about the server, e.g. "core 0".
         """
         super(StreamServer, self).__init__()
         self.name = name
         self._name = name
+        self._extra_info = extra_info
         self._formatted_name = (name + " ") if (name is not None) else ""
         self._is_read_only = is_read_only
         self._abstract_socket = None
@@ -74,7 +76,8 @@ class StreamServer(threading.Thread):
         self.join()
 
     def run(self):
-        LOG.info("%sserver started on port %d", self._formatted_name, self._port)
+        LOG.info("%sserver started on port %d%s", self._formatted_name, self._port,
+            (" (%s)" % self._extra_info) if self._extra_info else "")
         self.connected = None
         try:
             while not self._shutdown_event.is_set():


### PR DESCRIPTION
- The core number is logged along with the gdbserver and telnet port numbers, so external tools can associate port with core.
- Added a `sync` monitor command that sends a stop notification to gdb. This is useful in cases where gdb is out of sync with the target. Currently considered experimental.