### PR TITLE
Fix read_memory_block32 size in ElfReaderContext

### DIFF
--- a/pyocd/debug/elf/elf_reader.py
+++ b/pyocd/debug/elf/elf_reader.py
@@ -80,5 +80,5 @@ class ElfReaderContext(DebugContext):
         return list(data)
 
     def read_memory_block32(self, addr, size):
-        return conversion.byte_list_to_u32le_list(self.read_memory_block8(addr, size))
+        return conversion.byte_list_to_u32le_list(self.read_memory_block8(addr, size * 4))
 


### PR DESCRIPTION
I was hitting some semihosting issues running pyocd like this:

`pyocd gdbserver --target <target> --elf <elf_file> -S`

It turns out there is a small size issue in `ElfReaderContext::read_memory_block32()`. In my case it works also if I remove the `--elf <elf_file>` argument.