### PR TITLE
DAP concurrency fixes and probe capabilities

### DIFF
--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -37,6 +37,7 @@ A32 = 0x0c
 APSEL_SHIFT = 24
 APSEL = 0xff000000
 APBANKSEL = 0x000000f0
+APSEL_APBANKSEL = APSEL | APBANKSEL
 
 ## @brief Mask for register address within the AP address space.
 #
@@ -901,7 +902,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         self.write_reg(self._reg_offset + MEM_AP_CSW, self._csw | CSW_SIZE32)
         self.write_reg(self._reg_offset + MEM_AP_TAR, addr)
         try:
-            self.dp.probe.write_ap_multiple(self.address.address + self._reg_offset + MEM_AP_DRW, data)
+            self.dp.write_ap_multiple(self.address.address + self._reg_offset + MEM_AP_DRW, data)
         except exceptions.TransferFaultError as error:
             # Annotate error with target address.
             self._handle_error(error, num)
@@ -928,7 +929,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         self.write_reg(self._reg_offset + MEM_AP_CSW, self._csw | CSW_SIZE32)
         self.write_reg(self._reg_offset + MEM_AP_TAR, addr)
         try:
-            resp = self.dp.probe.read_ap_multiple(self.address.address + self._reg_offset + MEM_AP_DRW, size)
+            resp = self.dp.read_ap_multiple(self.address.address + self._reg_offset + MEM_AP_DRW, size)
         except exceptions.TransferFaultError as error:
             # Annotate error with target address.
             self._handle_error(error, num)

--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import logging
-import threading
 from contextlib import contextmanager
 from functools import total_ordering
 from enum import Enum
@@ -362,7 +361,6 @@ class AccessPort(object):
         self.has_rom_table = False
         self.rom_table = None
         self.core = None
-        self._lock = threading.RLock()
         self._flags = flags
         self._cmpid = cmpid
     
@@ -415,11 +413,11 @@ class AccessPort(object):
     
     def lock(self):
         """! @brief Lock the AP from access by other threads."""
-        self._lock.acquire()
+        self.dp.probe.lock()
     
     def unlock(self):
         """! @brief Unlock the AP."""
-        self._lock.release()
+        self.dp.probe.unlock()
     
     @contextmanager
     def locked(self):

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2015-2019 Arm Limited
+# Copyright (c) 2015-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ from enum import Enum
 from ..core import (exceptions, memory_interface)
 from ..probe.debug_probe import DebugProbe
 from ..probe.swj import SWJSequenceSender
-from .ap import (MEM_AP_CSW, APSEL, APBANKSEL, APREG_MASK, AccessPort)
+from .ap import (MEM_AP_CSW, APSEL, APBANKSEL, APSEL_APBANKSEL, APREG_MASK, AccessPort)
 from ..utility.sequencer import CallSequence
 from ..utility.timeout import Timeout
 
@@ -49,8 +49,8 @@ DP_RDBUFF = 0xC # read-only
 # Mask and shift for extracting DPBANKSEL from our DP register address constants. These are not
 # related to the SELECT.DPBANKSEL bitfield.
 DPADDR_MASK = 0x0f
-DPBANKSEL_MASK = 0xf0
-DPBANKSEL_SHIFT = 4
+DPADDR_DPBANKSEL_MASK = 0xf0
+DPADDR_DPBANKSEL_SHIFT = 4
 
 DPIDR1_ASIZE_MASK = 0x00000007f
 DPIDR1_ERRMODE_MASK = 0x00000080
@@ -73,7 +73,9 @@ CTRLSTAT_STICKYERR = 0x00000020
 CTRLSTAT_READOK = 0x00000040
 CTRLSTAT_WDATAERR = 0x00000080
 
+# DP SELECT register fields.
 SELECT_DPBANKSEL_MASK = 0x0000000f
+SELECT_APADDR_MASK = 0xfffffff0
 
 DPIDR_REVISION_MASK = 0xf0000000
 DPIDR_REVISION_SHIFT = 28
@@ -206,8 +208,11 @@ class DebugPort(object):
         self.dpidr = None
         self.aps = {}
         self._access_number = 0
-        self._cached_dpbanksel = None
+        self._cached_dp_select = None
         self._protocol = None
+        self._probe_managed_ap_select = False
+        self._probe_managed_dpbanksel = False
+        self._probe_supports_dpbanksel = False
         
         # DPv3 attributes
         self._is_dpv3 = False
