### PR TITLE
Fix for file_programmer import issue with user script namespace

### DIFF
--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -315,6 +315,7 @@ class Session(Notifier):
         later on.
         """
         import pyocd
+        import pyocd.flash.file_programmer
         self._user_script_namespace = {
             # Modules and classes
             'pyocd': pyocd,

--- a/test/test_user_script.py
+++ b/test/test_user_script.py
@@ -1,0 +1,156 @@
+# Test user script.
+#
+# Provides stub implementations of all hooks.
+
+def will_connect(board):
+    """! @brief Pre-init hook for the board.
+    @param self
+    @param board A Board instance that is about to be initialized.
+    @return Ignored.
+    """
+    pass
+
+def did_connect(board):
+    """! @brief Post-initialization hook for the board.
+    @param self
+    @param board A Board instance.
+    @return Ignored.
+    """
+    pass
+
+def will_init_target(target, init_sequence):
+    """! @brief Hook to review and modify init call sequence prior to execution.
+    @param self
+    @param target A CoreSightTarget object about to be initialized.
+    @param init_sequence The CallSequence that will be invoked. Because call sequences are
+        mutable, this parameter can be modified before return to change the init calls.
+    @return Ignored.
+    """
+    pass
+
+def did_init_target(target):
+    """! @brief Post-initialization hook.
+    @param self
+    @param target A CoreSightTarget.
+    @return Ignored.
+    """
+    pass
+
+def will_start_debug_core(core):
+    """! @brief Hook to enable debug for the given core.
+    @param self
+    @param core A CortexM object about to be initialized.
+    @retval True Do not perform the normal procedure to start core debug.
+    @retval "False or None" Continue with normal behaviour.
+    """
+    pass
+
+def did_start_debug_core(core):
+    """! @brief Post-initialization hook.
+    @param self
+    @param core A CortexM object.
+    @return Ignored.
+    """
+    pass
+
+def will_stop_debug_core(core):
+    """! @brief Pre-cleanup hook for the core.
+    @param self
+    @param core A CortexM object.
+    @retval True Do not perform the normal procedure to disable core debug.
+    @retval "False or None" Continue with normal behaviour.
+    """
+    pass
+
+def did_stop_debug_core(core):
+    """! @brief Post-cleanup hook for the core.
+    @param self
+    @param core A CortexM object.
+    @return Ignored.
+    """
+    pass
+
+def will_disconnect(target, resume):
+    """! @brief Pre-disconnect hook.
+    @param self
+    @param target Either a CoreSightTarget or CortexM object.
+    @param resume The value of the `disconnect_on_resume` option.
+    @return Ignored.
+    """
+    pass
+
+def did_disconnect(target, resume):
+    """! @brief Post-disconnect hook.
+    @param self
+    @param target Either a CoreSightTarget or CortexM object.
+    @param resume The value of the `disconnect_on_resume` option.
+    @return Ignored."""
+    pass
+
+def will_reset(core, reset_type):
+    """! @brief Pre-reset hook.
+    @param self
+    @param core A CortexM instance.
+    @param reset_type One of the Target.ResetType enumerations.
+    @retval True
+    @retval "False or None"
+    """
+    pass
+
+def did_reset(core, reset_type):
+    """! @brief Post-reset hook.
+    @param self
+    @param core A CortexM instance.
+    @param reset_type One of the Target.ResetType enumerations.
+    @return Ignored.
+    """
+    pass
+
+def set_reset_catch(core, reset_type):
+    """! @brief Hook to prepare target for halting on reset.
+    @param self
+    @param core A CortexM instance.
+    @param reset_type One of the Target.ResetType enumerations.
+    @retval True
+    @retval "False or None"
+    """
+    pass
+
+def clear_reset_catch(core, reset_type):
+    """! @brief Hook to clean up target after a reset and halt.
+    @param self
+    @param core A CortexM instance.
+    @param reset_type
+    @return Ignored.
+    """
+    pass
+
+def mass_erase(target):
+    """! @brief Hook to override mass erase.
+    @param self
+    @param target A CoreSightTarget object.
+    @retval True Indicate that mass erase was performed by the hook.
+    @retval "False or None" Mass erase was not overridden and the caller should proceed with the standard
+        mass erase procedure.
+    """
+    pass
+
+def trace_start(target, mode):
+    """! @brief Hook to prepare for tracing the target.
+    @param self
+    @param target A CoreSightTarget object.
+    @param mode The trace mode. Currently always 0 to indicate SWO.
+    @return Ignored.
+    """
+    pass
+
+def trace_stop(target, mode):
+    """! @brief Hook to clean up after tracing the target.
+    @param self
+    @param target A CoreSightTarget object.
+    @param mode The trace mode. Currently always 0 to indicate SWO.
+    @return Ignored.
+    """
+    pass
+
+

--- a/test/user_script_test.py
+++ b/test/user_script_test.py
@@ -1,0 +1,111 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+import traceback
+import logging
+
+from pyocd.core.helpers import ConnectHelper
+from pyocd.probe.pydapaccess import DAPAccess
+from pyocd.core.memory_map import MemoryType
+
+from test_util import (
+    Test,
+    TestResult,
+    get_session_options,
+    get_target_test_params,
+    )
+
+testdir = os.path.dirname(os.path.abspath(__file__))
+parentdir = os.path.dirname(testdir)
+
+TEST_USER_SCRIPT = os.path.join(testdir, "test_user_script.py")
+
+class UserScriptTestResult(TestResult):
+    def __init__(self):
+        super(UserScriptTestResult, self).__init__(None, None, None)
+        self.name = "user_script"
+
+class UserScriptTest(Test):
+    def __init__(self):
+        super(UserScriptTest, self).__init__("User Script Test", user_script_test)
+
+    def run(self, board):
+        try:
+            result = self.test_function(board.unique_id)
+        except Exception as e:
+            result = UserScriptTestResult()
+            result.passed = False
+            print("Exception %s when testing board %s" % (e, board.unique_id))
+            traceback.print_exc(file=sys.stdout)
+        result.board = board
+        result.test = self
+        return result
+
+def user_script_test(board_id):
+    with ConnectHelper.session_with_chosen_probe(
+            unique_id=board_id, user_script=TEST_USER_SCRIPT, **get_session_options()) as session:
+        board = session.board
+        target = session.target
+
+        test_params = get_target_test_params(session)
+        session.probe.set_clock(test_params['test_clock'])
+
+        memory_map = target.get_memory_map()
+        boot_region = memory_map.get_boot_memory()
+        ram_region = memory_map.get_default_region_of_type(MemoryType.RAM)
+        binary_file = os.path.join(parentdir, 'binaries', board.test_binary)
+        
+        test_pass_count = 0
+        test_count = 0
+        result = UserScriptTestResult()
+
+        target.reset_and_halt()
+        target.resume()
+        target.halt()
+        target.step()
+        
+        test_count += 1
+        test_pass_count += 1
+        
+        print("\nTest Summary:")
+        print("Pass count %i of %i tests" % (test_pass_count, test_count))
+        if test_pass_count == test_count:
+            print("USER SCRIPT TEST PASSED")
+        else:
+            print("USER SCRIPT TEST FAILED")
+
+        target.reset()
+
+        result.passed = test_count == test_pass_count
+        return result
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='pyOCD user script test')
+    parser.add_argument('-d', '--debug', action="store_true", help='Enable debug logging')
+    parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
+    args = parser.parse_args()
+    level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(level=level)
+    DAPAccess.set_args(args.daparg)
+    # Set to debug to print some of the decisions made while flashing
+    session = ConnectHelper.session_with_chosen_probe(**get_session_options())
+    test = UserScriptTest()
+    result = [test.run(session.board)]
+


### PR DESCRIPTION
When a custom Python script created a session that pulled in a user script, you'd get an exception because `pyocd.flash.file_programmer` was not available. This would only happen if `pyocd.flash.file_programmer` hadn't already been imported prior to the session being created, which is why it never failed in the functional tests or `pyocd` tool.

Added a very simple functional test that verifies that a user script can be loaded. Something to build on.