### PR TITLE
Several small command related improvements

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -226,7 +226,16 @@ file for running the functional tests on boards that cannot be automatically det
 <tr><td>user_script</td>
 <td>str</td>
 <td><i>No default.</i></td>
-<td>Path of the user script file.</td></tr>
+<td>
+Path of the user script file.
+</td></tr>
+
+<tr><td>warning.cortex_m_default</td>
+<td>bool</td>
+<td><i>True</i></td>
+<td>Whether to show the warning when no target type is selected and the default cortex_m target
+type is used. The warning is never shown if the cortex_m target type is explicitly specified.
+</td></tr>
 
 </table>
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -387,4 +387,14 @@ Enable target power when connecting via a JLink probe, and disable power when di
 Default is True.
 </td></tr>
 
+<tr><td>jlink.device</td>
+<td>str</td>
+<td>None</td>
+<td>
+Set the device name passed to the J-Link. Normally, it doesn't matter because pyOCD does has its own
+device support, and so when this option is unset, "Cortex-M4" is used just to supply something
+valid. (For non-M4-based devices, you might see a warning about unexpected core type if you look at
+the J-Link logs, but this is harmless. J-Link does not support a "none" or "unknown" device type.)
+</td></tr>
+
 </table>

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -41,6 +41,7 @@ from .utility.cmdline import (
     convert_vector_catch,
     convert_session_options,
     convert_reset_type,
+    convert_frequency,
     )
 from .probe.pydapaccess import DAPAccess
 from .tools.lists import ListGenerator
@@ -81,20 +82,6 @@ ERASE_OPTIONS = [
     'chip',
     'sector',
     ]
-
-def convert_frequency(value):
-    """! @brief Applies scale suffix to frequency value string."""
-    value = value.strip()
-    suffix = value[-1].lower()
-    if suffix in ('k', 'm'):
-        value = int(value[:-1])
-        if suffix == 'k':
-            value *= 1000
-        elif suffix == 'm':
-            value *= 1000000
-        return value
-    else:
-        return int(value)
 
 def flatten_args(args):
     """! @brief Converts a list of lists to a single list."""
@@ -164,7 +151,8 @@ class PyOCDTool(object):
         connectOptions.add_argument("-t", "--target", dest="target_override", metavar="TARGET",
             help="Set the target type.")
         connectOptions.add_argument("-f", "--frequency", dest="frequency", default=None, type=convert_frequency,
-            help="SWD/JTAG clock frequency in Hz, with optional k/K or m/M suffix for kHz or MHz.")
+            help="SWD/JTAG clock frequency in Hz. Accepts a float or int with optional case-"
+                "insensitive K/M suffix and optional Hz. Examples: \"1000\", \"2.5khz\", \"10m\".")
         connectOptions.add_argument("-W", "--no-wait", action="store_true",
             help="Do not wait for a probe to be connected if none are available.")
         connectOptions.add_argument("-M", "--connect", dest="connect_mode", metavar="MODE",

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -157,7 +157,7 @@ class PyOCDTool(object):
         # Common connection related options.
         connectParser = argparse.ArgumentParser(description='common', add_help=False)
         connectOptions = connectParser.add_argument_group("connection")
-        connectOptions.add_argument("-u", "--uid", dest="unique_id",
+        connectOptions.add_argument("-u", "--uid", "--probe", dest="unique_id",
             help="Choose a probe by its unique ID or a substring thereof.")
         connectOptions.add_argument("-b", "--board", dest="board_override", metavar="BOARD",
             help="Set the board type (not yet implemented).")

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -167,12 +167,14 @@ class PyOCDTool(object):
             help="SWD/JTAG clock frequency in Hz, with optional k/K or m/M suffix for kHz or MHz.")
         connectOptions.add_argument("-W", "--no-wait", action="store_true",
             help="Do not wait for a probe to be connected if none are available.")
+        connectOptions.add_argument("-M", "--connect", dest="connect_mode", metavar="MODE",
+            help="Select connect mode from one of (halt, pre-reset, under-reset, attach).")
 
         # Create *commander* subcommand parser.
         commanderParser = argparse.ArgumentParser(description='commander', add_help=False)
         commanderOptions = commanderParser.add_argument_group("commander options")
         commanderOptions.add_argument("-H", "--halt", action="store_true", default=None,
-            help="Halt core upon connect.")
+            help="Halt core upon connect. (Deprecated, see --connect.)")
         commanderOptions.add_argument("-N", "--no-init", action="store_true",
             help="Do not init debug system.")
         commanderOptions.add_argument("--elf", metavar="PATH",
@@ -520,6 +522,7 @@ class PyOCDTool(object):
                             target_override=self._args.target_override,
                             frequency=self._args.frequency,
                             blocking=(not self._args.no_wait),
+                            connect_mode=self._args.connect_mode,
                             options=convert_session_options(self._args.options))
         if session is None:
             LOG.error("No device available to flash")