@@ -245,7 +250,8 @@ class DebugPort(object):
     def init(self, protocol=None):
         """! @brief Connect to the target.
         
-        This method causes the debug probe to connect using the selected wire protocol.
+        This method causes the debug probe to connect using the selected wire protocol. The probe
+        must have already been opened prior to this call.
         
         Unlike init_sequence(), this method is intended to be used when manually constructing a
         DebugPort instance. It simply calls init_sequence() and invokes the returned call sequence.
@@ -264,14 +270,24 @@ class DebugPort(object):
         DP, power up debug and the system, check the DP version to identify whether the target uses
         ADI v5 or v6, then clears sticky errors.
         
+        The probe must have already been opened prior to this method being called.
+        
         @param self
         """
         return CallSequence(
+            ('get_probe_capabilities', self._get_probe_capabilities),
             ('connect',             self._connect),
             ('clear_sticky_err',    self.clear_sticky_err),
             ('power_up_debug',      self.power_up_debug),
             ('check_version',       self._check_version),
             )
+
+    def _get_probe_capabilities(self):
+        """! @brief Examine the probe's capabilities."""
+        caps = self._probe.capabilities
+        self._probe_managed_ap_select = (DebugProbe.Capability.MANAGED_AP_SELECTION in caps)
+        self._probe_managed_dpbanksel = (DebugProbe.Capability.MANAGED_DPBANKSEL in caps)
+        self._probe_supports_dpbanksel = (DebugProbe.Capability.BANKED_DP_REGISTERS in caps)
 
     def _connect(self):
         # Attempt to connect.
@@ -381,13 +397,13 @@ class DebugPort(object):
         return True
 
     def reset(self):
-        self._cached_dpbanksel = None
+        self._cached_dp_select = None
         for ap in self.aps.values():
             ap.reset_did_occur()
         self.probe.reset()
 
     def assert_reset(self, asserted):
-        self._cached_dpbanksel = None
+        self._cached_dp_select = None
         if asserted:
             for ap in self.aps.values():
                 ap.reset_did_occur()
@@ -399,21 +415,67 @@ class DebugPort(object):
     def set_clock(self, frequency):
         self.probe.set_clock(frequency)
 
-    def _set_dpbanksel(self, addr):
-        # SELECT and RDBUFF ignore DPBANKSEL.
-        if (addr & DPADDR_MASK) not in (DP_SELECT, DP_RDBUFF):
-            # Make sure the correct DP bank is selected.
-            dpbanksel = addr & DPBANKSEL_MASK
-            if dpbanksel != self._cached_dpbanksel:
-                # Blow away any selected AP.
-                select = dpbanksel >> DPBANKSEL_SHIFT
-                self.write_dp(DP_SELECT, select)
-                self._cached_dpbanksel = dpbanksel
+    def _write_dp_select(self, mask, value):
+        """! @brief Modify part of the DP SELECT register and write if cache is stale."""
+        # Compute the new SELECT value and see if we need to write it.
+        if self._cached_dp_select is None:
+            select = value
+        else:
+            select = (self._cached_dp_select & ~mask) | value
+            if select == self._cached_dp_select:
+                return
+        
+        # Update the SELECT register and cache.
+        self.write_dp(DP_SELECT, select)
+        self._cached_dp_select = select
+    
+    def _set_dpbanksel(self, addr, is_write):
+        """! @brief Updates the DPBANKSEL field of the SELECT register as required.
+        
+        Several DP registers (most, actually) ignore DPBANKSEL. If one of those is being
+        accessed, any value of DPBANKSEL can be used. Otherwise SELECT is updated if necessary
+        and a lock acquired so another thread doesn't change DPBANKSEL until thsi transaction is
+        complete.
+        
+        This method also handles the case where the debug probe manages DPBANKSEL on its own,
+        such as with STLink.
+        
+        @return Whether the access needs a lock on DP SELECT.
+        @exception exceptions.ProbeError Raised when a banked register is being accessed but the
+            probe doesn't support DPBANKSEL.
+        """
+        # For DPv1-2, only address 0x4 (CTRL/STAT) honours DPBANKSEL.
+        # For DPv3, SELECT and RDBUFF ignore DPBANKSEL for both reads and writes, while
+        # ABORT ignores it only for writes (address 0 for reads is IDR).
+        if self._is_dpv3 and not is_write:
+            registers_ignoring_dpbanksel = (DP_SELECT, DP_RDBUFF)
+        else:
+            registers_ignoring_dpbanksel = (DP_ABORT, DP_SELECT, DP_RDBUFF)
+        
+        if (addr & DPADDR_MASK) not in registers_ignoring_dpbanksel:
+            # Get the DP bank.
+            dpbanksel = (addr & DPADDR_DPBANKSEL_MASK) >> DPADDR_DPBANKSEL_SHIFT
+            
+            # Check if the probe handles this for us.
+            if self._probe_managed_dpbanksel:
+                # If there is a nonzero DPBANKSEL and the probe doesn't support this,
+                # then report an error.
+                if dpbanksel and not self._probe_supports_dpbanksel:
+                    raise exceptions.ProbeError("probe does not support banked DP registers")
+                else:
+                    return False
+            
+            # Update the selected DP bank.
+            self._write_dp_select(SELECT_DPBANKSEL_MASK, dpbanksel)
+            return True
+        else:
+            return False
 
     def read_dp(self, addr, now=True):
         num = self.next_access_number
         
