### PR TITLE
CMSIS-DAP thread safety

### DIFF
--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -92,7 +92,7 @@ class DAPSWOMode:
     UART = 1
     MANCHESTER = 2
 
-# SWO control acions.
+# SWO control actions.
 class DAPSWOControl:
     STOP = 0
     START = 1

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -63,7 +63,7 @@ class DAPAccessIntf(object):
         pass
 
     class TransferError(CommandError):
-        """! @brief Error ocurred with a transfer over SWD or JTAG"""
+        """! @brief Error occurred with a transfer over SWD or JTAG"""
         pass
 
     class TransferTimeoutError(TransferError):
@@ -132,7 +132,7 @@ class DAPAccessIntf(object):
     #          Target control functions
     # ------------------------------------------- #
     def connect(self, port=None):
-        """! @brief Initailize DAP IO pins for JTAG or SWD"""
+        """! @brief Initialize DAP IO pins for JTAG or SWD"""
         raise NotImplementedError()
 
     def configure_swd(self, turnaround=1, always_send_data_phase=False):

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2006-2013,2018-2019 Arm Limited
+# Copyright (c) 2006-2013,2018-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -143,7 +143,7 @@ class _Transfer(object):
         if self._error is not None:
             # Pylint is confused and thinks self._error is None
             # since that is what it is initialized to.
-            # Supress warnings for this.
+            # Suppress warnings for this.
             # pylint: disable=raising-bad-type
             raise self._error
 
@@ -151,9 +151,9 @@ class _Transfer(object):
         return self._result
 
 class _Command(object):
-    """! @brief Wrapper object representing a command send to the layer below (ex. USB).
+    """! @brief Wrapper object representing a command sent to the layer below (ex. USB).
 
-    This class wraps the phyiscal commands DAP_Transfer and DAP_TransferBlock
+    This class wraps the physical commands DAP_Transfer and DAP_TransferBlock
     to provide a uniform way to build the command to most efficiently transfer
     the data supplied.  Register reads and writes individually or in blocks
     are added to a command object until it is full.  Once full, this class
@@ -450,7 +450,7 @@ class _Command(object):
         return data
 
 class DAPAccessCMSISDAP(DAPAccessIntf):
-    """! @brief An implementation of the DAPAccessIntf layer for DAPLINK boards
+    """! @brief An implementation of the DAPAccessIntf layer for DAPLink boards
     """
 
     # ------------------------------------------- #
@@ -628,7 +628,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     def set_deferred_transfer(self, enable):
         """! @brief Allow transfers to be delayed and buffered
 
-        By default deferred transfers are turned off.  All reads and
+        By default deferred transfers are turned on.  When off, all reads and
         writes will be completed by the time the function returns.
 
         When enabled packets are buffered and sent all at once, which
@@ -637,14 +637,6 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         memory write.  This means that an invalid write could cause an
         exception to occur on a later, unrelated write.  To guarantee
         that previous writes are complete call the flush() function.
-
-        The behaviour of read operations is determined by the modes
-        READ_START, READ_NOW and READ_END.  The option READ_NOW is the
-        default and will cause the read to flush all previous writes,
-        and read the data immediately.  To improve performance, multiple
-        reads can be made using READ_START and finished later with READ_NOW.
-        This allows the reads to be buffered and sent at once.  Note - All
-        READ_ENDs must be called before a call using READ_NOW can be made.
         """
         if self._deferred_transfer and not enable:
             self.flush()
@@ -854,7 +846,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     # ------------------------------------------- #
 
     def _init_deferred_buffers(self):
-        """! @brief Initialize or reinitalize all the deferred transfer buffers
+        """! @brief Initialize or reinitialize all the deferred transfer buffers
 
         Calling this method will drop all pending transactions
         so use with care.
@@ -917,7 +909,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     def _send_packet(self):
         """! @brief Send a single packet to the interface
 
-        This function guarentees that the number of packets
+        This function guarantees that the number of packets
         that are stored in daplink's buffer (the number of
         packets written but not read) does not exceed the
         number supported by the given device.
@@ -1000,7 +992,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         # clear all deferred buffers
         self._init_deferred_buffers()
         # finish all pending reads and ignore the data
-        # Only do this if the error is a tranfer error.
+        # Only do this if the error is a transfer error.
         # Otherwise this could cause another exception
         if isinstance(exception, DAPAccessIntf.TransferError):
             for _ in range(pending_reads):

--- a/pyocd/probe/pydapaccess/interface/common.py
+++ b/pyocd/probe/pydapaccess/interface/common.py
@@ -49,7 +49,7 @@ def is_known_cmsis_dap_vid_pid(vid, pid):
 def filter_device_by_class(vid, pid, device_class):
     """! @brief Test whether the device should be ignored by comparing bDeviceClass.
     
-    This function checks the device's bDeviceClass to determine whether the it is likely to be
+    This function checks the device's bDeviceClass to determine whether it is likely to be
     a CMSIS-DAP device. It uses the vid and pid for device-specific quirks.
     
     @retval True Skip the device.

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -49,7 +49,7 @@ class PyWinUSB(Interface):
         self.report = None
         # deque used here instead of synchronized Queue
         # since read speeds are ~10-30% faster and are
-        # comprable to a based list implmentation.
+        # comparable to a list based implementation.
         self.rcv_data = collections.deque()
         self.device = None
 

--- a/pyocd/utility/concurrency.py
+++ b/pyocd/utility/concurrency.py
@@ -1,0 +1,31 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import wraps
+
+def locked(func):
+    """! @brief Decorator to automatically lock a method of a class.
+    
+    The class is required to have `lock()` and `unlock()` methods.
+    """
+    @wraps(func)
+    def _locking(self, *args, **kwargs):
+        try:
+            self.lock()
+            return func(self, *args, **kwargs)
+        finally:
+            self.unlock()
+    return _locking


### PR DESCRIPTION
This PR adds a lock per instance of the `DAPAccessCMSISDAP` class to protect from concurrent transfers on multiple threads from the layers above.

Note that concurrent higher level operations are not protected by this patch. That will be coming in another PR.