### PR TITLE
Fix several DFP region creation bugs

### DIFF
--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -529,7 +529,7 @@ class CmsisPackDevice(object):
             return Target.ResetType.SW
     
     def __repr__(self):
-        return "<%s@%x %s %s>" % (self.__class__.__name__, id(self), self.part_number, self._info)
+        return "<%s@%x %s>" % (self.__class__.__name__, id(self), self.part_number)
         
         
 

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -400,16 +400,19 @@ class CmsisPackDevice(object):
             # algo for all sector sizes.
             algo = packAlgo.get_pyocd_flash_algo(page_size, self._default_ram)
 
-            # Create a separate flash region for each sector size range.
-            for i, sectorInfo in enumerate(packAlgo.sector_sizes):
+            # Create a separate flash region for each sector size range. The sector_sizes attribute
+            # is a list of bi-tuples of (start-address, sector-size), sorted by start address.
+            for j, sectorInfo in enumerate(packAlgo.sector_sizes):
+                # Unpack this sector range's start address and sector size.
                 start, sector_size = sectorInfo
-                if i + 1 >= len(packAlgo.sector_sizes):
-                    nextStart = region.length
-                else:
-                    nextStart, _ = packAlgo.sector_sizes[i + 1]
                 
-                length = nextStart - start
-                start += region.start
+                # Determine the end address of the this sector range. For the last range, the end
+                # is just the end of the entire region. Otherwise it's the start of the next
+                # range - 1.
+                if j + 1 >= len(packAlgo.sector_sizes):
+                    end = region.end
+                else:
+                    end = packAlgo.sector_sizes[j + 1][0] - 1
                 
                 # Limit page size.
                 if page_size > sector_size:
@@ -431,7 +434,7 @@ class CmsisPackDevice(object):
                 rangeRegion = FlashRegion(name=region.name,
                                 access=region.access,
                                 start=start,
-                                length=length,
+                                end=end,
                                 sector_size=sector_size,
                                 page_size=region_page_size,
                                 flm=packAlgo,

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -179,7 +179,6 @@ class PackTargets(object):
             if tgt is None:
                 return
             part = dev.part_number.lower()
-            LOG.debug("Loading target '%s' from CMSIS-Pack", part)
 
             # Make sure there isn't a duplicate target name.
             if part not in TARGET:

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -200,7 +200,9 @@ class PackTargets(object):
         if not isinstance(pack_list, (list, tuple)):
             pack_list = [pack_list]
         for pack_or_path in pack_list:
-            if not isinstance(pack_or_path, CmsisPack):
+            if isinstance(pack_or_path, CmsisPack):
+                pack = pack_or_path
+            else:
                 pack = CmsisPack(pack_or_path)
             for dev in pack.devices:
                 PackTargets.populate_device(dev)


### PR DESCRIPTION
1. Fix bugs with computing of addresses of flash regions for different sector-size ranges.
2. Fix parameter handling bug in `PackTargets.populate_targets_from_pack()`.
3. Removed unhelpful `_info` attribute from `CmsisPackDevice` repr.
4. Include some memory regions defined in DFPs with a `Pname` attribute set. This is only a partial fix in that the memory regions will appear in the memory map, where a full fix would include support for core-specific memory maps.
5. Removed a debug log message for every target loaded from DFPs, which could cause a large spew of log messages.