@@ -555,6 +558,7 @@ class PyOCDTool(object):
                             target_override=self._args.target_override,
                             frequency=self._args.frequency,
                             blocking=(not self._args.no_wait),
+                            connect_mode=self._args.connect_mode,
                             options=convert_session_options(self._args.options))
         if session is None:
             LOG.error("No device available to erase")
@@ -568,8 +572,6 @@ class PyOCDTool(object):
     
     def do_reset(self):
         """! @brief Handle 'reset' subcommand."""
-        self._increase_logging(["pyocd.flash.loader"])
-        
         # Verify selected reset type.
         try:
             the_reset_type = convert_reset_type(self._args.reset_type)
@@ -587,6 +589,7 @@ class PyOCDTool(object):
                             target_override=self._args.target_override,
                             frequency=self._args.frequency,
                             blocking=(not self._args.no_wait),
+                            connect_mode=self._args.connect_mode,
                             options=convert_session_options(self._args.options))
         if session is None:
             LOG.error("No device available to reset")
@@ -679,6 +682,7 @@ class PyOCDTool(object):
                 unique_id=self._args.unique_id,
                 target_override=self._args.target_override,
                 frequency=self._args.frequency,
+                connect_mode=self._args.connect_mode,
                 options=sessionOptions)
             if session is None:
                 LOG.error("No probe selected.")

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -33,6 +33,15 @@ class Board(GraphNode):
         # As a last resort, default the target to 'cortex_m'.
         if target is None:
             target = 'cortex_m'
+        
+            # Log a helpful warning when defaulting to the generic cortex_m target.
+            if session.options.get('warning.cortex_m_default'):
+                LOG.warning("Generic 'cortex_m' target type is selected by default; is this "
+                            "intentional? You will be able to debug most devices, but not program "
+                            " flash. To set the target type use the '--target' argument or "
+                            "'target_override' option. Use 'pyocd list --targets' to see available "
+                            "targets types.")
+
         self._session = session
         self._target_type = target.lower()
         self._test_binary = session.options.get('test_binary')
@@ -59,13 +68,6 @@ class Board(GraphNode):
         
         # Tell the user what target type is selected.
         LOG.info("Target type is %s", self._target_type)
-        
-        # Log a helpful warning when using the generic cortex_m target.
-        if self._target_type == 'cortex_m':
-            LOG.warning("Generic 'cortex_m' target type is selected; is this intentional? "
-                        "You will be able to debug but not program flash. To set the "
-                        "target type use the '--target' argument or 'target_override' option. "
-                        "Use 'pyocd list --targets' to see available targets types.")
         
         self.add_child(self.target)
 

--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -111,6 +111,7 @@ class ConnectHelper(object):
             ConnectHelper._print_probe_list(allProbes)
         else:
             print(colorama.Fore.RED + "No available debug probes are connected" + colorama.Style.RESET_ALL)