-        self._set_dpbanksel(addr)
+        # Update DPBANKSEL if required.
+        self._set_dpbanksel(addr, False)
 
         try:
             result_cb = self.probe.read_dp(addr & DPADDR_MASK, now=False)
@@ -428,6 +490,7 @@ class DebugPort(object):
                 TRACE.debug("read_dp:%06d %s(addr=0x%08x) -> 0x%08x", num, "" if now else "...", addr, result)
                 return result
             except exceptions.TargetError as error:
+                TRACE.debug("read_dp:%06d %s(addr=0x%08x) -> error (%s)", num, "" if now else "...", addr, error)
                 self._handle_error(error, num)
                 raise
 
@@ -440,9 +503,8 @@ class DebugPort(object):
     def write_dp(self, addr, data):
         num = self.next_access_number
         
-        # Writing to ABORT ignores DPBANKSEL.
-        if (addr & DPADDR_MASK) != DP_ABORT:
-            self._set_dpbanksel(addr)
+        # Update DPBANKSEL if required.
+        self._set_dpbanksel(addr, True)
 
         # Write the DP register.
         try:
@@ -453,12 +515,34 @@ class DebugPort(object):
             raise
 
         return True
+    
+    def _select_ap(self, addr):
+        """! @brief Write DP_SELECT to choose the given AP.
+        
+        Handles the case where the debug probe manages selecting an AP itself, in which case we
+        never write SELECT directly.
+
+        @return Whether the access needs a lock on DP SELECT.
+        """
+        # If the probe handles selecting the AP for us, there's nothing to do here.
+        if self._probe_managed_ap_select:
+            return False
+        
+        # Write DP SELECT to select the probe.
+        if self.adi_version == ADIVersion.ADIv5:
+            self._write_dp_select(APSEL_APBANKSEL, addr & APSEL_APBANKSEL)
+        elif self.adi_version == ADIVersion.ADIv6:
+            self._write_dp_select(SELECT_APADDR_MASK, addr & SELECT_APADDR_MASK)
+        else:
+            assert False, "invalid ADI version"
+        return True
 
     def write_ap(self, addr, data):
         assert type(addr) in (six.integer_types)
         num = self.next_access_number
 
         try:
+            self._select_ap(addr)
             TRACE.debug("write_ap:%06d (addr=0x%08x) = 0x%08x", num, addr, data)
             self.probe.write_ap(addr, data)
         except exceptions.TargetError as error:
@@ -472,6 +556,7 @@ class DebugPort(object):
         num = self.next_access_number
 
         try:
+            self._select_ap(addr)
             result_cb = self.probe.read_ap(addr, now=False)
         except exceptions.TargetError as error:
             self._handle_error(error, num)
@@ -484,6 +569,7 @@ class DebugPort(object):
                 TRACE.debug("read_ap:%06d %s(addr=0x%08x) -> 0x%08x", num, "" if now else "...", addr, result)
                 return result
             except exceptions.TargetError as error:
+                TRACE.debug("read_ap:%06d %s(addr=0x%08x) -> error (%s)", num, "" if now else "...", addr, error)
                 self._handle_error(error, num)
                 raise
 
@@ -492,6 +578,44 @@ class DebugPort(object):
         else:
             TRACE.debug("read_ap:%06d (addr=0x%08x) -> ...", num, addr)
             return read_ap_cb
