### PR TITLE
Commander changes plus some misc changes and fixes

### DIFF
--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -245,6 +245,9 @@ class Session(Notifier):
             # Set a different default for disabling existing loggers.
             if 'disable_existing_loggers' not in config:
                 config['disable_existing_loggers'] = False
+            # Remove an empty 'loggers' key.
+            if ('loggers' in config) and (config['loggers'] is None):
+                del config['loggers']
             
             try:
                 logging.config.dictConfig(config)

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -252,7 +252,7 @@ class DebugPort(object):
     def flush(self):
         try:
             self.probe.flush()
-        except exceptions.ProbeError as error:
+        except exceptions.TargetError as error:
             self._handle_error(error, self.next_access_number)
             raise
 
@@ -356,7 +356,7 @@ class DebugPort(object):
 
         try:
             result_cb = self.probe.read_dp(addr & DPADDR_MASK, now=False)
-        except exceptions.ProbeError as error:
+        except exceptions.TargetError as error:
             self._handle_error(error, num)
             raise
 
@@ -366,7 +366,7 @@ class DebugPort(object):
                 result = result_cb()
                 TRACE.debug("read_dp:%06d %s(addr=0x%08x) -> 0x%08x", num, "" if now else "...", addr, result)
                 return result
-            except exceptions.ProbeError as error:
+            except exceptions.TargetError as error:
                 self._handle_error(error, num)
                 raise
 
@@ -387,7 +387,7 @@ class DebugPort(object):
         try:
             TRACE.debug("write_dp:%06d (addr=0x%08x) = 0x%08x", num, addr, data)
             self.probe.write_dp(addr & DPADDR_MASK, data)
-        except exceptions.ProbeError as error:
+        except exceptions.TargetError as error:
             self._handle_error(error, num)
             raise
 
@@ -400,7 +400,7 @@ class DebugPort(object):
         try:
             TRACE.debug("write_ap:%06d (addr=0x%08x) = 0x%08x", num, addr, data)
             self.probe.write_ap(addr, data)
-        except exceptions.ProbeError as error:
+        except exceptions.TargetError as error:
             self._handle_error(error, num)
             raise
 
@@ -412,7 +412,7 @@ class DebugPort(object):
 
         try:
             result_cb = self.probe.read_ap(addr, now=False)
-        except exceptions.ProbeError as error:
+        except exceptions.TargetError as error:
             self._handle_error(error, num)
             raise
 
@@ -422,7 +422,7 @@ class DebugPort(object):
                 result = result_cb()
                 TRACE.debug("read_ap:%06d %s(addr=0x%08x) -> 0x%08x", num, "" if now else "...", addr, result)
                 return result
-            except exceptions.ProbeError as error:
+            except exceptions.TargetError as error:
                 self._handle_error(error, num)
                 raise
 

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -267,6 +267,9 @@ class GDBServer(threading.Thread):
 
     def run(self):
         LOG.info('GDB server started on port %d (core %d)', self.port, self.core)
+        
+        # Make sure the target is halted. Otherwise gdb gets easily confused.
+        self.target.halt()
 
         while True:
             try:

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -128,7 +128,7 @@ COMMAND_INFO = {
             'help' : "Unlock security on the target"
             },
         'status' : {
-            'aliases' : ['stat'],
+            'aliases' : ['stat', 'st'],
             'args' : "",
             'help' : "Show the target's current state"
             },
@@ -579,6 +579,7 @@ class PyOCDCommander(object):
                 'unlock' :  self.handle_unlock,
                 'status' :  self.handle_status,
                 'stat' :    self.handle_status,
+                'st' :      self.handle_status,
                 'reg' :     self.handle_reg,
                 'wreg' :    self.handle_write_reg,
                 'reset' :   self.handle_reset,
@@ -851,16 +852,12 @@ class PyOCDCommander(object):
         ConnectHelper.list_connected_probes()
 
     def handle_status(self, args):
