### PR TITLE
Some Cortex-M changes and fixes

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -162,13 +162,6 @@ Path or list of paths to CMSIS Device Family Packs. Devices defined in the pack(
 list of available targets.
 </td></tr>
 
-<tr><td>probe_all_aps</td>
-<td>bool</td>
-<td>False</td>
-<td>
-Controls whether all 256 ADIv5 AP addresses will be probed.
-</td></tr>
-
 <tr><td>project_dir</td>
 <td>str</td>
 <td><i>See description.</i></td>
@@ -211,6 +204,13 @@ Timeout for waiting for the core to halt after a reset and halt.
 <td>True</td>
 <td>
 Whether to resume a halted target when disconnecting.
+</td></tr>
+
+<tr><td>scan_all_aps</td>
+<td>bool</td>
+<td>False</td>
+<td>
+Controls whether all 256 ADIv5 AP addresses will be probed.
 </td></tr>
 
 <tr><td>smart_flash</td>

--- a/docs/options.md
+++ b/docs/options.md
@@ -199,6 +199,13 @@ Number of seconds to hold hardware reset asserted.
 Number of seconds to delay after a reset is issued.
 </td></tr>
 
+<tr><td>reset.halt_timeout</td>
+<td>float</td>
+<td>2.0</td>
+<td>
+Timeout for waiting for the core to halt after a reset and halt.
+</td></tr>
+
 <tr><td>resume_on_disconnect</td>
 <td>bool</td>
 <td>True</td>

--- a/docs/options.md
+++ b/docs/options.md
@@ -360,6 +360,7 @@ The source letters are:
 - `h`=hard fault
 - `b`=bus fault
 - `m`=mem fault
+- `e`=secure fault
 - `i`=irq err
 - `s`=state err
 - `c`=check err

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -63,8 +63,6 @@ BUILTIN_OPTIONS = [
     OptionInfo('pack', (str, list), None,
         "Path or list of paths to CMSIS Device Family Packs. Devices defined in the pack(s) are "
         "added to the list of available targets."),
-    OptionInfo('scan_all_aps', bool, False,
-        "Controls whether all 256 ADIv5 AP addresses will be probed. Default is False."),
     OptionInfo('project_dir', str, None,
         "Path to the session's project directory. Defaults to the working directory when the pyocd "
         "tool was executed."),
@@ -79,6 +77,8 @@ BUILTIN_OPTIONS = [
         "Timeout for waiting for the core to halt after a reset and halt. Default is 2.0 s."),
     OptionInfo('resume_on_disconnect', bool, True,
         "Whether to run target on disconnect."),
+    OptionInfo('scan_all_aps', bool, False,
+        "Controls whether all 256 ADIv5 AP addresses will be probed. Default is False."),
     OptionInfo('smart_flash', bool, True,
         "If set to True, the flash loader will attempt to not program pages whose contents are not "
         "going to change by scanning target flash memory. A value of False will force all pages to "

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -75,6 +75,8 @@ BUILTIN_OPTIONS = [
         "Number of seconds to hold hardware reset asserted. Default is 0.1 s (100 ms)."),
     OptionInfo('reset.post_delay', float, 0.1,
         "Number of seconds to delay after a reset is issued. Default is 0.1 s (100 ms)."),
+    OptionInfo('reset.halt_timeout', float, 2.0,
+        "Timeout for waiting for the core to halt after a reset and halt. Default is 2.0 s."),
     OptionInfo('resume_on_disconnect', bool, True,
         "Whether to run target on disconnect."),
     OptionInfo('smart_flash', bool, True,

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -103,8 +103,11 @@ class Target(MemoryInterface):
         COPROCESSOR_ERR = (1 << 6)
         ## Trap on local reset.
         CORE_RESET = (1 << 7)
-        ALL = (HARD_FAULT | BUS_FAULT | MEM_FAULT | INTERRUPT_ERR \
-                    | STATE_ERR | CHECK_ERR | COPROCESSOR_ERR | CORE_RESET)
+        ## Trap SecureFault.
+        SECURE_FAULT = (1 << 8)
+        ALL = (HARD_FAULT | BUS_FAULT | MEM_FAULT | INTERRUPT_ERR
+                    | STATE_ERR | CHECK_ERR | COPROCESSOR_ERR | CORE_RESET
+                    | SECURE_FAULT)
 
     class Event(Enum):
         """! Target notification events."""

--- a/pyocd/coresight/core_ids.py
+++ b/pyocd/coresight/core_ids.py
@@ -57,4 +57,20 @@ class CoreArchitecture(Enum):
     ARMv8M_BASE = 3
     ARMv8M_MAIN = 4
     
-
+class CortexMExtension(Enum):
+    """! @brief Extensions for the Cortex-M architecture."""
+    FPU = "FPU" # Single-Precision floating point
+    DSP = "DSP" # Digital Signal Processing instructions
+    FPU_DP = "FPU_DP" # Double-Precision floating point
+    FPU_HP = "FPU_HP" # Half-Precision floating point
+    SEC = "SEC" # Security Extension
+    MVE = "MVE" # M-profile Vector Extension
+    UDE = "UDE" # Unprivileged Debug Extension
+    RAS = "RAS" # Reliability, Serviceability, and Availability
+    PMU = "PMU" # Performance Monitoring Unit
+    LOB = "LOB" # Low-Overhead loops and Branch Future
+    PXN = "PXN" # Privileged eXecute-Never
+    MAIN = "MAIN" # Main Extension
+    MPU = "MPU" # Memory Protection Unit
+    DIT = "DIT" # Data-Independent Timing
+    FPCXT = "FPCXT" # Floating Point Context

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -208,6 +208,7 @@ class CortexM(Target, CoreSightCoreComponent):
     DEMCR = 0xE000EDFC
     # DWTENA in armv6 architecture reference manual
     DEMCR_TRCENA = (1 << 24)
+    DEMCR_VC_SFERR = (1 << 11)
     DEMCR_VC_HARDERR = (1 << 10)
     DEMCR_VC_INTERR = (1 << 9)
     DEMCR_VC_BUSERR = (1 << 8)
@@ -1289,6 +1290,8 @@ class CortexM(Target, CoreSightCoreComponent):
             result |= CortexM.DEMCR_VC_NOCPERR
         if mask & Target.VectorCatch.CORE_RESET:
             result |= CortexM.DEMCR_VC_CORERESET
+        if mask & Target.VectorCatch.SECURE_FAULT:
+            result |= CortexM.DEMCR_VC_SFERR
         return result
 
     @staticmethod
@@ -1310,6 +1313,8 @@ class CortexM(Target, CoreSightCoreComponent):
             result |= Target.VectorCatch.COPROCESSOR_ERR
         if mask & CortexM.DEMCR_VC_CORERESET:
             result |= Target.VectorCatch.CORE_RESET
+        if mask & CortexM.DEMCR_VC_SFERR:
+            result |= Target.VectorCatch.SECURE_FAULT
         return result
 
     def set_vector_catch(self, enableMask):

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -25,7 +25,7 @@ from ..utility.notification import Notification
 from .component import CoreSightCoreComponent
 from .fpb import FPB
 from .dwt import DWT
-from .core_ids import (CORE_TYPE_NAME, CoreArchitecture)
+from .core_ids import (CORE_TYPE_NAME, CoreArchitecture, CortexMExtension)
 from ..debug.breakpoints.manager import BreakpointManager
 from ..debug.breakpoints.software import SoftwareBreakpointProvider
 
@@ -399,6 +399,7 @@ class CortexM(Target, CoreSightCoreComponent):
         CoreSightCoreComponent.__init__(self, ap, cmpid, address)
 
         self._architecture = None
+        self._extensions = []
         self.core_type = 0
         self.has_fpu = False
         self.core_number = core_num
@@ -440,6 +441,11 @@ class CortexM(Target, CoreSightCoreComponent):
     def architecture(self):
         """! @brief @ref pyocd.coresight.core_ids.CoreArchitecture "CoreArchitecture" for this core."""
         return self._architecture
+
+    @property
+    def extensions(self):
+        """! @brief List of extensions supported by this core."""
+        return self._extensions
 
     @property
     def elf(self):
@@ -617,6 +623,8 @@ class CortexM(Target, CoreSightCoreComponent):
         self.write32(CortexM.CPACR, originalCpacr)
 
         if self.has_fpu:
+            self._extensions.append(CortexMExtension.FPU)
+            
             # Now check whether double-precision is supported.
             # (Minimal tests to distinguish current permitted ARMv7-M and
             # ARMv8-M FPU types; used for printing only).
@@ -628,6 +636,7 @@ class CortexM(Target, CoreSightCoreComponent):
 
             if dp_val >= 2:
                 fpu_type = "FPv5"
+                self._extensions.append(CortexMExtension.FPU_DP)
             elif vfp_misc_val >= 4:
                 fpu_type = "FPv5-SP"
             else:

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -654,12 +654,12 @@ class CortexM(Target, CoreSightCoreComponent):
             vfp_misc_val = (mvfr2 & CortexM.MVFR2_VFP_MISC_MASK) >> CortexM.MVFR2_VFP_MISC_SHIFT
 
             if dp_val >= 2:
-                fpu_type = "FPv5"
+                fpu_type = "FPv5-D16-M"
                 self._extensions.append(CortexMExtension.FPU_DP)
             elif vfp_misc_val >= 4:
-                fpu_type = "FPv5-SP"
+                fpu_type = "FPv5-SP-D16-M"
             else:
-                fpu_type = "FPv4-SP"
+                fpu_type = "FPv4-SP-D16-M"
             LOG.info("FPU present: " + fpu_type)
 
     def write_memory(self, addr, value, transfer_size=32):

--- a/pyocd/coresight/cortex_m_v8m.py
+++ b/pyocd/coresight/cortex_m_v8m.py
@@ -17,7 +17,7 @@
 import logging
 
 from .cortex_m import CortexM
-from .core_ids import (CORE_TYPE_NAME, CoreArchitecture)
+from .core_ids import (CORE_TYPE_NAME, CoreArchitecture, CortexMExtension)
 from ..core import exceptions
 from ..core.target import Target
 
@@ -82,6 +82,8 @@ class CortexM_v8M(CortexM):
         pfr1 = self.read32(self.PFR1)
         pfr1_sec = ((pfr1 & self.PFR1_SECURITY_MASK) >> self.PFR1_SECURITY_SHIFT)
         self.has_security_extension = pfr1_sec in (self.PFR1_SECURITY_EXT_V8_0, self.PFR1_SECURITY_EXT_V8_1)
+        if self.has_security_extension:
+            self._extensions.append(CortexMExtension.SEC)
         
         if arch == self.ARMv8M_BASE:
             self._architecture = CoreArchitecture.ARMv8M_BASE

--- a/pyocd/coresight/discovery.py
+++ b/pyocd/coresight/discovery.py
@@ -102,7 +102,7 @@ class ADIv5Discovery(CoreSightDiscovery):
         """! @brief Find valid APs using the ADIv5 method.
         
         Scans for valid APs starting at APSEL=0. The default behaviour is to stop after reading
-        0 for the AP's IDR twice in succession. If the `probe_all_aps` user option is set to True,
+        0 for the AP's IDR twice in succession. If the `scan_all_aps` user option is set to True,
         then the scan will instead probe every APSEL from 0-255.
         
         If there is already a list of valid APs defined for the @ref pyocd.coresight.dap.DebugPort
@@ -125,7 +125,7 @@ class ADIv5Discovery(CoreSightDiscovery):
                 if isValid:
                     ap_list.append(apsel)
                     invalid_count = 0
-                elif not self.session.options.get('probe_all_aps'):
+                elif not self.session.options.get('scan_all_aps'):
                     invalid_count += 1
                     if invalid_count == 2:
                         break

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -81,6 +81,7 @@ VC_NAMES_MAP = {
         Target.VectorCatch.CHECK_ERR : "check error",
         Target.VectorCatch.COPROCESSOR_ERR : "coprocessor error",
         Target.VectorCatch.CORE_RESET : "core reset",
+        Target.VectorCatch.SECURE_FAULT : "secure fault",
         }
 
 HPROT_BIT_DESC = {

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -56,6 +56,7 @@ def split_command_line(cmd_line):
 
 ## Map of vector char characters to masks.
 VECTOR_CATCH_CHAR_MAP = {
+        'e': Target.VectorCatch.SECURE_FAULT,
         'h': Target.VectorCatch.HARD_FAULT,
         'b': Target.VectorCatch.BUS_FAULT,
         'm': Target.VectorCatch.MEM_FAULT,


### PR DESCRIPTION
- Added vector catch support for the v8-M SecureFault. The character `e` in the `vector_catch` option's value enables.
- `CortexM` and subclasses gain an `extensions` property that is a list of `pyocd.coresight.core_ids.CortexMExtension` enums. While enums for the full set of v8.1-M extensions are defined, only `FPU`, `FPU_DP`, and `SEC` are actually detected and added to the list.
- The `reset.halt_timeout` option controls the timeout during reset and halt.
- If the `cortex_m` target type is used, it will have the default Cortex-M system memory map as defined in the Architecture Reference Manual instead of an empty memory map. This prevents some issues with gdb.
- Fixed name of `scan_all_aps` option in several places, so it actually works now.
- Logging the fully characterized name of a detected FPU, e.g. "FPv4-SP-D16-M", "FPv5-SP-D16-M", or "FPv5-D16-M".