+
+    def write_ap_multiple(self, addr, values):
+        assert type(addr) in (six.integer_types)
+        num = self.next_access_number
+        
+        try:
+            self._select_ap(addr)
+            TRACE.debug("write_ap_multiple:%06d (addr=0x%08x) = (%i values)", num, addr, len(values))
+            return self.probe.write_ap_multiple(addr, values)
+        except exceptions.TargetError as error:
+            self._handle_error(error, num)
+            raise
+
+    def read_ap_multiple(self, addr, count=1, now=True):
+        assert type(addr) in (six.integer_types)
+        num = self.next_access_number
+        
+        try:
+            self._select_ap(addr)
+            TRACE.debug("read_ap_multiple:%06d (addr=0x%08x, count=%i)", num, addr, count)
+            result_cb = self.probe.read_ap_multiple(addr, count, now=False)
+        except exceptions.TargetError as error:
+            self._handle_error(error, num)
+            raise
+
+        # Need to wrap the deferred callback to convert exceptions.
+        def read_ap_multiple_cb():
+            try:
+                return result_cb()
+            except exceptions.TargetError as error:
+                TRACE.debug("read_ap_multiple:%06d %s(addr=0x%08x) -> error (%s)", num, "" if now else "...", addr, error)
+                self._handle_error(error, num)
+                raise
+
+        if now:
+            return read_ap_multiple_cb()
+        else:
+            return read_ap_multiple_cb
 
     def _handle_error(self, error, num):
         TRACE.debug("error:%06d %s", num, error)
@@ -505,7 +629,7 @@ class DebugPort(object):
             self.write_reg(DP_ABORT, ABORT_DAPABORT)
 
     def clear_sticky_err(self):
-        self._cached_dpbanksel = None
+        self._cached_dp_select = None
         mode = self.probe.wire_protocol
         if mode == DebugProbe.Protocol.SWD:
             self.write_reg(DP_ABORT, ABORT_ORUNERRCLR | ABORT_WDERRCLR | ABORT_STKERRCLR | ABORT_STKCMPCLR)

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -132,7 +132,8 @@ class DPConnector(object):
         @exception TransferError
         """
         protocol_name = self._session.options.get('dap_protocol').strip().lower()
-        send_swj = self._session.options.get('dap_enable_swj') and self._probe.supports_swj_sequence
+        send_swj = self._session.options.get('dap_enable_swj') \
+                and (DebugProbe.Capability.SWJ_SEQUENCE in self._probe.capabilities)
         use_deprecated = self._session.options.get('dap_use_deprecated_swj')
 
         # Convert protocol from setting if not passed as parameter.

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2018-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,32 @@ class DebugProbe(object):
             'jtag': Protocol.JTAG,
             'default': Protocol.DEFAULT,
         }
+    
+    class Capability(Enum):
+        """! @brief Probe capabilities."""
+        ## @brief Whether the probe supports the swj_sequence() API.
+        #
+        # If this property is True, then the swj_sequence() method is used to move between protocols.
+        # If False, it is assumed the probe firmware automatically manages the protocol switch.
+        SWJ_SEQUENCE = 0
+        
+        ## @brief Whether the probe supports receiving SWO data.
+        SWO = 1
+
+        ## @brief Whether the probe can access banked DP registers.
+        BANKED_DP_REGISTERS = 2
+        
+        ## @brief Whether the probe can access APv2 registers.
+        APv2_ADDRESSES = 3
+        
+        ## @brief Whether the probe automatically handles AP selection in the DP.
+        #
+        # If this capability is not present, the DebugPort object will perform the AP selection
+        # by DP register writes.
+        MANAGED_AP_SELECTION = 4
+        
+        ## @brief whether the probe automatically handles access of banked DAP registers.
+        MANAGED_DPBANKSEL = 5
     
     @classmethod
     def get_all_connected_probes(cls):
@@ -108,11 +134,10 @@ class DebugProbe(object):
         raise NotImplementedError()
     
     @property
-    def supports_swj_sequence(self):
-        """! @brief Whether the probe supports the swj_sequence() API.
+    def capabilities(self):
+        """! @brief A set of DebugProbe.Capability enums indicating the probe's features.
         
-        If this property is True, then the swj_sequence() method is used to move between protocols.
-        If False, it is assumed the probe firmware automatically manages the protocol switch.
+        This value should not be trusted until after the probe is opened.
         """
         raise NotImplementedError()
 
@@ -250,10 +275,6 @@ class DebugProbe(object):
 
     ## @name SWO
     ##@{
-
-    def has_swo(self):
-        """! @brief Returns bool indicating whether the probe supports SWO."""
-        raise NotImplementedError()
 
     def swo_start(self, baudrate):
         """! @brief Start receiving SWO data at the given baudrate.

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from enum import Enum
+import threading
 
 class DebugProbe(object):
     """! @brief Abstract debug probe class."""
@@ -74,6 +75,7 @@ class DebugProbe(object):
     def __init__(self):
         """! @brief Constructor."""
         self._session = None
+        self._lock = threading.RLock()
 
     @property
     def session(self):
@@ -161,6 +163,22 @@ class DebugProbe(object):
     def close(self):
         """! @brief Close the probe's USB interface."""
         raise NotImplementedError()
