### PR TITLE
Several flash related fixes

### DIFF
--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -135,7 +135,6 @@ class CoreSightTarget(Target, GraphNode):
     def create_init_sequence(self):
         seq = CallSequence(
             ('load_svd',            self.load_svd),
-            ('create_flash',        self.create_flash),
             ('pre_connect',         self.pre_connect),
             ('dp_init',             self.dp.init_sequence),
             ('create_discoverer',   self.create_discoverer),
@@ -144,6 +143,7 @@ class CoreSightTarget(Target, GraphNode):
             ('halt_on_connect',     self.perform_halt_on_connect),
             ('post_connect',        self.post_connect),
             ('post_connect_hook',   self.post_connect_hook),
+            ('create_flash',        self.create_flash),
             ('notify',              lambda : self.session.notify(Target.Event.POST_CONNECT, self))
             )
         

--- a/pyocd/flash/builder.py
+++ b/pyocd/flash/builder.py
@@ -218,7 +218,11 @@ class FlashBuilder(object):
         memory mapped and accessible.
         """
         if not self.algo_inited_for_read:
-            self.flash.init(self.flash.Operation.VERIFY)
+            try:
+                self.flash.init(self.flash.Operation.VERIFY)
+            except FlashFailure:
+                # If initing for verify fails, then try again in erase mode.
+                self.flash.init(self.flash.Operation.ERASE)
             self.algo_inited_for_read = True
 
     def _build_sectors_and_pages(self, keep_unwritten):

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -714,12 +714,13 @@ class GDBServer(threading.Thread):
         elif b'FlashDone' in ops :
             # Only program if we received data.
             if self.flash_loader is not None:
-                # Write all buffered flash contents.
-                self.flash_loader.commit()
-
-                # Set flash loader to None so that on the next flash command a new
-                # object is used.
-                self.flash_loader = None
+                try:
+                    # Write all buffered flash contents.
+                    self.flash_loader.commit()
+                finally:
+                    # Set flash loader to None so that on the next flash command a new
+                    # object is used.
+                    self.flash_loader = None
 
             self.first_run_after_reset_or_flash = True
             if self.thread_provider is not None:

--- a/pyocd/target/builtin/target_MKL28Z512xxx7.py
+++ b/pyocd/target/builtin/target_MKL28Z512xxx7.py
@@ -132,14 +132,12 @@ class Flash_kl28z(Flash_Kinetis):
         self._saved_firccsr = 0
         self._saved_rccr = 0
 
-    def prepare_target(self, operation, address=None, clock=0, reset=True):
+    def prepare_target(self):
         """!
         This function sets up target clocks to ensure that flash is clocked at the maximum
         of 24MHz. Doing so gets the best flash programming performance. The FIRC clock source
         is used so that there is no dependency on an external crystal frequency.
         """
-        super(Flash_kl28z, self).init(operation, address, clock, reset)
-
         # Enable FIRC.
         value = self.target.read32(SCG_FIRCCSR)
         self._saved_firccsr = value

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -1028,7 +1028,10 @@ class PyOCDCommander(object):
         region = self.session.target.memory_map.get_region_for_address(addr)
         flash_init_required =  region is not None and region.is_flash and not region.is_powered_on_boot and region.flash is not None
         if flash_init_required:
-            region.flash.init(region.flash.Operation.VERIFY)
+            try:
+                region.flash.init(region.flash.Operation.VERIFY)
+            except exceptions.FlashFailure:
+                region.flash.init(region.flash.Operation.ERASE)
 
         data = bytearray(self.target.aps[self.selected_ap].read_memory_block8(addr, count))
 
@@ -1082,7 +1085,10 @@ class PyOCDCommander(object):
         region = self.session.target.memory_map.get_region_for_address(addr)
         flash_init_required =  region is not None and region.is_flash and not region.is_powered_on_boot and region.flash is not None
         if flash_init_required:
-            region.flash.init(region.flash.Operation.VERIFY)
+            try:
+                region.flash.init(region.flash.Operation.VERIFY)
+            except exceptions.FlashFailure:
+                region.flash.init(region.flash.Operation.ERASE)
 
         with open(filename, 'rb') as f:
             file_data = f.read(length)


### PR DESCRIPTION
1. Work around cases where initing the flash algo in VERIFY mode fails by attempting to reinit in ERASE mode.
2. If the gdbserver gets an exception while programming flash, it deletes the `FlashLoader` instance it was using. This prevents conflicts when trying to add data to the stale `FlashLoader` if another attempt is made to program flash.
3. Moved the `create_flash` init task to the end of the init sequence, just prior to the post-connect notification. This allows the memory map to be modified or replaced during initialization without losing existing flash instances.
4. Fixed the `Flash_kl28z.prepare_target()` method signature. Thanks to @Hoohaha for this fix.

Fixes #851 
Fixes #865 