-        if self.target.is_locked():
-            print("Security:       Locked")
-        else:
-            print("Security:       Unlocked")
-        if isinstance(self.target, target_kinetis.Kinetis):
-            print("MDM-AP Status:  0x%08x" % self.target.mdm_ap.read_reg(target_kinetis.MDM_STATUS))
         if not self.target.is_locked():
             for i, c in enumerate(self.target.cores):
                 core = self.target.cores[c]
-                print("Core %d status:  %s" % (i, CORE_STATUS_DESC[core.get_state()]))
+                print("Core %d:  %s" % (i, CORE_STATUS_DESC[core.get_state()]))
+        else:
+            print("Target is locked")
 
     def handle_reg(self, args):
         # If there are no args, print all register values.

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -1520,6 +1520,7 @@ class PyOCDCommander(object):
         addr = self.convert_value(args[0])
         data = self.convert_value(args[1])
         self.target.dp.write_reg(addr, data)
+        self.target.flush()
 
     def handle_readap(self, args):
         if len(args) < 1:
@@ -1547,6 +1548,7 @@ class PyOCDCommander(object):
             data_arg = 2
         data = self.convert_value(args[data_arg])
         self.target.dp.write_ap(addr, data)
+        self.target.flush()
 
     def handle_initdp(self, args):
         self.target.dp.init()

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -415,6 +415,10 @@ INFO_HELP = {
             'aliases' : [],
             'help' : "Print the target object graph."
             },
+        'locked' : {
+            'aliases' : [],
+            'help' : "Report whether the target is locked."
+            },
         }
 
 OPTION_HELP = {
@@ -665,6 +669,7 @@ class PyOCDCommander(object):
                 'hnonsec' :             self.handle_show_hnonsec,
                 'hprot' :               self.handle_show_hprot,
                 'graph' :               self.handle_show_graph,
+                'locked' :              self.handle_show_locked,
             }
         self.option_list = {
                 'vector-catch' :        self.handle_set_vectorcatch,
@@ -1809,6 +1814,12 @@ class PyOCDCommander(object):
 
     def handle_show_graph(self, args):
         self.board.dump()
+    
+    def handle_show_locked(self, args):
+        if self.target.is_locked():
+            print("Taget is locked")
+        else:
+            print("Taget is unlocked")
 
     def handle_set(self, args):
         if len(args) < 1:

--- a/pyocd/utility/autoflush.py
+++ b/pyocd/utility/autoflush.py
@@ -1,0 +1,45 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..core import exceptions
+
+class Autoflush(object):
+    """! @brief Context manager for performing flushes.
+    
+    Pass a Target instance to the constructor, and when the context exits, the target will be
+    automatically flushed. If a TransferError or subclass, such as TransferFaultError, is raised
+    within the context, then the flush will be skipped.
+    
+    The parameter passed to the constructor can actually be any object with a `flush()` method,
+    due to Python's dynamic dispatch.
+    """
+    
+    def __init__(self, target):
+        """! @brief Constructor.
+        
+        @param self The object.
+        @param target Object on which the flush will be performed. Normally this is a Target
+            instance.
+        """
+        self._target = target
+    
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if type is None or not issubclass(type, exceptions.TransferError):
+            self._target.flush()
+        return False

--- a/pyocd/utility/hex.py
+++ b/pyocd/utility/hex.py
@@ -60,15 +60,7 @@ def dump_hex_data(data, start_address=0, width=8, output=None, print_ascii=True)
     
     The output is always terminated with a newline.
     
-    If you want a string instead of output to a file, you can use `io.StringIO` as such:
-    
-    ```py
-    import io
-    
-    sio = io.StringIO()
-    dump_hex_data(data, output=sio)
-    my_hex_dump = sio.getvalue()
-    ```
+    If you want a string instead of output to a file, use the dump_hex_data_to_str() function.
     
     @param data The data to print as hex. Can be a `bytes`, `bytearray`, or list of integers.
     @param start_address Address of the first byte of the data. Defaults to 0. If set to None,
@@ -124,3 +116,11 @@ def dump_hex_data(data, start_address=0, width=8, output=None, print_ascii=True)
             output.write("   " + s)
         
         output.write("\n")
+
+def dump_hex_data_to_str(data, **kwargs):
+    """! @brief Returns a string with data formatted as hex.
+    @see dump_hex_data()
+    """
+    sio = io.StringIO()
+    dump_hex_data(data, output=sio, **kwargs)
+    return sio.getvalue()

--- a/test/unit/test_autoflush.py
+++ b/test/unit/test_autoflush.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2016-2020 Arm Limited
+# Copyright (c) 2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,21 +15,25 @@
 # limitations under the License.
 
 import pytest
-import logging
 
-# unittest.mock is available from Python 3.3.
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from .conftest import mock
 
-from .mockcore import MockCore
+from pyocd.core.exceptions import TransferError
+from pyocd.utility.autoflush import Autoflush
 
 @pytest.fixture(scope='function')
-def mockcore():
-    return MockCore()
+def mock_obj():
+    return mock.Mock()
 
-# Ignore semihosting test that currently crashes on Travis
-collect_ignore = [
-    "test_semihosting.py",
-    ]
+class TestAutoflush:
+    def test_flushed(self, mock_obj):
+        with Autoflush(mock_obj):
+            pass
+        assert mock_obj.flush.called
+
+    def test_transfer_err_not_flushed(self, mock_obj):
+        with pytest.raises(TransferError):
+            with Autoflush(mock_obj):
+                raise TransferError("bad joojoo")
+        assert mock_obj.flush.not_called
+

--- a/test/unit/test_compatibility.py
+++ b/test/unit/test_compatibility.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019 Arm Limited
+# Copyright (c) 2019-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@ from pyocd.utility.compatibility import (
     iter_single_bytes,
     to_bytes_safe,
     to_str_safe,
+    get_terminal_size,
 )
 
 class TestCompatibility(object):