+    
+    def lock(self):
+        """! @brief Lock the probe from access by other threads.
+        
+        This lock is recursive, so locking multiple times from a single thread is acceptable as long
+        as the thread unlocks the same number of times.
+        """
+        self._lock.acquire()
+    
+    def unlock(self):
+        """! @brief Unlock the probe.
+        
+        Only when the thread unlocks the probe the same number of times it has called lock() will
+        the lock actually be released and other threads allowed access.
+        """
+        self._lock.release()
 
     ## @name Target control
     ##@{

--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -129,8 +129,8 @@ class JLinkProbe(DebugProbe):
         return self._link.opened
     
     @property
-    def supports_swj_sequence(self):
-        return False
+    def capabilities(self):
+        return {self.Capability.SWO}
     
     def open(self):
         try:
@@ -310,9 +310,6 @@ class JLinkProbe(DebugProbe):
     def write_ap_multiple(self, addr, values):
         for v in values:
             self.write_ap(addr, v)
-
-    def has_swo(self):
-        return True
 
     def swo_start(self, baudrate):
         try:

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -188,7 +188,7 @@ class STLink(object):
         
         This property is not valid until the connection is opened.
         """
-        return self._jtag_version >= self.MIN_JTAG_VERSION_DPBANKSEL_HW_V2[self._hw_version]
+        return self._jtag_version >= self.MIN_JTAG_VERSION_DPBANKSEL[self._hw_version]
 
     def get_target_voltage(self):
         response = self._device.transfer([Commands.GET_TARGET_VOLTAGE], readSize=8)

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2018-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,14 +43,19 @@ class STLink(object):
     # 8-bit transfers have a maximum size of the maximum USB packet size (64 bytes for full speed).
     MAXIMUM_TRANSFER_SIZE = 1024
     
-    ## Minimum required STLink firmware version.
+    ## Minimum required STLink firmware version (hw version 2).
     MIN_JTAG_VERSION = 24
     
-    ## Firmware version that adds 16-bit transfers.
+    ## Firmware version that adds 16-bit transfers (hw version 2).
     MIN_JTAG_VERSION_16BIT_XFER = 26
     
-    ## Firmware version that adds multiple AP support.
+    ## Firmware version that adds multiple AP support (hw version 2).
     MIN_JTAG_VERSION_MULTI_AP = 28
+    
+    ## Firmware version that adds DP bank support.
+    #
+    # Keys are the hardware version, value is the minimum JTAG version.
+    MIN_JTAG_VERSION_DPBANKSEL = {2: 32, 3: 2}
     
     ## Port number to use to indicate DP registers.
     DP_PORT = 0xffff
@@ -176,6 +181,14 @@ class STLink(object):
     @property
     def target_voltage(self):
         return self._target_voltage
+    
+    @property
+    def supports_banked_dp(self):
+        """! @brief Whether the firmware version supports accessing banked DP registers.
+        
+        This property is not valid until the connection is opened.
+        """
+        return self._jtag_version >= self.MIN_JTAG_VERSION_DPBANKSEL_HW_V2[self._hw_version]
 
     def get_target_voltage(self):
         response = self._device.transfer([Commands.GET_TARGET_VOLTAGE], readSize=8)
@@ -402,9 +415,19 @@ class STLink(object):
     def write_mem8(self, addr, data, apsel):
         self._write_mem(addr, data, Commands.JTAG_WRITEMEM_8BIT, self._device.max_packet_size, apsel)
     
+    def _check_dp_bank(self, port, addr):
+        """! @brief Check if attempting to access a banked DP register with a firmware version that
+                doesn't support that.
+        """
+        if ((port == self.DP_PORT) and ((addr & 0xf0) != 0) and not self.supports_banked_dp):
+            raise exceptions.ProbeError("this STLinkV%d firmware version does not support accessing"
+                    " banked DP registers; please upgrade to the latest STLinkV%d firmware release",
+                    self._hw_version, self._hw_version)
+    
     def read_dap_register(self, port, addr):
-        assert ((addr & 0xf0) == 0) or (port != self.DP_PORT), "banks are not allowed for DP registers"
         assert (addr >> 16) == 0, "register address must be 16-bit"
+        
+        self._check_dp_bank(port, addr)
         
         with self._lock:
             cmd = [Commands.JTAG_COMMAND, Commands.JTAG_READ_DAP_REG]
@@ -415,8 +438,9 @@ class STLink(object):
             return value
     
     def write_dap_register(self, port, addr, value):
-        assert ((addr & 0xf0) == 0) or (port != self.DP_PORT), "banks are not allowed for DP registers"
         assert (addr >> 16) == 0, "register address must be 16-bit"
+
+        self._check_dp_bank(port, addr)
 
         with self._lock:
             cmd = [Commands.JTAG_COMMAND, Commands.JTAG_WRITE_DAP_REG]

--- a/pyocd/trace/swv.py
+++ b/pyocd/trace/swv.py
@@ -26,6 +26,7 @@ from ..coresight.itm import ITM
 from ..coresight.tpiu import TPIU
 from ..core.target import Target
 from ..core import exceptions
+from ..probe.debug_probe import DebugProbe
 
 LOG = logging.getLogger(__name__)
 
@@ -101,7 +102,7 @@ class SWVReader(threading.Thread):
         """
         self._swo_clock = swo_clock
         
