### PR TITLE
Reset subcommand and commander improvements

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -177,6 +177,20 @@ Which type of reset to use by default (one of 'default', 'hw', 'sw', 'sw_sysrese
 'sw_vectreset', 'sw_emulated').
 </td></tr>
 
+<tr><td>reset.hold_time</td>
+<td>float</td>
+<td>0.1</td>
+<td>
+Number of seconds to hold hardware reset asserted.
+</td></tr>
+
+<tr><td>reset.post_delay</td>
+<td>float</td>
+<td>0.1</td>
+<td>
+Number of seconds to delay after a reset is issued.
+</td></tr>
+
 <tr><td>resume_on_disconnect</td>
 <td>bool</td>
 <td>True</td>
@@ -344,6 +358,24 @@ The source letters are:
 <td>
 When set to True, XPSR and CONTROL registers will have their respective bitfields defined for
 presentation in gdb.
+</td></tr>
+
+</table>
+
+## J-Link probe options
+
+These user options apply to SEGGER J-Link debug probes
+
+<table>
+
+<tr><th>Option Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
+
+<tr><td>jlink.power</td>
+<td>bool</td>
+<td>True</td>
+<td>
+Enable target power when connecting via a JLink probe, and disable power when disconnecting.
+Default is True.
 </td></tr>
 
 </table>

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -517,9 +517,10 @@ class PyOCDTool(object):
                             unique_id=self._args.unique_id,
                             target_override=self._args.target_override,
                             frequency=self._args.frequency,
-                            blocking=False,
+                            blocking=(not self._args.no_wait),
                             options=convert_session_options(self._args.options))
         if session is None:
+            LOG.error("No device available to flash")
             sys.exit(1)
         with session:
             programmer = FileProgrammer(session,
@@ -551,9 +552,10 @@ class PyOCDTool(object):
                             unique_id=self._args.unique_id,
                             target_override=self._args.target_override,
                             frequency=self._args.frequency,
-                            blocking=False,
+                            blocking=(not self._args.no_wait),
                             options=convert_session_options(self._args.options))
         if session is None:
+            LOG.error("No device available to erase")
             sys.exit(1)
         with session:
             mode = self._args.erase_mode or FlashEraser.Mode.SECTOR
@@ -582,9 +584,10 @@ class PyOCDTool(object):
                             unique_id=self._args.unique_id,
                             target_override=self._args.target_override,
                             frequency=self._args.frequency,
-                            blocking=False,
+                            blocking=(not self._args.no_wait),
                             options=convert_session_options(self._args.options))
         if session is None:
