### PR TITLE
Core architecture

### DIFF
--- a/pyocd/coresight/core_ids.py
+++ b/pyocd/coresight/core_ids.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 019 Arm Limited
+# Copyright (c) 2019 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from enum import Enum
 
 # pylint: disable=invalid_name
 
@@ -41,3 +43,12 @@ CORE_TYPE_NAME = {
                  ARM_CortexM33 : "Cortex-M33",
                  ARM_CortexM35P : "Cortex-M35P",
                }
+
+class CoreArchitecture(Enum):
+    """! @brief CPU architectures."""
+    ARMv6M = 1
+    ARMv7M = 2
+    ARMv8M_BASE = 3
+    ARMv8M_MAIN = 4
+    
+

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -198,7 +198,6 @@ class CortexM(Target, CoreSightCoreComponent):
 
     # Debug Fault Status Register
     DFSR = 0xE000ED30
-    DFSR_PMU = (1 << 5)
     DFSR_EXTERNAL = (1 << 4)
     DFSR_VCATCH = (1 << 3)
     DFSR_DWTTRAP = (1 << 2)

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -398,7 +398,6 @@ class CortexM(Target, CoreSightCoreComponent):
         Target.__init__(self, session, memoryMap)
         CoreSightCoreComponent.__init__(self, ap, cmpid, address)
 
-        self.arch = 0
         self._architecture = None
         self.core_type = 0
         self.has_fpu = False
@@ -559,7 +558,7 @@ class CortexM(Target, CoreSightCoreComponent):
             append_regs(self.regs_xpsr_control_plain, xml_regs_general)
         
         # Check if target has ARMv7 registers
-        if self.arch == CortexM.ARMv7M:
+        if self.architecture == CoreArchitecture.ARMv7M:
             append_regs(self.regs_system_armv7_only, xml_regs_general)
         # Check if target has FPU registers
         if self.has_fpu:
@@ -579,14 +578,14 @@ class CortexM(Target, CoreSightCoreComponent):
         if implementer != CortexM.CPUID_IMPLEMENTER_ARM:
             LOG.warning("CPU implementer is not ARM!")
 
-        self.arch = (cpuid & CortexM.CPUID_ARCHITECTURE_MASK) >> CortexM.CPUID_ARCHITECTURE_POS
+        arch = (cpuid & CortexM.CPUID_ARCHITECTURE_MASK) >> CortexM.CPUID_ARCHITECTURE_POS
         self.core_type = (cpuid & CortexM.CPUID_PARTNO_MASK) >> CortexM.CPUID_PARTNO_POS
         
         self.cpu_revision = (cpuid & CortexM.CPUID_VARIANT_MASK) >> CortexM.CPUID_VARIANT_POS
         self.cpu_patch = (cpuid & CortexM.CPUID_REVISION_MASK) >> CortexM.CPUID_REVISION_POS
         
         # Only v7-M supports VECTRESET.
-        if self.arch == CortexM.ARMv7M:
+        if arch == CortexM.ARMv7M:
             self._architecture = CoreArchitecture.ARMv7M
             self._supports_vectreset = True
         else:
@@ -602,7 +601,8 @@ class CortexM(Target, CoreSightCoreComponent):
         
         The core architecture must have been identified prior to calling this function.
         """
-        if self.arch != CortexM.ARMv7M:
+        # FPU is not supported in these architectures.
+        if self.architecture in (CoreArchitecture.ARMv6M, CoreArchitecture.ARMv8M_BASE):
             self.has_fpu = False
             return
 

--- a/pyocd/coresight/cortex_m_v8m.py
+++ b/pyocd/coresight/cortex_m_v8m.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019 Arm Limited
+# Copyright (c) 2019-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 import logging
 
 from .cortex_m import CortexM
-from .core_ids import CORE_TYPE_NAME
+from .core_ids import (CORE_TYPE_NAME, CoreArchitecture)
 from ..core import exceptions
 from ..core.target import Target
 
@@ -75,6 +75,11 @@ class CortexM_v8M(CortexM):
         
         pfr1 = self.read32(self.PFR1)
         self.has_security_extension = ((pfr1 & self.PFR1_SECURITY_MASK) >> self.PFR1_SECURITY_SHIFT) == 1
+        
+        if self.arch == self.ARMv8M_BASE:
+            self._architecture = CoreArchitecture.ARMv8M_BASE
+        else:
+            self._architecture = CoreArchitecture.ARMv8M_MAIN
         
         if self.core_type in CORE_TYPE_NAME:
             if self.has_security_extension:

--- a/pyocd/coresight/cortex_m_v8m.py
+++ b/pyocd/coresight/cortex_m_v8m.py
@@ -67,7 +67,7 @@ class CortexM_v8M(CortexM):
         if implementer != CortexM.CPUID_IMPLEMENTER_ARM:
             LOG.warning("CPU implementer is not ARM!")
 
-        self.arch = (cpuid & CortexM.CPUID_ARCHITECTURE_MASK) >> CortexM.CPUID_ARCHITECTURE_POS
+        arch = (cpuid & CortexM.CPUID_ARCHITECTURE_MASK) >> CortexM.CPUID_ARCHITECTURE_POS
         self.core_type = (cpuid & CortexM.CPUID_PARTNO_MASK) >> CortexM.CPUID_PARTNO_POS
         
         self.cpu_revision = (cpuid & CortexM.CPUID_VARIANT_MASK) >> CortexM.CPUID_VARIANT_POS
@@ -76,7 +76,7 @@ class CortexM_v8M(CortexM):
         pfr1 = self.read32(self.PFR1)
         self.has_security_extension = ((pfr1 & self.PFR1_SECURITY_MASK) >> self.PFR1_SECURITY_SHIFT) == 1
         
-        if self.arch == self.ARMv8M_BASE:
+        if arch == self.ARMv8M_BASE:
             self._architecture = CoreArchitecture.ARMv8M_BASE
         else:
             self._architecture = CoreArchitecture.ARMv8M_MAIN


### PR DESCRIPTION
Replaced the `CortexM.arch` attribute (which was just an int) with a property that is a `CoreArchitecture` enum. The `arch` attribute did not distinguish between v6/7-M and v8-M since those architectures have the same values in the CPUID register.

The `CoreArchitecture` enum has this definition:
```py
class CoreArchitecture(Enum):
    ARMv6M = 1
    ARMv7M = 2
    ARMv8M_BASE = 3
    ARMv8M_MAIN = 4
```

Moved the code to detect the PMU halt reason to `CortexM_v8M` since it is only supported on v8.1-M cores.