-        if not self._session.probe.has_swo():
+        if DebugProbe.Capability.SWO not in self._session.probe.capabilities:
             LOG.warning("Probe %s does not support SWO", self._session.probe.unique_id)
             return
         

--- a/test/automated_test.py
+++ b/test/automated_test.py
@@ -48,6 +48,7 @@ from gdb_test import GdbTest
 from gdb_server_json_test import GdbServerJsonTest
 from connect_test import ConnectTest
 from debug_context_test import DebugContextTest
+from concurrency_test import ConcurrencyTest
 
 XML_RESULTS_TEMPLATE = "test_results{}.xml"
 LOG_FILE_TEMPLATE = "automated_test_result{}.txt"
@@ -64,6 +65,7 @@ test_list = [
              ConnectTest(),
              SpeedTest(),
              CortexTest(),
+             ConcurrencyTest(),
              FlashTest(),
              FlashLoaderTest(),
              DebugContextTest(),

--- a/test/concurrency_test.py
+++ b/test/concurrency_test.py
@@ -1,0 +1,204 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+from time import (sleep, time)
+from random import randrange
+import math
+import struct
+import traceback
+import argparse
+import logging
+from itertools import (chain, repeat)
+
+from pyocd.core.helpers import ConnectHelper
+from pyocd.flash.file_programmer import FileProgrammer
+from pyocd.probe.pydapaccess import DAPAccess
+from pyocd.utility.conversion import float32_to_u32
+from pyocd.utility.mask import same
+from pyocd.utility.compatibility import to_str_safe
+from pyocd.core.memory_map import MemoryType
+
+from test_util import (
+    Test,
+    TestResult,
+    get_session_options,
+    get_target_test_params,
+    run_in_parallel,
+    )
+
+parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Test configuration values.        
+TEST_MAX_LENGTH = 1 * 1024 * 1024
+TEST_THREAD_COUNT = 8
+TEST_SUBCHUNK_COUNT = 2 # Number of reads/writes per thread.
+
+def ncycles(iterable, n):
+    return chain.from_iterable(repeat(tuple(iterable), n))
+
+class ConcurrencyTestResult(TestResult):
+    def __init__(self):
+        super(ConcurrencyTestResult, self).__init__(None, None, None)
+        self.name = "concurrency"
+
+class ConcurrencyTest(Test):
+    def __init__(self):
+        super(ConcurrencyTest, self).__init__("Concurrency Test", concurrency_test)
+
+    def run(self, board):
+        try:
+            result = self.test_function(board.unique_id)
+        except Exception as e:
+            result = ConcurrencyTestResult()
+            result.passed = False
+            print("Exception %s when testing board %s" % (e, board.unique_id))
+            traceback.print_exc(file=sys.stdout)
+        result.board = board
+        result.test = self
+        return result
+
+def concurrency_test(board_id):
+    with ConnectHelper.session_with_chosen_probe(unique_id=board_id, **get_session_options()) as session:
+        board = session.board
+        target = session.target
+
+        test_params = get_target_test_params(session)
+        session.probe.set_clock(test_params['test_clock'])
+
+        memory_map = target.get_memory_map()
+        boot_region = memory_map.get_boot_memory()
+        ram_region = memory_map.get_default_region_of_type(MemoryType.RAM)
+        binary_file = os.path.join(parentdir, 'binaries', board.test_binary)
+
+        test_pass_count = 0
+        test_count = 0
+        result = ConcurrencyTestResult()
+        
+        target.reset_and_halt()
+        
+        # Prepare TEST_THREAD_COUNT regions of RAM with patterns
+        data_len = min(TEST_MAX_LENGTH, ram_region.length)
+        chunk_len = data_len // TEST_THREAD_COUNT
+        subchunk_len = chunk_len // TEST_SUBCHUNK_COUNT
+        
+        chunk_data = []
+        for i in range(TEST_THREAD_COUNT):
+            chunk_data.append([(i + j) % 256 for j in range(chunk_len)])
+        
+        def write_chunk_data(core, i):
+            start = ram_region.start + chunk_len * i
+            for j in range(TEST_SUBCHUNK_COUNT):
+                offset = subchunk_len * j
+                addr = start + offset
+                end = addr + subchunk_len - 1
+                print("Writing region %i:%i from %#010x to %#010x via %s" % (i, j, addr, end, core.ap))
+                core.write_memory_block8(addr, chunk_data[i][offset:offset + subchunk_len])
+                print("Finished writing region %i:%i" % (i, j))
+
+        def read_chunk_data(core, i):
+            start = ram_region.start + chunk_len * i
+            for j in range(TEST_SUBCHUNK_COUNT):
+                offset = subchunk_len * j
+                addr = start + offset
+                end = addr + subchunk_len - 1
+                print("Reading region %i:%i from %#010x to %#010x via %s" % (i, j, addr, end, core.ap))
+                data = core.read_memory_block8(addr, subchunk_len)
+                chunk_read_data[i].extend(data)
+                print("Finished reading region %i:%i" % (i, j))
+        
+        # Test with a single core/AP.
+        print("\n------ Test 1: Concurrent memory accesses, single core ------")
+        
+        core = target.cores[0]
+
+        # Write chunk patterns concurrently.
+        print("Writing %i regions to RAM" % TEST_THREAD_COUNT)
+        run_in_parallel(write_chunk_data, [[core, i] for i in range(TEST_THREAD_COUNT)])
+        
+        print("Reading %i regions to RAM" % TEST_THREAD_COUNT)
+        chunk_read_data = [list() for i in range(TEST_THREAD_COUNT)]
+        run_in_parallel(read_chunk_data, [[core, i] for i in range(TEST_THREAD_COUNT)])
+        
+        print("Comparing data")
+        
+        for i in range(TEST_THREAD_COUNT):
+            test_count += 1
+            if same(chunk_read_data[i], chunk_data[i]):
+                test_pass_count += 1
+                print("Region %i PASSED" % i)
+            else:
+                print("Region %i FAILED" % i)
+        
+        # Test with a multiple cores/APs.
+        # Disabled until cores each have their own memory map, the regions accessible to each
+        # core can be identified.
+        if False: # len(target.cores) > 1:
+            print("\n------ Test 2: Concurrent memory accesses, multiple cores ------")
+            
+            cycle_count = ((len(target.cores) + TEST_THREAD_COUNT - 1) // TEST_THREAD_COUNT * TEST_THREAD_COUNT)
+            repeat_cores = ncycles(iter(target.cores), cycle_count)
+            thread_args = []
+            for i in range(TEST_THREAD_COUNT):
+                thread_args.append((target.cores[next(repeat_cores)], i))
+
+            # Write chunk patterns concurrently.
+            print("Writing %i regions to RAM" % TEST_THREAD_COUNT)
+            run_in_parallel(write_chunk_data, thread_args)
+        
+            print("Reading %i regions to RAM" % TEST_THREAD_COUNT)
+            chunk_read_data = [list() for i in range(TEST_THREAD_COUNT)]
+            run_in_parallel(read_chunk_data, thread_args)
+        
+            print("Comparing data")
+        
+            for i in range(TEST_THREAD_COUNT):
+                test_count += 1
+                if same(chunk_read_data[i], chunk_data[i]):
+                    test_pass_count += 1
+                    print("Region %i PASSED" % i)
+                else:
+                    print("Region %i FAILED" % i)
+
+        # --- end ---
+        print("\nTest Summary:")
+        print("Pass count %i of %i tests" % (test_pass_count, test_count))
+        if test_pass_count == test_count:
+            print("CONCURRENCY TEST PASSED")
+        else:
+            print("CONCURRENCY TEST FAILED")
+
+        target.reset()
+
+        result.passed = test_count == test_pass_count
+        return result
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='pyOCD concurrency test')
+    parser.add_argument('-d', '--debug', action="store_true", help='Enable debug logging')
+    parser.add_argument("-da", "--daparg", dest="daparg", nargs='+', help="Send setting to DAPAccess layer.")
+    args = parser.parse_args()
+    level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(level=level)
+    DAPAccess.set_args(args.daparg)
+    # Set to debug to print some of the decisions made while flashing
+    session = ConnectHelper.session_with_chosen_probe(**get_session_options())
+    test = ConcurrencyTest()
+    result = [test.run(session.board)]
+

--- a/test/parallel_test.py
+++ b/test/parallel_test.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2016-2019 Arm Limited
+# Copyright (c) 2016-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,31 +21,7 @@ import multiprocessing
 from pyocd.core.helpers import ConnectHelper
 from pyocd.probe.pydapaccess import DAPAccess
 
-def run_in_parallel(function, args_list):
-    """Create and run a thread in parallel for each element in args_list
-
-    Wait until all threads finish executing. Throw an exception if an exception
-    occurred on any of the threads.
-    """
-    def _thread_helper(idx, func, args):
-        """Run the function and set result to True if there was not error"""
-        func(*args)
-        result_list[idx] = True
-
-    result_list = [False] * len(args_list)
-    thread_list = []
-    for idx, args in enumerate(args_list):
-        thread = threading.Thread(target=_thread_helper,
-                                  args=(idx, function, args))
-        thread.start()
-        thread_list.append(thread)
-
-    for thread in thread_list:
-        thread.join()
-    for result in result_list:
-        if result is not True:
-            raise Exception("Running in thread failed")
-
+from test_util import run_in_parallel
 
 def run_in_processes(function, args_list):
     """Create and run a processes in parallel for each element in args_list

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2015-2019 Arm Limited
+# Copyright (c) 2015-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@ from xml.etree import ElementTree
 import six
 import subprocess
 import tempfile
+import threading
 from pyocd.utility.compatibility import to_str_safe
 
 isPy2 = (sys.version_info[0] == 2)
@@ -93,6 +94,31 @@ def binary_to_elf_file(binary_file, base_address):
     if sys.platform.startswith('win'):
         temp_test_elf_name = temp_test_elf_name.replace('\\', '\\\\')
     return temp_test_elf_name
+
+def run_in_parallel(function, args_list):
+    """Create and run a thread in parallel for each element in args_list
+
+    Wait until all threads finish executing. Throw an exception if an exception
+    occurred on any of the threads.
+    """
+    def _thread_helper(idx, func, args):
+        """Run the function and set result to True if there was not error"""
+        func(*args)
+        result_list[idx] = True
+
+    result_list = [False] * len(args_list)
+    thread_list = []
+    for idx, args in enumerate(args_list):
+        thread = threading.Thread(target=_thread_helper,
+                                  args=(idx, function, args))
+        thread.start()
+        thread_list.append(thread)
+
+    for thread in thread_list:
+        thread.join()
+    for result in result_list:
+        if result is not True:
+            raise Exception("Running in thread failed")
 
 class IOTee(object):
     def __init__(self, *args):


### PR DESCRIPTION
This PR resolves issues for concurrent AP and DP accesses from multiple threads. Accesses are only locked if the implementation requires multiple calls to the probe layer.

This PR includes several group of connected changes:

- Add capability flags to `DebugProbe`. Several properties were replaced with capabilities. Most importantly, capabilities specify whether the probe handles DP bank and AP address selection internally (as STLink and J-Link do).
- Handling of AP and AP register bank selection moved into `DebugPort` (for when the probe doesn't handle this internally, as indicated by the capability flags). This required adding `{read,write}_ap_multiple()` methods to `DebugPort`. The reason for this change is that it simplifies management of locking.
- All locking above the internal probe level is done with a single lock on the `DebugProbe` instance via that class' new `lock()` and `unlock()` methods. The DP and AP now call these methods for locking.

For instance, a DP register access only acquires the probe lock if the register address honours `DPBANKSEL`, because that requires two calls to `DebugProbe.write_dp()`. For an access to a DP register such as `RDBUFF`, only one probe call is needed because `DPBANKSEL` is ignored.

This locking design favours correctness over concurrency. Improvements to the design to increase concurrency are likely over time. Also, there are remaining higher-level APIs that are not thread safe, such as breakpoint management for a single core. These APIs will be addressed in the future, and documentation will be added to indicate which APIs are thread safe.

Other notes:

- Support for accessing banked DP registers was added to the STLink probe. It requires firmware version V2J32 or V3J2.
- A `concurrency_test.py` functional test was added. It simply reads and writes memory concurrently, for now from a single AP.