### PR TITLE
Several bug fixes

### DIFF
--- a/docs/user_scripts.md
+++ b/docs/user_scripts.md
@@ -48,7 +48,7 @@ This example shows how to override the flash algorithm for an external flash mem
 # Unlike the previous example, the board argument is excluded here.
 def will_connect():
     # Look up the external flash memory region.
-    extFlash = target.memory_map.get_region_by_name("flexspi")
+    extFlash = target.memory_map.get_first_matching_region(name="flexspi")
 
     # Set the path to an .FLM flash algorithm.
     extFlash.flm = "MIMXRT105x_QuadSPI_4KB_SEC.FLM"

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -1291,7 +1291,7 @@ class CortexM(Target, CoreSightCoreComponent):
         if mask & CortexM.DEMCR_VC_BUSERR:
             result |= Target.VectorCatch.BUS_FAULT
         if mask & CortexM.DEMCR_VC_MMERR:
-            result |= Target.TargetVectorCatch.MEM_FAULT
+            result |= Target.VectorCatch.MEM_FAULT
         if mask & CortexM.DEMCR_VC_INTERR:
             result |= Target.VectorCatch.INTERRUPT_ERR
         if mask & CortexM.DEMCR_VC_STATERR:

--- a/pyocd/debug/breakpoints/provider.py
+++ b/pyocd/debug/breakpoints/provider.py
@@ -25,7 +25,7 @@ class Breakpoint(object):
         self.provider = provider
 
     def __repr__(self):
-        return "<%s@0x%08x type=%d addr=0x%08x>" % (self.__class__.__name__, id(self), self.type, self.addr)
+        return "<%s@0x%08x type=%s addr=0x%08x>" % (self.__class__.__name__, id(self), self.type.name, self.addr)
 
 class BreakpointProvider(object):
     """! @brief Abstract base class for breakpoint providers."""

--- a/pyocd/debug/elf/decoder.py
+++ b/pyocd/debug/elf/decoder.py
@@ -146,6 +146,9 @@ class DwarfAddressDecoder(object):
                 # Skip subprograms excluded from the link.
                 if low_pc == 0:
                     continue
+                # Skip empty subprograms (no null intervals are allowed).
+                if low_pc == high_pc:
+                    continue
 
                 # If high_pc is not explicitly an address, then it's an offset from the
                 # low_pc value.
@@ -194,6 +197,7 @@ class DwarfAddressDecoder(object):
                     toAddr = entry.state.address
                     try:
                         if fromAddr != 0 and toAddr != 0:
+                            # Ensure we don't insert null intervals.
                             if fromAddr == toAddr:
                                 toAddr += 1
                             self.line_tree.addi(fromAddr, toAddr, info)

--- a/pyocd/debug/elf/elf_reader.py
+++ b/pyocd/debug/elf/elf_reader.py
@@ -35,6 +35,9 @@ class ElfReaderContext(DebugContext):
         for sect in [s for s in self._elf.sections if (s.region and s.region.is_flash)]:
             start = sect.start
             length = sect.length
+            # Skip empty sections.
+            if length == 0:
+                continue
             sect.data # Go ahead and read the data from the file.
             self._tree.addi(start, start + length, sect)
             LOG.debug("created flash section [%x:%x] for section %s", start, start + length, sect.name)


### PR DESCRIPTION
Fixed bugs:
1. Fixed null interval error in `ElfReaderContext` that would occur if there was an empty (zero size) section with attributes making it loadable and a base address within a flash memory region.
2. Fix name error in `CortexM._map_from_vector_catch_mask()` caused by a typo.
3. Fix regression in `Breakpoint.__repr__()` due to breakpoint types being changes to enum.
4. Fix reference to outdated `MemoryMap.get_region_by_name()` in `user_script.md`.
