### PR TITLE
Fixed invalid reference to DFSR_PMU constant from CortexM

### DIFF
--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -1346,8 +1346,6 @@ class CortexM(Target, CoreSightCoreComponent):
             reason = Target.HaltReason.VECTOR_CATCH
         elif dfsr & CortexM.DFSR_EXTERNAL:
             reason = Target.HaltReason.EXTERNAL
-        elif dfsr & CortexM.DFSR_PMU:
-            reason = Target.HaltReason.PMU
         else:
             reason = None
         return reason


### PR DESCRIPTION
Regression introduced into v0.26.0.

Reported by @Hoohaha in #865 