+        print(colorama.Style.RESET_ALL, end='')
 
     @staticmethod
     def choose_probe(blocking=True, return_first=False, unique_id=None):

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -84,6 +84,8 @@ OPTIONS_INFO = {
         "Name of test firmware binary."),
     'user_script': OptionInfo('user_script', str, None,
         "Path of the user script file."),
+    'warning.cortex_m_default': OptionInfo('warning.cortex_m_default', bool, True,
+        "Whether to show the warning about use of the cortex_m target type. Default is True."),
     
     # JLink options
     'jlink.power': OptionInfo('jlink.power', bool, True,

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -88,6 +88,9 @@ OPTIONS_INFO = {
         "Whether to show the warning about use of the cortex_m target type. Default is True."),
     
     # JLink options
+    'jlink.device': OptionInfo('jlink.device', str, None,
+        "Set the device name passed to the J-Link. Normally, it doesn't matter because pyOCD does"
+        "has its own device support, and \"Cortex-M4\" is used."),
     'jlink.power': OptionInfo('jlink.power', bool, True,
         "Enable target power when connecting via a JLink probe, and disable power when "
         "disconnecting. Default is True."),

--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -184,7 +184,8 @@ class JLinkProbe(DebugProbe):
             self._link.set_tif(iface)
             if self.session.options.get('jlink.power'):
                 self._link.power_on()
-            self._link.connect('Cortex-M4')
+            device_name = self.session.options.get('jlink.device') or "Cortex-M4"
+            self._link.connect(device_name)
             self._link.coresight_configure()
             self._protocol = protocol
         except JLinkException as exc:

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -450,7 +450,10 @@ OPTION_HELP = {
             },
         'mem-ap' : {
             'aliases' : [],
-            'help' : "Select the MEM-AP used for memory read/write commands."
+            'help' : "Select the MEM-AP used for memory read/write commands.",
+            'extra_help' : "When the selected core is changed by the 'core' command, the selected "
+                "MEM-AP is changed to match. This overrides a user-selected MEM-AP if different "
+                "from the AP for the newly selected core.",
             },
         'hnonsec' : {
             'aliases' : [],
@@ -1525,9 +1528,12 @@ class PyOCDCommander(object):
         if len(args) < 1:
             print("Core %d is selected" % self.target.selected_core.core_number)
             return
+        original_core_ap = core_ap = self.target.selected_core.ap
         core = int(args[0], base=0)
         self.target.select_core(core)
-        print("Selected core %d" % core)
+        core_ap = self.target.selected_core.ap
+        self.selected_ap = core_ap.address
+        print("Selected core {} ({})".format(core, core_ap.short_description))
 
     def handle_readdp(self, args):
         if len(args) < 1:

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -182,32 +182,43 @@ COMMAND_INFO = {
         'read8' : {
             'aliases' : ['read', 'r', 'rb'],
             'args' : "ADDR [LEN]",
-            'help' : "Read 8-bit bytes"
+            'help' : "Read 8-bit bytes",
+            "extra_help" : "Optional length parameter is the number of bytes to read. If the "
+                           "length is not provided, one byte is read."
             },
         'read16' : {
             'aliases' : ['r16', 'rh'],
             'args' : "ADDR [LEN]",
-            'help' : "Read 16-bit halfwords"
+            'help' : "Read 16-bit halfwords",
+            "extra_help" : "Optional length parameter is the number of bytes to read. It must be "
+                           "divisible by 2. If the length is not provided, one halfword is read. "
+                           "The address may be unaligned."
             },
         'read32' : {
             'aliases' : ['r32', 'rw'],
             'args' : "ADDR [LEN]",
-            'help' : "Read 32-bit words"
+            'help' : "Read 32-bit words",
+            "extra_help" : "Optional length parameter is the number of bytes to read. It must be "
+                           "divisible by 4. If the length is not provided, one word is read. "
+                           "The address may be unaligned."
             },
         'write8' : {
             'aliases' : ['write', 'w', 'wb'],
             'args' : "ADDR DATA...",
-            'help' : "Write 8-bit bytes to memory (RAM or flash)"
+            'help' : "Write 8-bit bytes to memory (RAM or flash). Flash writes are subject to "
+                     "minimum write size and alignment."
             },
         'write16' : {
             'aliases' : ['w16', 'wh'],
             'args' : "ADDR DATA...",
-            'help' : "Write 16-bit halfwords to memory (RAM or flash)"
+            'help' : "Write 16-bit halfwords to memory (RAM or flash). The address may be "
+                     "unaligned. Flash writes are subject to minimum write size and alignment."
             },
         'write32' : {
             'aliases' : ['w32', 'ww'],
             'args' : "ADDR DATA...",
-            'help' : "Write 32-bit words to memory (RAM or flash)"
+            'help' : "Write 32-bit words to memory (RAM or flash). The address may be unaligned. "
+                     "Flash writes are subject to minimum write size and alignment."
             },
         'fill' : {
             'aliases' : [],
@@ -215,7 +226,7 @@ COMMAND_INFO = {
             'help' : "Fill a range of memory with a pattern",
             'extra_help' : "The optional SIZE parameter must be one of 8, 16, or 32. If not "
                            "provided, the size is determined by the pattern value's most "
-                           "significant set bit."
+                           "significant set bit. Only RAM regions may be filled."
             },
         'find' : {
             'aliases' : [],
@@ -1249,6 +1260,10 @@ class PyOCDCommander(object):
             count = width // 8
         else:
             count = self.convert_value(args[1])
+        
+        if (count % (width // 8)) != 0:
+            print("Error: length ({}) is not aligned to width ({})".format(count, width // 8))
+            return 1
 
         if width == 8:
             data = self.target.aps[self.selected_ap].read_memory_block8(addr, count)
@@ -1273,7 +1288,7 @@ class PyOCDCommander(object):
             return 1
         else:
             data = [self.convert_value(d) for d in args[1:]]
-
+        
         if width == 8:
             pass
         elif width == 16:

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -783,9 +783,12 @@ class PyOCDCommander(object):
 
         options = convert_session_options(self.args.options)
         
-        # Set connect mode. If --halt is set then the connect mode is halt. If connect_mode is
-        # set through -O then use that. Otherwise default to attach.
-        if self.args.halt:
+        # Set connect mode. The --connect option takes precedence when set. Then, if --halt is set
+        # then the connect mode is halt. If connect_mode is set through -O then use that.
+        # Otherwise default to attach.
+        if hasattr(self.args, 'connect_mode') and self.args.connect_mode is not None:
+            connect_mode = self.args.connect_mode
+        elif self.args.halt:
             connect_mode = 'halt'
         elif 'connect_mode' in options:
             connect_mode = None

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -48,7 +48,7 @@ from ..flash.eraser import FlashEraser
 from ..flash.file_programmer import FileProgrammer
 from ..gdbserver.gdbserver import GDBServer
 from ..utility import (mask, conversion)
-from ..utility.cmdline import convert_session_options
+from ..utility.cmdline import (convert_session_options, convert_frequency)
 from ..utility.hex import (format_hex_width, dump_hex_data)
 from ..utility.progress import print_progress
 from ..utility.compatibility import get_terminal_size
@@ -453,7 +453,10 @@ OPTION_HELP = {
             },
         'clock' : {
             'aliases' : [],
-            'help' : "Set SWD or JTAG clock frequency in kilohertz."
+            'help' : "Set SWD or JTAG clock frequency in Hertz. A case-insensitive metric scale "
+                "suffix of either 'k' or 'm' is allowed, as well as a trailing \"Hz\". There must "
+                "be no space between the frequency and the suffix. For example, \"2.5MHz\" sets "
+                "the clock to 2.5 MHz."
             },
         'option' : {
             'aliases' : [],
@@ -1492,7 +1495,7 @@ class PyOCDCommander(object):
             print("Error: no clock frequency provided")
             return 1
         try:
-            freq_Hz = self.convert_value(args[0]) * 1000
+            freq_Hz = convert_frequency(args[0])
         except:
             print("Error: invalid frequency")
             return 1

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -27,6 +27,7 @@ import prettytable
 import traceback
 import pprint
 import textwrap
+import colorama
 
 # Attempt to import readline.
 try:
@@ -502,7 +503,7 @@ def cmdoptions(opts):
     return process_opts
 
 class PyOCDConsole(object):
-    PROMPT = '>>> '
+    PROMPT = colorama.Fore.BLUE + 'pyocd> ' + colorama.Style.RESET_ALL
 
     def __init__(self, tool):
         self.tool = tool

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -26,6 +26,7 @@ import six
 import prettytable
 import traceback
 import pprint
+import textwrap
 
 # Attempt to import readline.
 try:
@@ -1906,6 +1907,7 @@ class PyOCDCommander(object):
         self.target.aps[self.selected_ap].hprot = value
 
     def handle_help(self, args):
+        term_width = get_terminal_size()[0]
         if not args:
             self._list_commands("Commands", COMMAND_INFO, "{cmd:<25} {args:<20} {help}")
             print("""
@@ -1930,9 +1932,9 @@ Prefix line with ! to execute a shell command.""")
                         print(("Usage: " + usageFormat).format(cmd=name, **info))
                         if len(info['aliases']):
                             print("Aliases:", ", ".join(info['aliases']))
-                        print(info['help'])
+                        print("\n" + textwrap.fill(info['help'], width=term_width))
                         if 'extra_help' in info:
-                            print(info['extra_help'])
+                            print("\n" + textwrap.fill(info['extra_help'], width=term_width))
             
             if subcmd is None:
                 print_help(cmd, COMMAND_INFO, "{cmd} {args}")

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -161,3 +161,24 @@ def convert_reset_type(value):
         raise ValueError("unexpected value for reset_type option ('%s')" % value)
     return RESET_TYPE_MAP[value]
 
+def convert_frequency(value):
+    """! @brief Applies scale suffix to frequency value string.
+    @param value String with a float and possible 'k' or 'm' suffix (case-insensitive). "Hz" may
+        also follow. No space is allowed between the float and suffix. Leading and trailing
+        whitespace is allowed.
+    @return Integer scaled according to optional metric suffix.
+    """
+    value = value.strip().lower()
+    if value.endswith("hz"):
+        value = value[:-2]
+    suffix = value[-1]
+    if suffix in ('k', 'm'):
+        value = float(value[:-1])
+        if suffix == 'k':
+            value *= 1000
+        elif suffix == 'm':
+            value *= 1000000
+        return int(value)
+    else:
+        return int(float(value))
+


### PR DESCRIPTION
commander:

- When changing the selected core with the `core` command, the selected MEM-AP (`show/set mem-ap`) is also changed. For most users, this is more appropriate than having the two be disconnected.
- Help text is wrapped to the terminal width.
- An error is reported on memory reads if the size is not aligned to the read element size (byte, halfword, word).
- Clarified help text for read and write commands that the address may be unaligned.
- The command prompt is colorised and changed to `pyocd>`.

gdbserver:

- Added `--core` argument to run a gdbserver for specific cores. The argument accepts a list of one or more core numbers separated by commas.

general:

- Added `--connect` argument to directly support the `connect_mode` option. It accepts the same values the option supports: `halt`, `pre-reset`, `under-reset`, `attach`.
- Added `--probe` argument as an alias for `-u` and `--uid`.
- You can specify the device name used with the J-Link probe by setting the `jlink.device` option. By default, it uses "Cortex-M4", which is fine since the J-Link's device support isn't used by pyOCD—it only uses lower-level DAP APIs.
- Both the `--frequency` command line argument and commander `set clock` command now accept the same format. It has been extended to allow floating point values and an optional "Hz" suffix (case-insensitive). For example: "2.5m", "1000kHz", etc.
- The warning about using the "cortex_m" target type has been slightly relaxed, so that the warning is only logged if "cortex_m" is selected by default. If you explicitly specify "cortex_m", the warning is not logged.