### PR TITLE
Commander improvements

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -37,6 +37,13 @@ Whether to perform a chip erase or sector erases when programming flash. The val
 'auto', 'sector', or 'chip'.
 </td></tr>
 
+<tr><td>commander.history_length</td>
+<td>int</td>
+<td>1000</td>
+<td>
+Number of entries in the pyOCD Commander command history. Set to -1 for unlimited.
+</td></tr>
+
 <tr><td>config_file</td>
 <td>str</td>
 <td><i>See description.</i></td>

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -27,6 +27,8 @@ OPTIONS_INFO = {
     'chip_erase': OptionInfo('chip_erase', str, "sector",
         "Whether to perform a chip erase or sector erases when programming flash. The value must be"
         " one of \"auto\", \"sector\", or \"chip\"."),
+    'commander.history_length': OptionInfo('commander.history_length', int, 1000,
+        "Number of entries in the pyOCD Commander command history. Set to -1 for unlimited. Default is 1000."),
     'config_file': OptionInfo('config_file', str, None,
         "Path to custom config file."),
     'connect_mode': OptionInfo('connect_mode', str, "halt",

--- a/pyocd/coresight/cortex_m_v8m.py
+++ b/pyocd/coresight/cortex_m_v8m.py
@@ -42,6 +42,9 @@ class CortexM_v8M(CortexM):
     PFR1 = 0xE000ED44
     PFR1_SECURITY_MASK = 0x000000f0
     PFR1_SECURITY_SHIFT = 4
+    
+    PFR1_SECURITY_EXT_V8_0 = 0x1 # Base security extension.
+    PFR1_SECURITY_EXT_V8_1 = 0x3 # v8.1-M adds several instructions.
 
     def __init__(self, rootTarget, ap, memoryMap=None, core_num=0, cmpid=None, address=None):
         super(CortexM_v8M, self).__init__(rootTarget, ap, memoryMap, core_num, cmpid, address)
@@ -59,7 +62,7 @@ class CortexM_v8M(CortexM):
         if self.has_security_extension:
             return (Target.SecurityState.NONSECURE, Target.SecurityState.SECURE)
         else:
-            return (Target.SecurityState.NONSECURE)
+            return (Target.SecurityState.NONSECURE,)
 
     def _read_core_type(self):
         """! @brief Read the CPUID register and determine core type and architecture."""
@@ -77,7 +80,8 @@ class CortexM_v8M(CortexM):
         self.cpu_patch = (cpuid & CortexM.CPUID_REVISION_MASK) >> CortexM.CPUID_REVISION_POS
         
         pfr1 = self.read32(self.PFR1)
-        self.has_security_extension = ((pfr1 & self.PFR1_SECURITY_MASK) >> self.PFR1_SECURITY_SHIFT) == 1
+        pfr1_sec = ((pfr1 & self.PFR1_SECURITY_MASK) >> self.PFR1_SECURITY_SHIFT)
+        self.has_security_extension = pfr1_sec in (self.PFR1_SECURITY_EXT_V8_0, self.PFR1_SECURITY_EXT_V8_1)
         
         if arch == self.ARMv8M_BASE:
             self._architecture = CoreArchitecture.ARMv8M_BASE

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -1671,6 +1671,7 @@ class PyOCDCommander(object):
             addr = self.convert_value(args[0])
         else:
             addr = self.target.read_core_register('pc')
+        addr &= ~0x1 # remove thumb bit
         
         lineInfo = self.elf.address_decoder.get_line_for_address(addr)
         if lineInfo is not None:
@@ -1683,10 +1684,13 @@ class PyOCDCommander(object):
         fnInfo = self.elf.address_decoder.get_function_for_address(addr)
         if fnInfo is not None:
             name = fnInfo.name.decode()
+            offset = addr - fnInfo.low_pc
         else:
             name = "<unknown symbol>"
+            offset = 0
         
-        print("{addr:#10x} : {fn} : {pathline}".format(addr=addr, fn=name, pathline=pathline))
+        print("{addr:#10x} : {fn}+{offset} : {pathline}".format(
+                addr=addr, fn=name, offset=offset, pathline=pathline))
 
     def handle_symbol(self, args):
         if self.elf is None:

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -71,14 +71,6 @@ LEVELS = {
         'critical':logging.CRITICAL
         }
 
-CORE_STATUS_DESC = {
-        Target.State.HALTED : "Halted",
-        Target.State.RUNNING : "Running",
-        Target.State.RESET : "Reset",
-        Target.State.SLEEPING : "Sleeping",
-        Target.State.LOCKUP : "Lockup",
-        }
-
 VC_NAMES_MAP = {
         Target.VectorCatch.HARD_FAULT : "hard fault",
         Target.VectorCatch.BUS_FAULT : "bus fault",
@@ -719,7 +711,7 @@ class PyOCDCommander(object):
                             status = "locked"
                         else:
                             try:
-                                status = CORE_STATUS_DESC[self.target.get_state()]
+                                status = self.target.get_state().name.capitalize()
                             except (AttributeError, KeyError):
                                 status = "<no core>"
 
@@ -882,7 +874,11 @@ class PyOCDCommander(object):
         if not self.target.is_locked():
             for i, c in enumerate(self.target.cores):
                 core = self.target.cores[c]
-                print("Core %d:  %s" % (i, CORE_STATUS_DESC[core.get_state()]))
+                state_desc = core.get_state().name.capitalize()
+                desc = "Core %d:  %s" % (i, state_desc)
+                if len(core.supported_security_states) > 1:
+                    desc += " [%s]" % core.get_security_state().name.capitalize()
+                print(desc)
         else:
             print("Target is locked")
 
@@ -1399,7 +1395,7 @@ class PyOCDCommander(object):
 
         status = self.target.get_state()
         if status != Target.State.HALTED:
-            print("Failed to halt device; target state is %s" % CORE_STATUS_DESC[status])
+            print("Failed to halt device; target state is %s" % status.name.capitalize())
             return 1
         else:
             print("Successfully halted device")

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -900,6 +900,10 @@ class PyOCDCommander(object):
 
         reg = args[0].lower()
         if reg in coresight.cortex_m.CORE_REGISTER:
+            if not self.target.is_halted():
+                print("Core is not halted; cannot read core registers")
+                return
+
             value = self.target.read_core_register(reg)
             if isinstance(value, six.integer_types):
                 print("%s = 0x%08x (%d)" % (reg, value, value))
@@ -938,6 +942,10 @@ class PyOCDCommander(object):
 
         reg = args[0].lower()
         if reg in coresight.cortex_m.CORE_REGISTER:
+            if not self.target.is_halted():
+                print("Core is not halted; cannot write core registers")
+                return
+
             if (reg.startswith('s') and reg != 'sp') or reg.startswith('d'):
                 value = float(args[1])
             else:
@@ -1373,6 +1381,10 @@ class PyOCDCommander(object):
             print("Unknown target status: %s" % status)
 
     def handle_step(self, args):
+        if not self.target.is_halted():
+            print("Core is not halted; cannot step")
+            return
+
         self.target.step(disable_interrupts=not self.step_into_interrupt)
         addr = self.target.read_core_register('pc')
         if isCapstoneAvailable:
@@ -2055,6 +2067,10 @@ Prefix line with ! to execute a shell command.""")
                 'r3', 'r9', 'pc',
                 'r4', 'r10', 'xpsr',
                 'r5', 'r11', 'primask']
+
+        if not self.target.is_halted():
+            print("Core is not halted; cannot read core registers")
+            return
 
         for i, reg in enumerate(regs):
             regValue = self.target.read_core_register(reg)


### PR DESCRIPTION
- Prevent accessing core registers unless core is halted. An error is printed.
- Print core security state in status command, if the core has more than one security state.
- `reg all` will print all available core register values.
- Command history file support, so the history is saved between runs of `pyocd commander`.
   - By default the history is stored in `~/.pyocd_history`. The `PYOCD_HISTORY` environment variable will override this if set.
   - The default history length is 1000 entries. The `PYOCD_HISTORY_LENGTH` environment variable or `commander.history_length` option allow you to change this. Setting either one to -1 will enable an infinite history (but beware history file size).
- `where` command prints the offset from the base address of the symbol.

Also included is a fix for detecting the Security extension in v8.1-M devices (Cortex-M55).