@@ -51,3 +52,10 @@ class TestCompatibility(object):
             assert to_str_safe("string") == "string"
             assert to_str_safe(u"string") == "string"
             assert to_str_safe(u'System Administrator\u2019s Mouse') == 'System Administrator\xe2\x80\x99s Mouse'
+
+    def test_get_terminal_size(self):
+        tsz = get_terminal_size()
+        assert isinstance(tsz, tuple)
+        assert len(tsz) == 2
+        assert isinstance(tsz[0], int)
+        assert isinstance(tsz[1], int)

--- a/test/unit/test_rom_table.py
+++ b/test/unit/test_rom_table.py
@@ -18,11 +18,7 @@ import pytest
 import logging
 from intervaltree import (Interval, IntervalTree)
 
-# unittest.mock is available from Python 3.3.
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from .conftest import mock
 
 from pyocd.coresight.component import CoreSightCoreComponent
 from pyocd.core import memory_map


### PR DESCRIPTION
Fixes:
- Fix incorrect `DebugPort` exception handlers. This could have caused certain faults to not be properly cleared.
- The gdbserver ensures the target is halted when gdb connects. If the target is not halted, gdb fails to read initial target state and gets seriously confused.

Commander changes:
- Add flush after DP and AP register writes.
- `reg` and `wreg` changes:
    - `reg` only shows fields when `-f` is set. It used to always show fields when reading one peripheral register.
    - `wreg` gains a `-r` option for controlling readback. It used to always perform a readback when modifying a peripheral register, which could produce undesirable effects.
    - Flushing after register writes.
- `status` command changes:
    - Added `st` alias.
    - `status` outputs only core status only, though if the target is locked it will say so.
- Added `show locked` to report the target locked status (currently only supported by NXP Kinetis and Nordic nRF52 devices).

Other changes:
- Add `dump_hex_data_to_str()` utility function.
- Ignore empty 'logging.loggers' yaml key when configuring logging.
- Added `Autoflush` context manager that will flush the target for you upon exit.
- Unit test for autoflusher.
- Unit test for `get_terminal_size()` utility.