### PR TITLE
Improve automated tests logging.

### DIFF
--- a/test/connect_test.py
+++ b/test/connect_test.py
@@ -141,10 +141,12 @@ def connect_test(board):
     live_board.target.reset()
     test_count += 1
     print("Verifying target is running")
-    if live_board.target.is_running() or live_board.target.get_state() == Target.State.SLEEPING:
+    current_state = live_board.target.get_state()
+    if live_board.target.is_running() or current_state == Target.State.SLEEPING:
         test_pass_count += 1
         print("TEST PASSED")
     else:
+        print("State=%s" % current_state)
         print("TEST FAILED")
     print("Disconnecting with resume=True")
     live_session.options['resume_on_disconnect'] = True

--- a/test/gdb_script.py
+++ b/test/gdb_script.py
@@ -85,7 +85,7 @@ monitor_commands = [
     "set step-into-interrupt on",
     "set step-into-interrupt off",
     # Invalid Command
-    "fawehfawoefhad"
+    "intentional_invalid_command_fawehfawoefhad"
 ]
 
 SIZE_TO_C_TYPE = {
@@ -265,6 +265,7 @@ def run_test():
         event = yield(DEFAULT_TIMEOUT)
         if not is_event_breakpoint(event, breakpoint):
             fail_count += 1
+            print("Expected: %s\nReceived: %s" % (breakpoint, event))
             print("Error - could not set pc to function")
         breakpoint.delete()
 


### PR DESCRIPTION
Avoid gdb_test hang indefinitely on errors, by adding timeouts.
This change adds also couple of minor logging improvements to tests.