### PR TITLE
Resolve isAlive deprecation warning

### DIFF
--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -699,7 +699,7 @@ class PyOCDTool(object):
                         server_listening_callback=self.server_listening)
                     gdbs.append(gdb)
                 gdb = gdbs[0]
-                while gdb.isAlive():
+                while gdb.is_alive():
                     gdb.join(timeout=0.5)
         except (KeyboardInterrupt, Exception):
             for gdb in gdbs:

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -233,13 +233,13 @@ class GDBServer(threading.Thread):
         self.start()
 
     def restart(self):
-        if self.isAlive():
+        if self.is_alive():
             self.detach_event.set()
 
     def stop(self):
-        if self.isAlive():
+        if self.is_alive():
             self.shutdown_event.set()
-            while self.isAlive():
+            while self.is_alive():
                 pass
             LOG.info("GDB server thread killed")
 

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -294,7 +294,7 @@ class GDBServerTool(object):
                             server_listening_callback=self.server_listening)
                         gdbs.append(gdb)
                     gdb = gdbs[0]
-                    while gdb.isAlive():
+                    while gdb.is_alive():
                         gdb.join(timeout=0.5)
             except KeyboardInterrupt:
                 for gdb in gdbs:


### PR DESCRIPTION
Prevent deprecating warnings about `threading.Thread.isAlive()` by renaming to `is_alive()`.