### PR TITLE
Miscellaneous DAP cleanup and small fixes

### DIFF
--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -878,11 +878,12 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         else:
             return read_mem_cb
 
-    @locked
-    def _write_block32(self, addr, data):
+    def _write_block32_page(self, addr, data):
         """! @brief Write a single transaction's worth of aligned words.
         
         The transaction must not cross the MEM-AP's auto-increment boundary.
+
+        This method is not locked because it is only called by _write_memory_block32(), which is locked.
         """
         assert (addr & 0x3) == 0
         num = self.dp.next_access_number
@@ -904,11 +905,12 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
             raise
         TRACE.debug("_write_block32:%06d }", num)
 
-    @locked
-    def _read_block32(self, addr, size):
+    def _read_block32_page(self, addr, size):
         """! @brief Read a single transaction's worth of aligned words.
         
         The transaction must not cross the MEM-AP's auto-increment boundary.
+
+        This method is not locked because it is only called by _read_memory_block32(), which is locked.
         """
         assert (addr & 0x3) == 0
         num = self.dp.next_access_number
@@ -940,7 +942,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
             n = self.auto_increment_page_size - (addr & (self.auto_increment_page_size - 1))
             if size*4 < n:
                 n = (size*4) & 0xfffffffc
-            self._write_block32(addr, data[:n//4])
+            self._write_block32_page(addr, data[:n//4])
             data = data[n//4:]
             size -= n//4
             addr += n
@@ -950,7 +952,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
     def _read_memory_block32(self, addr, size):
         """! @brief Read a block of aligned words in memory.
         
-        @return An array of word values
+        @return A list of word values.
         """
         assert (addr & 0x3) == 0
         resp = []
@@ -958,7 +960,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
             n = self.auto_increment_page_size - (addr & (self.auto_increment_page_size - 1))
             if size*4 < n:
                 n = (size*4) & 0xfffffffc
-            resp += self._read_block32(addr, n//4)
+            resp += self._read_block32_page(addr, n//4)
             size -= n//4
             addr += n
         return resp

--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -758,7 +758,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         ap_regaddr = addr & APREG_MASK
         if ap_regaddr == self._reg_offset + MEM_AP_CSW and self._cached_csw != -1 and now:
             return self._cached_csw
-        return super(MEM_AP, self).read_reg(addr, now)
+        return self.dp.read_ap(self.address.address + addr, now)
 
     @locked
     def write_reg(self, addr, data):
@@ -775,7 +775,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
             self._cached_csw = data
 
         try:
-            super(MEM_AP, self).write_reg(addr, data)
+            self.dp.write_ap(self.address.address + addr, data)
         except exceptions.ProbeError:
             # Invalidate cached CSW on exception.
             if ap_regaddr == self._reg_offset + MEM_AP_CSW:

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -499,6 +499,8 @@ class DebugPort(object):
             self.clear_sticky_err()
         # For timeouts caused by WAIT responses, set DAPABORT to abort the transfer.
         elif isinstance(error, exceptions.TransferTimeoutError):
+            # This may put the AP that was aborted into an unpredictable state. Should consider
+            # attempting to reset debug logic.
             self.write_reg(DP_ABORT, ABORT_DAPABORT)
 
     def clear_sticky_err(self):
@@ -507,7 +509,8 @@ class DebugPort(object):
         if mode == DebugProbe.Protocol.SWD:
             self.write_reg(DP_ABORT, ABORT_ORUNERRCLR | ABORT_WDERRCLR | ABORT_STKERRCLR | ABORT_STKCMPCLR)
         elif mode == DebugProbe.Protocol.JTAG:
-            self.write_reg(DP_CTRL_STAT, CTRLSTAT_STICKYERR | CTRLSTAT_STICKYCMP | CTRLSTAT_STICKYORUN)
+            self.write_reg(DP_CTRL_STAT, CSYSPWRUPREQ | CDBGPWRUPREQ | TRNNORMAL | MASKLANE
+                    | CTRLSTAT_STICKYERR | CTRLSTAT_STICKYCMP | CTRLSTAT_STICKYORUN)
         else:
             assert False
 

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -331,7 +331,7 @@ class DebugPort(object):
         @return Boolean indicating whether the power up request succeeded.
         """
         # Send power up request for system and debug.
-        self.write_reg(DP_CTRL_STAT, CSYSPWRUPREQ | CDBGPWRUPREQ)
+        self.write_reg(DP_CTRL_STAT, CSYSPWRUPREQ | CDBGPWRUPREQ | MASKLANE | TRNNORMAL)
 
         with Timeout(DP_POWER_REQUEST_TIMEOUT) as time_out:
             while time_out.check():
@@ -341,7 +341,7 @@ class DebugPort(object):
             else:
                 return False
 
-        self.write_reg(DP_CTRL_STAT, CSYSPWRUPREQ | CDBGPWRUPREQ | TRNNORMAL | MASKLANE)
+        self.write_reg(DP_CTRL_STAT, CSYSPWRUPREQ | CDBGPWRUPREQ | MASKLANE | TRNNORMAL)
         
         return True
 
@@ -356,7 +356,7 @@ class DebugPort(object):
         @return Boolean indicating whether the power down request succeeded.
         """
         # Power down system first.
-        self.write_reg(DP_CTRL_STAT, CDBGPWRUPREQ)
+        self.write_reg(DP_CTRL_STAT, CDBGPWRUPREQ | MASKLANE | TRNNORMAL)
         
         with Timeout(DP_POWER_REQUEST_TIMEOUT) as time_out:
             while time_out.check():
@@ -367,7 +367,7 @@ class DebugPort(object):
                 return False
 
         # Now power down debug.
-        self.write_reg(DP_CTRL_STAT, 0)
+        self.write_reg(DP_CTRL_STAT,  MASKLANE | TRNNORMAL)
         
         with Timeout(DP_POWER_REQUEST_TIMEOUT) as time_out:
             while time_out.check():

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -229,6 +229,7 @@ class STLinkMemoryInterface(MemoryInterface):
         By default the transfer size is a word.
         """
         assert transfer_size in (8, 16, 32)
+        addr &= 0xffffffff
         if transfer_size == 32:
             self._link.write_mem32(addr, conversion.u32le_list_to_byte_list([data]), self._apsel)
         elif transfer_size == 16:
@@ -242,6 +243,7 @@ class STLinkMemoryInterface(MemoryInterface):
         By default, a word will be read.
         """
         assert transfer_size in (8, 16, 32)
+        addr &= 0xffffffff
         if transfer_size == 32:
             result = conversion.byte_list_to_u32le_list(self._link.read_mem32(addr, 4, self._apsel))[0]
         elif transfer_size == 16:
@@ -254,8 +256,10 @@ class STLinkMemoryInterface(MemoryInterface):
         return result if now else read_callback
 
     def write_memory_block32(self, addr, data):
+        addr &= 0xffffffff
         self._link.write_mem32(addr, conversion.u32le_list_to_byte_list(data), self._apsel)
 
     def read_memory_block32(self, addr, size):
+        addr &= 0xffffffff
         return conversion.byte_list_to_u32le_list(self._link.read_mem32(addr, size * 4, self._apsel))
 


### PR DESCRIPTION
Noteworthy changes:

- `MEM_AP` checks whether 64-bit addresses are supported, though it doesn't actually implement the support yet.
- `MEM_AP` and the STLink probe mask memory addresses based on the supported address size (32/64-bit).
- Removed detection of `CSW.MSTRTYPE` support, replaced with a flag in the ID table. Only the AHB-AP included with the Cortex-M3 and Cortex-M4 has `MSTRTYPE`.

The rest of the changes are tiny changes to clean things up, or tiny improvements in the code that don't have a noticeable effect.