+            LOG.error("No device available to reset")
             sys.exit(1)
         try:
             # Handle hw reset specially using the probe, so we don't need a valid connection

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -68,6 +68,10 @@ OPTIONS_INFO = {
     'reset_type': OptionInfo('reset_type', str, 'default',
         "Which type of reset to use by default ('default', 'hw', 'sw', 'sw_sysresetreq', "
         "'sw_vectreset', 'sw_emulated'). The default is 'sw'."),
+    'reset.hold_time': OptionInfo('reset.hold_time', float, 0.1,
+        "Number of seconds to hold hardware reset asserted. Default is 0.1 s (100 ms)."),
+    'reset.post_delay': OptionInfo('reset.post_delay', float, 0.1,
+        "Number of seconds to delay after a reset is issued. Default is 0.1 s (100 ms)."),
     'resume_on_disconnect': OptionInfo('resume_on_disconnect', bool, True,
         "Whether to run target on disconnect."),
     'smart_flash': OptionInfo('smart_flash', bool, True,

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018 Arm Limited
+# Copyright (c) 2018-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
+from time import sleep
+
 from .debug_probe import DebugProbe
 from ..core import exceptions
 from .pydapaccess import DAPAccess
 from ..board.mbed_board import MbedBoard
 from ..board.board_ids import BOARD_ID_TO_INFO
-import six
 
 class CMSISDAPProbe(DebugProbe):
     """! @brief Wraps a pydapaccess link as a DebugProbe.
@@ -215,7 +217,10 @@ class CMSISDAPProbe(DebugProbe):
     def reset(self):
         try:
             self._invalidate_cached_registers()
-            self._link.reset()
+            self._link.assert_reset(True)
+            sleep(self.session.options.get('reset.hold_time'))
+            self._link.assert_reset(False)
+            sleep(self.session.options.get('reset.post_delay'))
         except DAPAccess.Error as exc:
             six.raise_from(self._convert_exception(exc), exc)
 

--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -223,19 +223,22 @@ class JLinkProbe(DebugProbe):
 
     def reset(self):
         try:
-            self._link.reset(halt=False)
-
             self._invalidate_cached_registers()
+
+            self._link.set_reset_pin_low()
+            sleep(self.session.options.get('reset.hold_time'))
+            self._link.set_reset_pin_high()
+            sleep(self.session.options.get('reset.post_delay'))
         except JLinkException as exc:
             six.raise_from(self._convert_exception(exc), exc)
 
     def assert_reset(self, asserted):
         try:
+            self._invalidate_cached_registers()
             if asserted:
                 self._link.set_reset_pin_low()
             else:
                 self._link.set_reset_pin_high()
-            self._invalidate_cached_registers()
         except JLinkException as exc:
             six.raise_from(self._convert_exception(exc), exc)
     

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -605,13 +605,6 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     def get_unique_id(self):
         return self._unique_id
 
-    def reset(self):
-        self.flush()
-        self._protocol.set_swj_pins(0, Pin.nRESET)
-        time.sleep(0.1)
-        self._protocol.set_swj_pins(Pin.nRESET, Pin.nRESET)
-        time.sleep(0.1)
-
     def assert_reset(self, asserted):
         self.flush()
         if asserted:

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2018-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
+from time import sleep
+
 from .debug_probe import DebugProbe
 from ..core.memory_interface import MemoryInterface
 from ..core import exceptions
@@ -24,7 +27,6 @@ from .stlink.detect.factory import create_mbed_detector
 from ..board.mbed_board import MbedBoard
 from ..board.board_ids import BOARD_ID_TO_INFO
 from ..utility import conversion
-import six
 
 class StlinkProbe(DebugProbe):
     """! @brief Wraps an STLink as a DebugProbe."""
@@ -136,7 +138,10 @@ class StlinkProbe(DebugProbe):
         self._link.set_swd_frequency(frequency)
 
     def reset(self):
-        self._link.target_reset()
+        self._link.drive_nreset(True)
+        sleep(self.session.options.get('reset.hold_time'))
+        self._link.drive_nreset(False)
+        sleep(self.session.options.get('reset.post_delay'))
 
     def assert_reset(self, asserted):
         self._link.drive_nreset(asserted)

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -25,6 +25,7 @@ from optparse import make_option
 import six
 import prettytable
 import traceback
+import pprint
 
 # Attempt to import readline.
 try:
@@ -49,6 +50,7 @@ from ..utility import (mask, conversion)
 from ..utility.cmdline import convert_session_options
 from ..utility.hex import (format_hex_width, dump_hex_data)
 from ..utility.progress import print_progress
+from ..utility.compatibility import get_terminal_size
 
 # Make disasm optional.
 try:
@@ -1480,7 +1482,8 @@ class PyOCDCommander(object):
                 if isinstance(result, six.integer_types):
                     print("0x%08x (%d)" % (result, result))
                 else:
-                    print(result)
+                    w, h = get_terminal_size()
+                    pprint.pprint(result, indent=2, width=w, depth=10)
         except Exception as e:
             print("Exception while executing expression:", e)
             if session.Session.get_current().log_tracebacks:

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -402,6 +402,10 @@ INFO_HELP = {
             'aliases' : [],
             'help' : "Display the current HPROT value used by the selected MEM-AP."
             },
+        'graph' : {
+            'aliases' : [],
+            'help' : "Print the target object graph."
+            },
         }
 
 OPTION_HELP = {
@@ -650,6 +654,7 @@ class PyOCDCommander(object):
                 'mem-ap' :              self.handle_show_ap,
                 'hnonsec' :             self.handle_show_hnonsec,
                 'hprot' :               self.handle_show_hprot,
+                'graph' :               self.handle_show_graph,
             }
         self.option_list = {
                 'vector-catch' :        self.handle_set_vectorcatch,
@@ -1783,6 +1788,9 @@ class PyOCDCommander(object):
                 bitvalue,
                 HPROT_BIT_DESC[bitnum][bitvalue])
         print(desc, end='')
+
+    def handle_show_graph(self, args):
+        self.board.dump()
 
     def handle_set(self, args):
         if len(args) < 1:

--- a/pyocd/utility/compatibility.py
+++ b/pyocd/utility/compatibility.py
@@ -66,3 +66,29 @@ if not PY3:
 
 # Symbol to reference either the builtin FNF or our custom subclass.
 FileNotFoundError_ = FileNotFoundError
+
+try:
+    from shutil import get_terminal_size
+except ImportError:
+    # From http://stackoverflow.com/a/566752/2646228
+    def get_terminal_size():
+        import os
+        env = os.environ
+        def ioctl_GWINSZ(fd):
+            try:
+                import fcntl, termios, struct, os
+                cr = struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
+            except:
+                return
+            return cr
+        cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
+        if not cr:
+            try:
+                fd = os.open(os.ctermid(), os.O_RDONLY)
+                cr = ioctl_GWINSZ(fd)
+                os.close(fd)
+            except:
+                pass
+        if not cr:
+            cr = (env.get('LINES', 25), env.get('COLUMNS', 80))
+        return int(cr[1]), int(cr[0])


### PR DESCRIPTION
Added a `reset` subcommand and some related improvements.

- `reset.hold_time` and `reset.post_delay` options to control the hold time and post-delay for hardware reset.
- `flash`, `erase, and `reset` commands are now blocking by default (they wait for you to plug a board in if none is connected).

Plus a couple small improvements for commander:
1. Pretty-printing of values returned from Python expressions ("$"-prefixed Python expressions entered at the commander prompt).
2. `show graph` command that prints out the pyocd object model graph.