### PR TITLE
Raise error if the config file does not have a top-level dict.

### DIFF
--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -27,6 +27,7 @@ try:
 except ImportError:
     from inspect import getargspec
 
+from . import exceptions
 from .options_manager import OptionsManager
 from ..board.board import Board
 from ..utility.notification import Notifier
@@ -187,7 +188,11 @@ class Session(Notifier):
                 try:
                     with open(configPath, 'r') as configFile:
                         LOG.debug("Loading config from: %s", configPath)
-                        return yaml.safe_load(configFile)
+                        config = yaml.safe_load(configFile)
+                        if not isinstance(config, dict):
+                            raise exceptions.Error("configuration file %s does not contain a top-level dictionary"
+                                    % configPath)
+                        return config
                 except IOError as err:
                     LOG.warning("Error attempting to access config file '%s': %s", configPath, err)
         


### PR DESCRIPTION
This should make it a lot easier to figure out why the config file is not working as expected in certain cases.