### PR TITLE
Major core register refactoring

### DIFF
--- a/pyocd/core/core_registers.py
+++ b/pyocd/core/core_registers.py
@@ -1,0 +1,230 @@
+# pyOCD debugger
+# Copyright (c) 2019-2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import six
+from copy import copy
+
+from ..utility import conversion
+
+LOG = logging.getLogger(__name__)
+
+class CoreRegisterInfo(object):
+    """! @brief Useful information about a core register.
+    
+    Provides properties for classification of the register, and utilities to convert to and from
+    the raw integer representation of the register value.
+    
+    Each core register has both a name (string), which is always lowercase, and an integer index.
+    The index is a unique identifier with an architecture-specified meaning.
+    """
+
+    ## Map of register name to info.
+    #
+    # This is just a placeholder. The architecture-specific subclass should override the definition. Its
+    # value is set to None to cause an exception if used.
+    _NAME_MAP = None
+    
+    ## Map of register index to info.
+    #
+    # This is just a placeholder. The architecture-specific subclass should override the definition. Its
+    # value is set to None to cause an exception if used.
+    _INDEX_MAP = None
+
+    @classmethod
+    def add_to_map(cls, all_regs):
+        """! @brief Build info map from list of CoreRegisterInfo instance."""
+        for reg in all_regs:
+            cls._NAME_MAP[reg.name] = reg
+            cls._INDEX_MAP[reg.index] = reg
+    
+    @classmethod
+    def get(cls, reg):
+        """! @brief Return the CoreRegisterInfo instance for a register.
+        @param reg Either a register name or internal register number.
+        @return CoreRegisterInfo
+        @exception KeyError
+        """
+        try:
+            if isinstance(reg, six.string_types):
+                reg = reg.lower()
+                return cls._NAME_MAP[reg]
+            else:
+                return cls._INDEX_MAP[reg]
+        except KeyError as err:
+            six.raise_from(KeyError('unknown core register %s' % reg), err)
+
+    def __init__(self, name, index, bitsize, reg_type, reg_group, reg_num=None, feature=None):
+        """! @brief Constructor."""
+        self._name = name
+        self._index = index
+        self._bitsize = bitsize
+        self._group = reg_group
+        self._gdb_type = reg_type
+        self._gdb_regnum = reg_num
+        self._gdb_feature = feature
+
+    @property
+    def name(self):
+        """! @brief Name of the register. Always lowercase."""
+        return self._name
+    
+    @property
+    def index(self):
+        """! @brief Integer index of the register."""
+        return self._index
+    
+    @property
+    def bitsize(self):
+        """! @brief Bit width of the register.."""
+        return self._bitsize
+    
+    @property
+    def group(self):
+        """! @brief Named group the register is contained within."""
+        return self._group
+    
+    @property
+    def gdb_type(self):
+        """! @brief Value type specific to gdb."""
+        return self._gdb_type
+    
+    @property
+    def gdb_regnum(self):
+        """! @brief Register number specific to gdb."""
+        return self._gdb_regnum
+    
+    @property
+    def gdb_feature(self):
+        """! @brief GDB architecture feature to which the register belongs."""
+        return self._gdb_feature
+
+    @property
+    def is_float_register(self):
+        """! @brief Returns true for registers single or double precision float registers (but not, say, FPSCR)."""
+        return self.is_single_float_register or self.is_double_float_register
+
+    @property
+    def is_single_float_register(self):
+        """! @brief Returns true for registers holding single-precision float values"""
+        return self.gdb_type == 'ieee_single'
+
+    @property
+    def is_double_float_register(self):
+        """! @brief Returns true for registers holding double-precision float values"""
+        return self.gdb_type == 'ieee_double'
+    
+    def from_raw(self, value):
+        """! @brief Convert register value from raw (integer) to canonical type."""
+        # Convert int to float.
+        if self.is_single_float_register:
+            value = conversion.u32_to_float32(value)
+        elif self.is_double_float_register:
+            value = conversion.u64_to_float64(value)
+        return value
+    
+    def to_raw(self, value):
+        """! @brief Convert register value from canonical type to raw (integer)."""
+        # Convert float to int.
+        if isinstance(value, float):
+            if self.is_single_float_register:
+                value = conversion.float32_to_u32(value)
+            elif self.is_double_float_register:
+                value = conversion.float64_to_u64(value)
+            else:
+                raise TypeError("non-float register value has float type")
+        return value
+    
+    def clone(self):
+        """! @brief Return a copy of the register info."""
+        return copy(self)
+    
+    def __eq__(self, other):
+        return isinstance(other, CoreRegisterInfo) and (self.index == other.index)
+    
+    def __hash__(self):
+        return hash(self.index)
+    
+    def __repr__(self):
+        return "<{}@{:#x} {}={} {}-bit>".format(self.__class__.__name__, id(self), self.name, self.index, self.bitsize)
+
+class CoreRegistersIndex(object):
+    """! @brief Class to hold indexes of available core registers.
+    
+    This class is meant to be used by a core to hold the set of core registers that are actually present on
+    a particular device, as determined by runtime inspection of the core. A number of properties are made
+    available to access the core registers by various keys.
+    """
+
+    def __init__(self):
+        self._groups = set()
+        self._all = set()
+        self._by_name = {}
+        self._by_index = {}
+        self._by_feature = {}
+    
+    @property
+    def groups(self):
+        """! @brief Set of unique register group names."""
+        return self._groups
+    
+    @property
+    def as_set(self):
+        """! @brief Set of available registers as CoreRegisterInfo objects."""
+        return self._all
+    
+    @property
+    def by_name(self):
+        """! @brief Dict of (register name) -> CoreRegisterInfo."""
+        return self._by_name
+
+    @property
+    def by_index(self):
+        """! @brief Dict of (register index) -> CoreRegisterInfo."""
+        return self._by_index
+
+    @property
+    def by_feature(self):
+        """! @brief Dict of (register gdb feature) -> List[CoreRegisterInfo]."""
+        return self._by_feature
+    
+    def iter_matching(self, predicate):
+        """! @brief Iterate over registers matching a given predicate callable.
+        @param self The object.
+        @param predicate Callable accepting a single argument, a CoreRegisterInfo, and returning a boolean.
+            If the predicate returns True then the iterator will include the register.
+        """
+        for reg in self._all:
+            if predicate(reg):
+                yield reg
+    
+    def add_group(self, regs):
+        """! @brief Add a list of registers.
+        @param self The object.
+        @param regs Iterable of CoreRegisterInfo objects. The objects are copied as they are added.
+        """
+        for reg in regs:
+            reg_copy = reg.clone()
+            self._groups.add(reg_copy.group)
+            self._all.add(reg_copy)
+            self._by_name[reg_copy.name] = reg_copy
+            self._by_index[reg_copy.index] = reg_copy
+            if reg_copy.gdb_feature is not None:
+                try:
+                    self._by_feature[reg_copy.gdb_feature].append(reg_copy)
+                except KeyError:
+                    self._by_feature[reg_copy.gdb_feature] = [reg_copy]
+

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -104,6 +104,10 @@ class CoreSightTarget(Target, GraphNode):
     @property
     def supported_security_states(self):
         return self.selected_core.supported_security_states
+    
+    @property
+    def core_registers(self):
+        return self.selected_core.core_registers
 
     @property
     def svd_device(self):

--- a/pyocd/core/exceptions.py
+++ b/pyocd/core/exceptions.py
@@ -49,6 +49,10 @@ class DebugError(TargetError):
     """! @brief Error controlling target debug resources"""
     pass
 
+class CoreRegisterAccessError(DebugError):
+    """! @brief Failure to read or write a core register."""
+    pass
+
 class TransferError(DebugError):
     """! @brief Error ocurred with a transfer over SWD or JTAG"""
     pass

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -217,6 +217,10 @@ class Target(MemoryInterface):
     @property
     def supported_security_states(self):
         raise NotImplementedError()
+    
+    @property
+    def core_registers(self):
+        raise NotImplementedError()
 
     def is_locked(self):
         return False

--- a/pyocd/coresight/core_ids.py
+++ b/pyocd/coresight/core_ids.py
@@ -64,7 +64,9 @@ class CortexMExtension(Enum):
     FPU_DP = "FPU_DP" # Double-Precision floating point
     FPU_HP = "FPU_HP" # Half-Precision floating point
     SEC = "SEC" # Security Extension
-    MVE = "MVE" # M-profile Vector Extension
+    SEC_V81 = "SEC_V81" # v8.1-M additions to the Security Extension
+    MVE = "MVE" # M-profile Vector Extension, with integer support
+    MVE_FP = "MVE_FP" # M-profile Vector Extension single- and half-precision floating-point
     UDE = "UDE" # Unprivileged Debug Extension
     RAS = "RAS" # Reliability, Serviceability, and Availability
     PMU = "PMU" # Performance Monitoring Unit

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -20,159 +20,22 @@ from xml.etree.ElementTree import (Element, SubElement, tostring)
 
 from ..core.target import Target
 from ..core import exceptions
+from ..core.core_registers import CoreRegistersIndex
 from ..core.memory_map import (MemoryMap, RamRegion, DeviceRegion)
 from ..utility import (cmdline, conversion, timeout)
 from ..utility.notification import Notification
 from .component import CoreSightCoreComponent
 from .fpb import FPB
 from .dwt import DWT
-from .core_ids import (CORE_TYPE_NAME, CoreArchitecture, CortexMExtension)
+from .core_ids import (CORE_TYPE_NAME, CoreArchitecture, CortexMExtension )
+from .cortex_m_core_registers import (
+    CortexMCoreRegisterInfo,
+    CoreRegisterGroups,
+    )
 from ..debug.breakpoints.manager import BreakpointManager
 from ..debug.breakpoints.software import SoftwareBreakpointProvider
 
 LOG = logging.getLogger(__name__)
-
-## @brief Map from register name to DCRSR register index.
-#
-# The CONTROL, FAULTMASK, BASEPRI, and PRIMASK registers are special in that they share the
-# same DCRSR register index and are returned as a single value. In this dict, these registers
-# have negative values to signal to the register read/write functions that special handling
-# is necessary. The values are the byte number containing the register value, plus 1 and then
-# negated. So -1 means a mask of 0xff, -2 is 0xff00, and so on. The actual DCRSR register index
-# for these combined registers has the key of 'cfbp'.
-#
-# XPSR is always read in its entirety via the debug interface, but we also provide
-# aliases for the submasks APSR, IPSR and EPSR. These are encoded as 0x10000 plus 3 lower bits
-# indicating which parts of the PSR we're interested in - encoded the same way as MRS's SYSm.
-# (Note that 'XPSR' continues to denote the raw 32 bits of the register, as per previous versions,
-# not the union of the three APSR+IPSR+EPSR masks which don't cover the entire register).
-#
-# The double-precision floating point registers (D0-D15) are composed of two single-precision
-# floating point registers (S0-S31). The value for double-precision registers in this dict is
-# the negated value of the first associated single-precision register.
-CORE_REGISTER = {
-                 'r0': 0,
-                 'r1': 1,
-                 'r2': 2,
-                 'r3': 3,
-                 'r4': 4,
-                 'r5': 5,
-                 'r6': 6,
-                 'r7': 7,
-                 'r8': 8,
-                 'r9': 9,
-                 'r10': 10,
-                 'r11': 11,
-                 'r12': 12,
-                 'sp': 13,
-                 'r13': 13,
-                 'lr': 14,
-                 'r14': 14,
-                 'pc': 15,
-                 'r15': 15,
-                 'xpsr': 16,
-                 'apsr': 0x10000,
-                 'iapsr': 0x10001,
-                 'eapsr': 0x10002,
-                 'ipsr': 0x10005,
-                 'epsr': 0x10006,
-                 'iepsr': 0x10007,
-                 'msp': 17,
-                 'psp': 18,
-                 'cfbp': 20,
-                 'control':-4,
-                 'faultmask':-3,
-                 'basepri':-2,
-                 'primask':-1,
-                 'fpscr': 33,
-                 's0': 0x40,
-                 's1': 0x41,
-                 's2': 0x42,
-                 's3': 0x43,
-                 's4': 0x44,
-                 's5': 0x45,
-                 's6': 0x46,
-                 's7': 0x47,
-                 's8': 0x48,
-                 's9': 0x49,
-                 's10': 0x4a,
-                 's11': 0x4b,
-                 's12': 0x4c,
-                 's13': 0x4d,
-                 's14': 0x4e,
-                 's15': 0x4f,
-                 's16': 0x50,
-                 's17': 0x51,
-                 's18': 0x52,
-                 's19': 0x53,
-                 's20': 0x54,
-                 's21': 0x55,
-                 's22': 0x56,
-                 's23': 0x57,
-                 's24': 0x58,
-                 's25': 0x59,
-                 's26': 0x5a,
-                 's27': 0x5b,
-                 's28': 0x5c,
-                 's29': 0x5d,
-                 's30': 0x5e,
-                 's31': 0x5f,
-                 'd0': -0x40,
-                 'd1': -0x42,
-                 'd2': -0x44,
-                 'd3': -0x46,
-                 'd4': -0x48,
-                 'd5': -0x4a,
-                 'd6': -0x4c,
-                 'd7': -0x4e,
-                 'd8': -0x50,
-                 'd9': -0x52,
-                 'd10': -0x54,
-                 'd11': -0x56,
-                 'd12': -0x58,
-                 'd13': -0x5a,
-                 'd14': -0x5c,
-                 'd15': -0x5e,
-                 }
-
-def register_name_to_index(reg):
-    if isinstance(reg, str):
-        try:
-            reg = CORE_REGISTER[reg.lower()]
-        except KeyError:
-            raise KeyError('cannot find %s core register' % reg)
-    return reg
-
-def is_float_register(index):
-    return is_single_float_register(index) or is_double_float_register(index)
-
-def is_single_float_register(index):
-    """! @brief Returns true for registers holding single-precision float values"""
-    return 0x40 <= index <= 0x5f
-
-def is_double_float_register(index):
-    """! Returns true for registers holding double-precision float values"""
-    return -0x40 >= index > -0x60
-
-def is_fpu_register(index):
-    return index == 33 or is_single_float_register(index) or is_double_float_register(index)
-
-def is_cfbp_subregister(index):
-    return -4 <= index <= -1
-
-def is_psr_subregister(index):
-    return 0x10000 <= index <= 0x10007
-
-def sysm_to_psr_mask(sysm):
-    """! Generate a PSR mask based on bottom 3 bits of a MRS SYSm value"""
-    mask = 0
-    if (sysm & 1) != 0:
-        mask |= CortexM.IPSR_MASK
-    if (sysm & 2) != 0:
-        mask |= CortexM.EPSR_MASK
-    if (sysm & 4) == 0:
-        mask |= CortexM.APSR_MASK
-    return mask
 
 class CortexM(Target, CoreSightCoreComponent):
     """! @brief CoreSight component for a v6-M or v7-M Cortex-M core.
@@ -306,77 +169,6 @@ class CortexM(Target, CoreSightCoreComponent):
     MVFR2_VFP_MISC_MASK = 0x000000f0
     MVFR2_VFP_MISC_SHIFT = 4
 
-    class RegisterInfo(object):
-        def __init__(self, name, bitsize, reg_type, reg_group):
-            self.name = name
-            self.reg_num = CORE_REGISTER[name]
-            self.bitsize = bitsize
-            self.gdb_xml_attrib = {}
-            self.gdb_xml_attrib['name'] = str(name)
-            self.gdb_xml_attrib['bitsize'] = str(bitsize)
-            self.gdb_xml_attrib['type'] = str(reg_type)
-            self.gdb_xml_attrib['group'] = str(reg_group)
-
-    regs_general = [
-        #            Name       bitsize     type            group
-        RegisterInfo('r0',      32,         'int',          'general'),
-        RegisterInfo('r1',      32,         'int',          'general'),
-        RegisterInfo('r2',      32,         'int',          'general'),
-        RegisterInfo('r3',      32,         'int',          'general'),
-        RegisterInfo('r4',      32,         'int',          'general'),
-        RegisterInfo('r5',      32,         'int',          'general'),
-        RegisterInfo('r6',      32,         'int',          'general'),
-        RegisterInfo('r7',      32,         'int',          'general'),
-        RegisterInfo('r8',      32,         'int',          'general'),
-        RegisterInfo('r9',      32,         'int',          'general'),
-        RegisterInfo('r10',     32,         'int',          'general'),
-        RegisterInfo('r11',     32,         'int',          'general'),
-        RegisterInfo('r12',     32,         'int',          'general'),
-        RegisterInfo('sp',      32,         'data_ptr',     'general'),
-        RegisterInfo('lr',      32,         'int',          'general'),
-        RegisterInfo('pc',      32,         'code_ptr',     'general'),
-        RegisterInfo('msp',     32,         'data_ptr',     'system'),
-        RegisterInfo('psp',     32,         'data_ptr',     'system'),
-        RegisterInfo('primask', 32,         'int',          'system'),
-        ]
-    
-    regs_xpsr_control_plain = [
-        RegisterInfo('xpsr',    32,         'int',          'general'),
-        RegisterInfo('control', 32,         'int',          'system'),
-        ]
-    
-    regs_xpsr_control_fields = [
-        RegisterInfo('xpsr',    32,         'xpsr',         'general'),
-        RegisterInfo('control', 32,         'control',      'system'),
-        ]
-
-    regs_system_armv7_only = [
-        #            Name       bitsize     type            group
-        RegisterInfo('basepri',     32,     'int',          'system'),
-        RegisterInfo('faultmask',   32,     'int',          'system'),
-        ]
-
-    regs_float = [
-        #            Name       bitsize     type            group
-        RegisterInfo('fpscr',   32,         'int',          'float'),
-        RegisterInfo('d0' ,     64,         'ieee_double',  'float'),
-        RegisterInfo('d1' ,     64,         'ieee_double',  'float'),
-        RegisterInfo('d2' ,     64,         'ieee_double',  'float'),
-        RegisterInfo('d3' ,     64,         'ieee_double',  'float'),
-        RegisterInfo('d4' ,     64,         'ieee_double',  'float'),
-        RegisterInfo('d5' ,     64,         'ieee_double',  'float'),
-        RegisterInfo('d6' ,     64,         'ieee_double',  'float'),
-        RegisterInfo('d7' ,     64,         'ieee_double',  'float'),
-        RegisterInfo('d8' ,     64,         'ieee_double',  'float'),
-        RegisterInfo('d9' ,     64,         'ieee_double',  'float'),
-        RegisterInfo('d10',     64,         'ieee_double',  'float'),
-        RegisterInfo('d11',     64,         'ieee_double',  'float'),
-        RegisterInfo('d12',     64,         'ieee_double',  'float'),
-        RegisterInfo('d13',     64,         'ieee_double',  'float'),
-        RegisterInfo('d14',     64,         'ieee_double',  'float'),
-        RegisterInfo('d15',     64,         'ieee_double',  'float'),
-        ]
-
     @classmethod
     def factory(cls, ap, cmpid, address):
         # Create a new core instance.
@@ -413,6 +205,7 @@ class CortexM(Target, CoreSightCoreComponent):
         self._target_context = None
         self._elf = None
         self.target_xml = None
+        self._core_registers = CoreRegistersIndex()
         self._supports_vectreset = False
         self._reset_catch_delegate_result = False
         self._reset_catch_saved_demcr = 0
@@ -452,6 +245,13 @@ class CortexM(Target, CoreSightCoreComponent):
     def extensions(self):
         """! @brief List of extensions supported by this core."""
         return self._extensions
+
+    @property
+    def core_registers(self):
+        """! @brief Instance of @ref pyocd.core.core_registers.CoreRegistersIndex "CoreRegistersIndex"
+            describing available core registers.
+        """
+        return self._core_registers
 
     @property
     def elf(self):
@@ -503,7 +303,7 @@ class CortexM(Target, CoreSightCoreComponent):
         if not self.call_delegate('will_start_debug_core', core=self):
             self._read_core_type()
             self._check_for_fpu()
-            self.build_target_xml()
+            self._build_registers()
             self.sw_bp.init()
 
         self.call_delegate('did_start_debug_core', core=self)
@@ -754,7 +554,7 @@ class CortexM(Target, CoreSightCoreComponent):
                 break
 
             # Read program counter and compare to [start, end)
-            program_counter = self.read_core_register(CORE_REGISTER['pc'])
+            program_counter = self.read_core_register('pc')
             if program_counter < start or end <= program_counter:
                 break
 
@@ -1065,76 +865,121 @@ class CortexM(Target, CoreSightCoreComponent):
     def find_breakpoint(self, addr):
         return self.bp_manager.find_breakpoint(addr)
 
+    def check_reg_list(self, reg_list):
+        """! @brief Sanity check register values and raise helpful errors."""
+        for reg in reg_list:
+            if reg not in self.core_registers.by_index:
+                # Invalid register, try to give useful error. An invalid name will already
+                # have raised a KeyError above.
+                info = CortexMCoreRegisterInfo.get(reg)
+                if info.is_fpu_register and (not self.has_fpu):
+                    raise KeyError("attempt to read FPU register %s without FPU", info.name)
+                else:
+                    raise KeyError("register %s not available in this CPU", info.name)
+
     def read_core_register(self, reg):
-        """! @brief Read CPU register.
+        """! @brief Read one core register.
         
-        Unpack floating point register values
+        The core must be halted or reads will fail.
+        
+        @param self The core.
+        @param reg Either the register's name in lowercase or an integer register index.
+        @return The current value of the register. Most core registers return an integer value,
+            while the floating point single and double precision register return a float value.
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            read the register.
         """
-        regIndex = register_name_to_index(reg)
-        regValue = self.read_core_register_raw(regIndex)
-        # Convert int to float.
-        if is_single_float_register(regIndex):
-            regValue = conversion.u32_to_float32(regValue)
-        elif is_double_float_register(regIndex):
-            regValue = conversion.u64_to_float64(regValue)
-        return regValue
+        reg_info = CortexMCoreRegisterInfo.get(reg)
+        regValue = self.read_core_register_raw(reg_info.index)
+        return reg_info.from_raw(regValue)
 
     def read_core_register_raw(self, reg):
-        """! @brief Read a core register.
+        """! @brief Read a core register without type conversion.
         
-        If reg is a string, find the number associated to this register
-        in the lookup table CORE_REGISTER
+        The core must be halted or reads will fail.
+        
+        @param self The core.
+        @param reg Either the register's name in lowercase or an integer register index.
+        @return The current integer value of the register. Even float register values are returned
+            as integers (thus the "raw").
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            read the register.
         """
         vals = self.read_core_registers_raw([reg])
         return vals[0]
 
     def read_core_registers_raw(self, reg_list):
         """! @brief Read one or more core registers.
-
-        Read core registers in reg_list and return a list of values.
-        If any register in reg_list is a string, find the number
-        associated to this register in the lookup table CORE_REGISTER.
+        
+        The core must be halted or reads will fail.
+        
+        @param self The core.
+        @param reg_list List of registers to read. Each element in the list can be either the
+            register's name in lowercase or the integer register index.
+        @return List of integer values of the registers requested to be read. The result list will
+            be the same length as _reg_list_.
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            read one or more registers.
         """
         # convert to index only
-        reg_list = [register_name_to_index(reg) for reg in reg_list]
+        reg_list = [CortexMCoreRegisterInfo.register_name_to_index(reg) for reg in reg_list]
+        self.check_reg_list(reg_list)
+        return self._base_read_core_registers_raw(reg_list)
 
-        # Sanity check register values
-        for reg in reg_list:
-            if reg not in CORE_REGISTER.values():
-                raise ValueError("unknown reg: %d" % reg)
-            elif is_fpu_register(reg) and (not self.has_fpu):
-                raise ValueError("attempt to read FPU register without FPU")
+    def _base_read_core_registers_raw(self, reg_list):
+        """! @brief Private core register read routine.
+        
+        Items in the _reg_list_ must be pre-converted to index and only include valid
+        registers for the core.
 
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            read one or more registers.
+        """
+        # Make sure the core is in debug state. If not, the DHCSR.S_REGRDY bit is UNKNOWN and may read
+        # as 1, so we have no way to see that the read failed. (This is seen on real devices.)
+        if not self.is_halted():
+            raise exceptions.CoreRegisterAccessError(
+                    "cannot read register{0} {1} because core #{2} is not halted".format(
+                    "s" if (len(reg_list) > 1) else "",
+                    ", ".join(CortexMCoreRegisterInfo.get(r).name for r in reg_list),
+                    self.core_number))
+        
         # Handle doubles.
-        doubles = [reg for reg in reg_list if is_double_float_register(reg)]
+        doubles = [reg for reg in reg_list if CortexMCoreRegisterInfo.get(reg).is_double_float_register]
         hasDoubles = len(doubles) > 0
         if hasDoubles:
             originalRegList = reg_list
             
             # Strip doubles from reg_list.
-            reg_list = [reg for reg in reg_list if not is_double_float_register(reg)]
+            reg_list = [reg for reg in reg_list if not CortexMCoreRegisterInfo.get(reg).is_double_float_register]
             
             # Read float regs required to build doubles.
             singleRegList = []
             for reg in doubles:
                 singleRegList += (-reg, -reg + 1)
-            singleValues = self.read_core_registers_raw(singleRegList)
+            singleValues = self._base_read_core_registers_raw(singleRegList)
 
         # Begin all reads and writes
         dhcsr_cb_list = []
         reg_cb_list = []
         for reg in reg_list:
-            if is_cfbp_subregister(reg):
-                reg = CORE_REGISTER['cfbp']
-            elif is_psr_subregister(reg):
-                reg = CORE_REGISTER['xpsr']
+            if CortexMCoreRegisterInfo.get(reg).is_cfbp_subregister:
+                reg = CortexMCoreRegisterInfo.get('cfbp').index
+            elif CortexMCoreRegisterInfo.get(reg).is_psr_subregister:
+                reg = CortexMCoreRegisterInfo.get('xpsr').index
 
             # write id in DCRSR
             self.write_memory(CortexM.DCRSR, reg)
 
             # Technically, we need to poll S_REGRDY in DHCSR here before reading DCRDR. But
             # we're running so slow compared to the target that it's not necessary.
-            # Read it and assert that S_REGRDY is set
+            # Read it and check that S_REGRDY is set.
 
             dhcsr_cb = self.read_memory(CortexM.DHCSR, now=False)
             reg_cb = self.read_memory(CortexM.DCRDR, now=False)
@@ -1143,25 +988,32 @@ class CortexM(Target, CoreSightCoreComponent):
 
         # Read all results
         reg_vals = []
+        fail_list = []
         for reg, reg_cb, dhcsr_cb in zip(reg_list, reg_cb_list, dhcsr_cb_list):
             dhcsr_val = dhcsr_cb()
-            assert dhcsr_val & CortexM.S_REGRDY
+            if (dhcsr_val & CortexM.S_REGRDY) == 0:
+                fail_list.append(reg)
             val = reg_cb()
 
             # Special handling for registers that are combined into a single DCRSR number.
-            if is_cfbp_subregister(reg):
+            if CortexMCoreRegisterInfo.get(reg).is_cfbp_subregister:
                 val = (val >> ((-reg - 1) * 8)) & 0xff
-            elif is_psr_subregister(reg):
-                val &= sysm_to_psr_mask(reg)
+            elif CortexMCoreRegisterInfo.get(reg).is_psr_subregister:
+                val &= CortexMCoreRegisterInfo.get(reg).psr_mask
 
             reg_vals.append(val)
+        
+        if fail_list:
+            raise exceptions.CoreRegisterAccessError("failed to read register{0} {1}".format(
+                    "s" if (len(fail_list) > 1) else "",
+                    ", ".join(CortexMCoreRegisterInfo.get(r).name for r in fail_list)))
         
         # Merge double regs back into result list.
         if hasDoubles:
             results = []
             for reg in originalRegList:
                 # Double
-                if is_double_float_register(reg):
+                if CortexMCoreRegisterInfo.get(reg).is_double_float_register:
                     doubleIndex = doubles.index(reg)
                     singleLow = singleValues[doubleIndex * 2]
                     singleHigh = singleValues[doubleIndex * 2 + 1]
@@ -1177,58 +1029,90 @@ class CortexM(Target, CoreSightCoreComponent):
     def write_core_register(self, reg, data):
         """! @brief Write a CPU register.
         
-        Will need to pack floating point register values before writing.
+        The core must be halted or the write will fail.
+        
+        @param self The core.
+        @param reg The name of the register to write.
+        @param data New value of the register. Float registers accept float values.
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            write the register.
         """
-        regIndex = register_name_to_index(reg)
-        # Convert float to int.
-        if is_single_float_register(regIndex) and type(data) is float:
-            data = conversion.float32_to_u32(data)
-        elif is_double_float_register(regIndex) and type(data) is float:
-            data = conversion.float64_to_u64(data)
-        self.write_core_register_raw(regIndex, data)
+        reg_info = CortexMCoreRegisterInfo.get(reg)
+        self.write_core_register_raw(reg_info.index, reg_info.to_raw(data))
 
     def write_core_register_raw(self, reg, data):
-        """! @brief Write a core register.
+        """! @brief Write a CPU register without type conversion.
         
-        If reg is a string, find the number associated to this register
-        in the lookup table CORE_REGISTER
+        The core must be halted or the write will fail.
+        
+        @param self The core.
+        @param reg The name of the register to write.
+        @param data New value of the register. Must be an integer, even for float registers.
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            write the register.
         """
         self.write_core_registers_raw([reg], [data])
 
     def write_core_registers_raw(self, reg_list, data_list):
         """! @brief Write one or more core registers.
+        
+        The core must be halted or writes will fail.
 
-        Write core registers in reg_list with the associated value in
-        data_list.  If any register in reg_list is a string, find the number
-        associated to this register in the lookup table CORE_REGISTER.
+        @param self The core.
+        @param reg_list List of registers to read. Each element in the list can be either the
+            register's name in lowercase or the integer register index.
+        @param data_list List of values for the registers in the corresponding positions of
+            _reg_list_. All values must be integers, even for float registers.
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            write one or more registers.
         """
         assert len(reg_list) == len(data_list)
+        
         # convert to index only
-        reg_list = [register_name_to_index(reg) for reg in reg_list]
+        reg_list = [CortexMCoreRegisterInfo.register_name_to_index(reg) for reg in reg_list]
+        self.check_reg_list(reg_list)
+        self._base_write_core_registers_raw(reg_list, data_list)
 
-        # Sanity check register values
-        for reg in reg_list:
-            if reg not in CORE_REGISTER.values():
-                raise ValueError("unknown reg: %d" % reg)
-            elif is_fpu_register(reg) and (not self.has_fpu):
-                raise ValueError("attempt to write FPU register without FPU")
+    def _base_write_core_registers_raw(self, reg_list, data_list):
+        """! @brief Private core register write routine.
+        
+        Items in the _reg_list_ must be pre-converted to index and only include valid
+        registers for the core. Similarly, data_list items must be pre-converted to integer values.
 
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            write one or more registers.
+        """
+        # Make sure the core is in debug state. If not, the DHCSR.S_REGRDY bit is UNKNOWN and may read
+        # as 1, so we have no way to see that the write failed. (This is seen on real devices.)
+        if not self.is_halted():
+            raise exceptions.CoreRegisterAccessError(
+                    "cannot write register{0} {1} because core #{2} is not halted".format(
+                    "s" if (len(reg_list) > 1) else "",
+                    ", ".join(CortexMCoreRegisterInfo.get(r).name for r in reg_list),
+                    self.core_number))
+        
         # Read special register if it is present in the list and
         # convert doubles to single float register writes.
         cfbpValue = None
         xpsrValue = None
         reg_data_list = []
         for reg, data in zip(reg_list, data_list):
-            if is_double_float_register(reg):
+            if CortexMCoreRegisterInfo.get(reg).is_double_float_register:
                 # Replace double with two single float register writes. For instance,
                 # a write of D2 gets converted to writes to S4 and S5.
                 singleLow = data & 0xffffffff
                 singleHigh = (data >> 32) & 0xffffffff
                 reg_data_list += [(-reg, singleLow), (-reg + 1, singleHigh)]
-            elif is_cfbp_subregister(reg) and cfbpValue is None:
-                cfbpValue = self.read_core_register_raw(CORE_REGISTER['cfbp'])
-            elif is_psr_subregister(reg) and xpsrValue is None:
-                xpsrValue = self.read_core_register_raw(CORE_REGISTER['xpsr'])
+            elif CortexMCoreRegisterInfo.get(reg).is_cfbp_subregister and cfbpValue is None:
+                cfbpValue = self._base_read_core_registers_raw([CortexMCoreRegisterInfo.get('cfbp').index])[0]
+            elif CortexMCoreRegisterInfo.get(reg).is_psr_subregister and xpsrValue is None:
+                xpsrValue = self._base_read_core_registers_raw([CortexMCoreRegisterInfo.get('xpsr').index])[0]
             else:
                 # Other register, just copy directly.
                 reg_data_list.append((reg, data))
@@ -1236,19 +1120,19 @@ class CortexM(Target, CoreSightCoreComponent):
         # Write out registers
         dhcsr_cb_list = []
         for reg, data in reg_data_list:
-            if is_cfbp_subregister(reg):
+            if CortexMCoreRegisterInfo.get(reg).is_cfbp_subregister:
                 # Mask in the new special register value so we don't modify the other register
                 # values that share the same DCRSR number.
                 shift = (-reg - 1) * 8
                 mask = 0xffffffff ^ (0xff << shift)
                 data = (cfbpValue & mask) | ((data & 0xff) << shift)
                 cfbpValue = data # update special register for other writes that might be in the list
-                reg = CORE_REGISTER['cfbp']
-            elif is_psr_subregister(reg):
-                mask = sysm_to_psr_mask(reg)
+                reg = CortexMCoreRegisterInfo.get('cfbp').index
+            elif CortexMCoreRegisterInfo.get(reg).is_psr_subregister:
+                mask = CortexMCoreRegisterInfo.get(reg).psr_mask
                 data = (xpsrValue & (0xffffffff ^ mask)) | (data & mask)
                 xpsrValue = data
-                reg = CORE_REGISTER['xpsr']
+                reg = CortexMCoreRegisterInfo.get('xpsr').index
 
             # write DCRDR
             self.write_memory(CortexM.DCRDR, data)
@@ -1262,11 +1146,17 @@ class CortexM(Target, CoreSightCoreComponent):
             dhcsr_cb = self.read_memory(CortexM.DHCSR, now=False)
             dhcsr_cb_list.append(dhcsr_cb)
 
-        # Make sure S_REGRDY was set for all register
-        # writes
-        for dhcsr_cb in dhcsr_cb_list:
+        # Make sure S_REGRDY was set for all register writes.
+        fail_list = []
+        for dhcsr_cb, reg_and_data in zip(dhcsr_cb_list, reg_data_list):
             dhcsr_val = dhcsr_cb()
-            assert dhcsr_val & CortexM.S_REGRDY
+            if (dhcsr_val & CortexM.S_REGRDY) == 0:
+                fail_list.append(reg_and_data[0])
+        
+        if fail_list:
+            raise exceptions.CoreRegisterAccessError("failed to write register{0} {1}".format(
+                    "s" if (len(fail_list) > 1) else "",
+                    ", ".join(CortexMCoreRegisterInfo.get(r).name for r in fail_list)))
 
     def set_breakpoint(self, addr, type=Target.BreakpointType.AUTO):
         """! @brief Set a hardware or software breakpoint at a specific location in memory.
@@ -1360,10 +1250,6 @@ class CortexM(Target, CoreSightCoreComponent):
         demcr = self.read_memory(CortexM.DEMCR)
         return CortexM._map_from_vector_catch_mask(demcr)
 
-    # GDB functions
-    def get_target_xml(self):
-        return self.target_xml
-
     def is_debug_trap(self):
         debugEvents = self.read_memory(CortexM.DFSR) & (CortexM.DFSR_DWTTRAP | CortexM.DFSR_BKPT | CortexM.DFSR_HALTED)
         return debugEvents != 0
@@ -1372,6 +1258,10 @@ class CortexM(Target, CoreSightCoreComponent):
         return self.get_halt_reason() == Target.HaltReason.VECTOR_CATCH
     
     def get_halt_reason(self):
+        """! @brief Returns the reason the core has halted.
+        
+        @return @ref pyocd.core.target.Target.HaltReason "Target.HaltReason" enumerator or None.
+        """
         dfsr = self.read32(CortexM.DFSR)
         if dfsr & CortexM.DFSR_HALTED:
             reason = Target.HaltReason.DEBUG

--- a/pyocd/coresight/cortex_m_core_registers.py
+++ b/pyocd/coresight/cortex_m_core_registers.py
@@ -149,6 +149,32 @@ class CoreRegisterGroups:
         _I('faultmask', -3,     32,     'int',          'system',   39,     "org.gnu.gdb.arm.m-profile"),
         ]
 
+    ## @brief Extra registers available with only with the Security extension.
+    V8M_SEC_ONLY = [
+        #  Name         index   bits    type            group      gdbnum  feature
+        _I('msp_ns',    24,     32,     'data_ptr',     'stack',    40,     "v8-m.sp"),
+        _I('psp_ns',    25,     32,     'data_ptr',     'stack',    41,     "v8-m.sp"),
+        _I('msp_s',     26,     32,     'data_ptr',     'stack',    42,     "v8-m.sp"),
+        _I('psp_s',     27,     32,     'data_ptr',     'stack',    43,     "v8-m.sp"),
+        _I('msplim_s',  28,     32,     'int',          'stack',    46,     "v8-m.sp"),
+        _I('psplim_s',  29,     32,     'int',          'stack',    47,     "v8-m.sp"),
+        _I('cfbp_s',    34,     32,     'int',          'system'),
+        _I('cfbp_ns',   35,     32,     'int',          'system'),
+        ]
+
+    ## @brief The NS stack limits are only available when both Main and Security extensions are present.
+    V8M_ML_SEC_ONLY = [
+        #  Name         index   bits    type            group       gdbnum  feature
+        _I('msplim_ns', 30,     32,     'int',          'stack',    44,     "v8-m.sp"),
+        _I('psplim_ns', 31,     32,     'int',          'stack',    45,     "v8-m.sp"),
+        ]
+
+    ## @brief Registers only available with the MVE extension.
+    V81M_MVE_ONLY = [
+        #  Name         index   bits    type            group       gdbnum  feature
+        _I('vpr',       36,     32,     'int',          'mve',      44,     "v8-m.mve"),
+        ]
+
     ## @brief VFPv5 floating point registers.
     #
     # GDB understands the double/single separation so we don't need to separately pass the single regs,
@@ -223,6 +249,9 @@ class CoreRegisterGroups:
 # Build info map.
 CortexMCoreRegisterInfo.add_to_map(CoreRegisterGroups.M_PROFILE_COMMON
             + CoreRegisterGroups.V7M_v8M_ML_ONLY
+            + CoreRegisterGroups.V8M_SEC_ONLY
+            + CoreRegisterGroups.V8M_ML_SEC_ONLY
+            + CoreRegisterGroups.V81M_MVE_ONLY
             + CoreRegisterGroups.VFP_V5)
 
 def index_for_reg(name):

--- a/pyocd/coresight/cortex_m_core_registers.py
+++ b/pyocd/coresight/cortex_m_core_registers.py
@@ -1,0 +1,230 @@
+# pyOCD debugger
+# Copyright (c) 2019-2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import six
+from copy import copy
+
+from ..core.core_registers import CoreRegisterInfo
+from ..utility import conversion
+
+LOG = logging.getLogger(__name__)
+
+# Program Status Register
+APSR_MASK = 0xF80F0000
+EPSR_MASK = 0x0700FC00
+IPSR_MASK = 0x000001FF
+
+class CortexMCoreRegisterInfo(CoreRegisterInfo):
+    """! @brief Core register subclass for Cortex-M registers.
+    
+    For most registers, the index is the value written to the DCRSR register to read or write the
+    core register. Other core registers not directly supported by DCRSR have special index values that
+    are interpreted by the helper methods on this class and the core register read/write code in CortexM
+    and its subclasses.
+    """
+
+    ## Map of register name to info.
+    _NAME_MAP = {}
+    
+    ## Map of register index to info.
+    _INDEX_MAP = {}
+
+    @classmethod
+    def register_name_to_index(cls, reg):
+        """! @brief Convert a register name to integer register index.
+        @param reg Either a register name or internal register number.
+        @return Internal register number.
+        @exception KeyError
+        """
+        if isinstance(reg, six.string_types):
+            try:
+                reg = cls._NAME_MAP[reg.lower()].index
+            except KeyError as err:
+                six.raise_from(KeyError('unknown core register name %s' % reg), err)
+        return reg
+
+    @property
+    def is_fpu_register(self):
+        """! @brief Returns true for FPSCR, SP, or DP registers."""
+        return self.index == 33 or self.is_float_register
+
+    @property
+    def is_cfbp_subregister(self):
+        """! @brief Whether the register is one of those combined into CFBP by the DCSR."""
+        return -4 <= self.index <= -1
+
+    @property
+    def is_psr_subregister(self):
+        """! @brief Whether the register is a combination of xPSR fields."""
+        return 0x100 <= self.index <= 0x107
+
+    @property
+    def psr_mask(self):
+        """! @brief Generate a PSR mask based on bottom 3 bits of a MRS SYSm value"""
+        mask = 0
+        if (self.index & 1) != 0:
+            mask |= IPSR_MASK
+        if (self.index & 2) != 0:
+            mask |= EPSR_MASK
+        if (self.index & 4) == 0:
+            mask |= APSR_MASK
+        return mask
+
+class CoreRegisterGroups:
+    """! @brief Namespace for lists of Cortex-M core register information."""
+    
+    _I = CortexMCoreRegisterInfo # Reduce table width.
+
+    # For most registers, the index is the DCRSR register selector value. Those registers not directly
+    # supported by the DCRSR have special values that are interpreted by the register read/write methods.
+    
+    ## @brief Registers common to all M-profile cores.
+    M_PROFILE_COMMON = [
+        #  Name         index   bits    type            group       gdbnum  feature
+        _I('r0',        0,      32,     'int',          'general',  0,      "org.gnu.gdb.arm.m-profile"),
+        _I('r1',        1,      32,     'int',          'general',  1,      "org.gnu.gdb.arm.m-profile"),
+        _I('r2',        2,      32,     'int',          'general',  2,      "org.gnu.gdb.arm.m-profile"),
+        _I('r3',        3,      32,     'int',          'general',  3,      "org.gnu.gdb.arm.m-profile"),
+        _I('r4',        4,      32,     'int',          'general',  4,      "org.gnu.gdb.arm.m-profile"),
+        _I('r5',        5,      32,     'int',          'general',  5,      "org.gnu.gdb.arm.m-profile"),
+        _I('r6',        6,      32,     'int',          'general',  6,      "org.gnu.gdb.arm.m-profile"),
+        _I('r7',        7,      32,     'int',          'general',  7,      "org.gnu.gdb.arm.m-profile"),
+        _I('r8',        8,      32,     'int',          'general',  8,      "org.gnu.gdb.arm.m-profile"),
+        _I('r9',        9,      32,     'int',          'general',  9,      "org.gnu.gdb.arm.m-profile"),
+        _I('r10',       10,     32,     'int',          'general',  10,     "org.gnu.gdb.arm.m-profile"),
+        _I('r11',       11,     32,     'int',          'general',  11,     "org.gnu.gdb.arm.m-profile"),
+        _I('r12',       12,     32,     'int',          'general',  12,     "org.gnu.gdb.arm.m-profile"),
+        _I('sp',        13,     32,     'data_ptr',     'general',  13,     "org.gnu.gdb.arm.m-profile"),
+        _I('lr',        14,     32,     'code_ptr',     'general',  14,     "org.gnu.gdb.arm.m-profile"),
+        _I('pc',        15,     32,     'code_ptr',     'general',  15,     "org.gnu.gdb.arm.m-profile"),
+        _I('msp',       17,     32,     'data_ptr',     'system',   16,     "org.gnu.gdb.arm.m-profile"),
+        _I('psp',       18,     32,     'data_ptr',     'system',   17,     "org.gnu.gdb.arm.m-profile"),
+        _I('primask',   -1,     32,     'int',          'system',   18,     "org.gnu.gdb.arm.m-profile"),
+        _I('xpsr',      16,     32,     'int',          'general',  19,     "org.gnu.gdb.arm.m-profile"),
+        _I('control',   -4,     32,     'int',          'system',   20,     "org.gnu.gdb.arm.m-profile"),
+
+        # The CONTROL, FAULTMASK, BASEPRI, and PRIMASK registers are special in that they share the
+        # same DCRSR register index and are returned as a single value. In this dict, these registers
+        # have negative values to signal to the register read/write functions that special handling
+        # is necessary. The values are the byte number containing the register value, plus 1 and then
+        # negated. So -1 means a mask of 0xff, -2 is 0xff00, and so on. The actual DCRSR register index
+        # for these combined registers has the key of 'cfbp'.
+        _I('cfbp',      20,     32,     'int',          'system'),
+
+        # Variants of XPSR.
+        #
+        # XPSR is always read in its entirety via the debug interface, but we also provide
+        # aliases for the submasks APSR, IPSR and EPSR. These are encoded as 0x10000 plus 3 lower bits
+        # indicating which parts of the PSR we're interested in - encoded the same way as MRS's SYSm.
+        # (Note that 'XPSR' continues to denote the raw 32 bits of the register, as per previous versions,
+        # not the union of the three APSR+IPSR+EPSR masks which don't cover the entire register).
+        #
+        #  Name         index   bits    type            group       gdbnum  gdb_feature
+        _I('apsr',      0x100,  32,     'int',          'system'),
+        _I('iapsr',     0x101,  32,     'int',          'system'),
+        _I('eapsr',     0x102,  32,     'int',          'system'),
+        _I('ipsr',      0x105,  32,     'int',          'system'),
+        _I('epsr',      0x106,  32,     'int',          'system'),
+        _I('iepsr',     0x107,  32,     'int',          'system'),
+        ]
+
+    ## @brief Registers available only on v7-M and v8-M.ML.
+    V7M_v8M_ML_ONLY = [
+        #  Name         index   bits    type            group       gdbnum  feature
+        _I('basepri',   -2,     32,     'int',          'system',   38,     "org.gnu.gdb.arm.m-profile"),
+        _I('faultmask', -3,     32,     'int',          'system',   39,     "org.gnu.gdb.arm.m-profile"),
+        ]
+
+    ## @brief VFPv5 floating point registers.
+    #
+    # GDB understands the double/single separation so we don't need to separately pass the single regs,
+    # just the double regs; thus only the double regs have a gdb regnum and feature.
+    VFP_V5 = [
+        #  Name         index   bits    type            group       gdbnum  gdb_feature
+        _I('fpscr',     33,     32,     'int',          'float',    21,     "org.gnu.gdb.arm.vfp"),
+
+        # Single-precision float registers.
+        #
+        #  Name         index   bits    type            group       gdbnum  gdb_feature
+        _I('s0',        0x40,   32,     'ieee_single',  'float'),
+        _I('s1',        0x41,   32,     'ieee_single',  'float'),
+        _I('s2',        0x42,   32,     'ieee_single',  'float'),
+        _I('s3',        0x43,   32,     'ieee_single',  'float'),
+        _I('s4',        0x44,   32,     'ieee_single',  'float'),
+        _I('s5',        0x45,   32,     'ieee_single',  'float'),
+        _I('s6',        0x46,   32,     'ieee_single',  'float'),
+        _I('s7',        0x47,   32,     'ieee_single',  'float'),
+        _I('s8',        0x48,   32,     'ieee_single',  'float'),
+        _I('s9',        0x49,   32,     'ieee_single',  'float'),
+        _I('s10',       0x4a,   32,     'ieee_single',  'float'),
+        _I('s11',       0x4b,   32,     'ieee_single',  'float'),
+        _I('s12',       0x4c,   32,     'ieee_single',  'float'),
+        _I('s13',       0x4d,   32,     'ieee_single',  'float'),
+        _I('s14',       0x4e,   32,     'ieee_single',  'float'),
+        _I('s15',       0x4f,   32,     'ieee_single',  'float'),
+        _I('s16',       0x50,   32,     'ieee_single',  'float'),
+        _I('s17',       0x51,   32,     'ieee_single',  'float'),
+        _I('s18',       0x52,   32,     'ieee_single',  'float'),
+        _I('s19',       0x53,   32,     'ieee_single',  'float'),
+        _I('s20',       0x54,   32,     'ieee_single',  'float'),
+        _I('s21',       0x55,   32,     'ieee_single',  'float'),
+        _I('s22',       0x56,   32,     'ieee_single',  'float'),
+        _I('s23',       0x57,   32,     'ieee_single',  'float'),
+        _I('s24',       0x58,   32,     'ieee_single',  'float'),
+        _I('s25',       0x59,   32,     'ieee_single',  'float'),
+        _I('s26',       0x5a,   32,     'ieee_single',  'float'),
+        _I('s27',       0x5b,   32,     'ieee_single',  'float'),
+        _I('s28',       0x5c,   32,     'ieee_single',  'float'),
+        _I('s29',       0x5d,   32,     'ieee_single',  'float'),
+        _I('s30',       0x5e,   32,     'ieee_single',  'float'),
+        _I('s31',       0x5f,   32,     'ieee_single',  'float'),
+
+        # Double-precision float registers.
+        #
+        # The double-precision floating point registers (D0-D15) are composed of two single-precision
+        # floating point registers (S0-S31). The index for double-precision registers is the negated
+        # value of the first associated single-precision register.
+        #
+        #  Name         index   bits    type            group       gdbnum  gdb_feature
+        _I('d0',        -0x40,  64,     'ieee_double',  'double',   22,     "org.gnu.gdb.arm.vfp"),
+        _I('d1',        -0x42,  64,     'ieee_double',  'double',   23,     "org.gnu.gdb.arm.vfp"),
+        _I('d2',        -0x44,  64,     'ieee_double',  'double',   24,     "org.gnu.gdb.arm.vfp"),
+        _I('d3',        -0x46,  64,     'ieee_double',  'double',   25,     "org.gnu.gdb.arm.vfp"),
+        _I('d4',        -0x48,  64,     'ieee_double',  'double',   26,     "org.gnu.gdb.arm.vfp"),
+        _I('d5',        -0x4a,  64,     'ieee_double',  'double',   27,     "org.gnu.gdb.arm.vfp"),
+        _I('d6',        -0x4c,  64,     'ieee_double',  'double',   28,     "org.gnu.gdb.arm.vfp"),
+        _I('d7',        -0x4e,  64,     'ieee_double',  'double',   29,     "org.gnu.gdb.arm.vfp"),
+        _I('d8',        -0x50,  64,     'ieee_double',  'double',   30,     "org.gnu.gdb.arm.vfp"),
+        _I('d9',        -0x52,  64,     'ieee_double',  'double',   31,     "org.gnu.gdb.arm.vfp"),
+        _I('d10',       -0x54,  64,     'ieee_double',  'double',   32,     "org.gnu.gdb.arm.vfp"),
+        _I('d11',       -0x56,  64,     'ieee_double',  'double',   33,     "org.gnu.gdb.arm.vfp"),
+        _I('d12',       -0x58,  64,     'ieee_double',  'double',   34,     "org.gnu.gdb.arm.vfp"),
+        _I('d13',       -0x5a,  64,     'ieee_double',  'double',   35,     "org.gnu.gdb.arm.vfp"),
+        _I('d14',       -0x5c,  64,     'ieee_double',  'double',   36,     "org.gnu.gdb.arm.vfp"),
+        _I('d15',       -0x5e,  64,     'ieee_double',  'double',   37,     "org.gnu.gdb.arm.vfp"),
+        ]
+        
+    del _I # Cleanup namespace.
+
+# Build info map.
+CortexMCoreRegisterInfo.add_to_map(CoreRegisterGroups.M_PROFILE_COMMON
+            + CoreRegisterGroups.V7M_v8M_ML_ONLY
+            + CoreRegisterGroups.VFP_V5)
+
+def index_for_reg(name):
+    """! @brief Utility to easily convert register name to index."""
+    return CortexMCoreRegisterInfo.get(name).index

--- a/pyocd/coresight/cortex_m_v8m.py
+++ b/pyocd/coresight/cortex_m_v8m.py
@@ -20,6 +20,7 @@ from .cortex_m import CortexM
 from .core_ids import (CORE_TYPE_NAME, CoreArchitecture, CortexMExtension)
 from ..core import exceptions
 from ..core.target import Target
+from .cortex_m_core_registers import CoreRegisterGroups
 
 LOG = logging.getLogger(__name__)
 
@@ -97,6 +98,13 @@ class CortexM_v8M(CortexM):
                 LOG.info("CPU core #%d is %s r%dp%d", self.core_number, CORE_TYPE_NAME[self.core_type], self.cpu_revision, self.cpu_patch)
         else:
             LOG.warning("CPU core #%d type is unrecognized", self.core_number)
+
+    def _build_registers(self):
+        super(CortexM_v8M, self)._build_registers()
+
+        if self.architecture == CoreArchitecture.ARMv8M_MAIN:
+            self._core_registers.add_group(CoreRegisterGroups.V7M_v8M_ML_ONLY)
+        
     
     def get_security_state(self):
         """! @brief Returns the current security state of the processor.

--- a/pyocd/coresight/cortex_m_v8m.py
+++ b/pyocd/coresight/cortex_m_v8m.py
@@ -47,6 +47,13 @@ class CortexM_v8M(CortexM):
     PFR1_SECURITY_EXT_V8_0 = 0x1 # Base security extension.
     PFR1_SECURITY_EXT_V8_1 = 0x3 # v8.1-M adds several instructions.
 
+    # Media and FP Feature Register 1
+    MVFR1 = 0xE000EF44
+    MVFR1_MVE_MASK = 0x00000f00
+    MVFR1_MVE_SHIFT = 8
+    MVFR1_MVE__INTEGER = 0x1
+    MVFR1_MVE__FLOAT = 0x2
+
     def __init__(self, rootTarget, ap, memoryMap=None, core_num=0, cmpid=None, address=None):
         super(CortexM_v8M, self).__init__(rootTarget, ap, memoryMap, core_num, cmpid, address)
 
@@ -85,6 +92,8 @@ class CortexM_v8M(CortexM):
         self.has_security_extension = pfr1_sec in (self.PFR1_SECURITY_EXT_V8_0, self.PFR1_SECURITY_EXT_V8_1)
         if self.has_security_extension:
             self._extensions.append(CortexMExtension.SEC)
+        if pfr1_sec == self.PFR1_SECURITY_EXT_V8_1:
+            self._extensions.append(CortexMExtension.SEC_V81)
         
         if arch == self.ARMv8M_BASE:
             self._architecture = CoreArchitecture.ARMv8M_BASE
@@ -99,13 +108,40 @@ class CortexM_v8M(CortexM):
         else:
             LOG.warning("CPU core #%d type is unrecognized", self.core_number)
 
+    def _check_for_fpu(self):
+        """! @brief Determine if a core has an FPU.
+        
+        In addition to the tests performed by CortexM, this method tests for the MVE extension.
+        """
+        super(CortexM_v8M, self)._check_for_fpu()
+        
+        # Check for MVE.
+        mvfr1 = self.read32(self.MVFR1)
+        mve = (mvfr1 & self.MVFR1_MVE_MASK) >> self.MVFR1_MVE_SHIFT
+        if mve == self.MVFR1_MVE__INTEGER:
+            self.extensions.append(CortexMExtension.MVE)
+        elif mve == self.MVFR1_MVE__FLOAT:
+            self.extensions += [CortexMExtension.MVE, CortexMExtension.MVE_FP]
+
     def _build_registers(self):
         super(CortexM_v8M, self)._build_registers()
+        
+        # Registers available with Security extension, either Baseline or Mainline.
+        if self.has_security_extension:
+            self._core_registers.add_group(CoreRegisterGroups.V8M_SEC_ONLY)
 
+        # Mainline-only registers.
         if self.architecture == CoreArchitecture.ARMv8M_MAIN:
             self._core_registers.add_group(CoreRegisterGroups.V7M_v8M_ML_ONLY)
         
-    
+            # Registers available when both Mainline and Security extensions are implemented.
+            if self.has_security_extension:
+                self._core_registers.add_group(CoreRegisterGroups.V8M_ML_SEC_ONLY)
+        
+        # MVE registers.
+        if CortexMExtension.MVE in self.extensions:
+            self._core_registers.add_group(CoreRegisterGroups.V81M_MVE_ONLY)
+        
     def get_security_state(self):
         """! @brief Returns the current security state of the processor.
         

--- a/pyocd/coresight/generic_mem_ap.py
+++ b/pyocd/coresight/generic_mem_ap.py
@@ -18,6 +18,7 @@ import logging
 
 from .component import CoreSightCoreComponent
 from ..core.target import Target
+from ..core.core_registers import CoreRegistersIndex
 
 LOG = logging.getLogger(__name__)
 
@@ -44,11 +45,15 @@ class GenericMemAPTarget(Target, CoreSightCoreComponent):
         CoreSightCoreComponent.__init__(self, ap, cmpid, address)
         self.core_number = core_num
         self.core_type = DEAD_VALUE
+        self._core_registers = CoreRegistersIndex()
         self._target_context = None
-        self.register_list = []
 
     def add_child(self, cmp):
         pass
+
+    @property
+    def core_registers(self):
+        return self._core_registers
 
     @property
     def supported_security_states(self):

--- a/pyocd/debug/context.py
+++ b/pyocd/debug/context.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2016-2019 Arm Limited
+# Copyright (c) 2016-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,7 @@
 
 from ..core.memory_interface import MemoryInterface
 from pyocd.coresight.component import CoreSightCoreComponent
-from ..coresight.cortex_m import (
-    CORE_REGISTER,
-    register_name_to_index,
-    is_single_float_register,
-    is_double_float_register
-    )
+from ..coresight.cortex_m_core_registers import CortexMCoreRegisterInfo
 from ..utility import conversion
 
 class DebugContext(MemoryInterface):
@@ -62,6 +57,10 @@ class DebugContext(MemoryInterface):
     @property
     def core(self):
         return self._core
+    
+    @property
+    def session(self):
+        return self.core.session
 
     def write_memory(self, addr, value, transfer_size=32):
         return self._parent.write_memory(addr, value, transfer_size)
@@ -82,53 +81,91 @@ class DebugContext(MemoryInterface):
         return self._parent.read_memory_block32(addr, size)
 
     def read_core_register(self, reg):
-        """! @brief Read CPU register
+        """! @brief Read one core register.
         
-        Unpack floating point register values
+        @param self The debug context.
+        @param reg Either the register's name in lowercase or an integer register index.
+        @return The current value of the register. Most core registers return an integer value,
+            while the floating point single and double precision register return a float value.
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            read the register.
         """
-        regIndex = register_name_to_index(reg)
-        regValue = self.read_core_register_raw(regIndex)
-        # Convert int to float.
-        if is_single_float_register(regIndex):
-            regValue = conversion.u32_to_float32(regValue)
-        elif is_double_float_register(regIndex):
-            regValue = conversion.u64_to_float64(regValue)
-        return regValue
+        reg_info = CortexMCoreRegisterInfo.get(reg)
+        regValue = self.read_core_register_raw(reg_info.index)
+        return reg_info.from_raw(regValue)
 
     def read_core_register_raw(self, reg):
-        """! @brief Read a core register.
+        """! @brief Read a core register without type conversion.
         
-        If reg is a string, find the number associated to this register
-        in the lookup table CORE_REGISTER
+        @param self The debug context.
+        @param reg Either the register's name in lowercase or an integer register index.
+        @return The current integer value of the register. Even float register values are returned
+            as integers (thus the "raw").
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            read the register.
         """
         vals = self.read_core_registers_raw([reg])
         return vals[0]
 
     def read_core_registers_raw(self, reg_list):
+        """! @brief Read one or more core registers.
+        
+        @param self The debug context.
+        @param reg_list List of registers to read. Each element in the list can be either the
+            register's name in lowercase or the integer register index.
+        @return List of integer values of the registers requested to be read. The result list will
+            be the same length as _reg_list_.
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            read one or more registers.
+        """
         return self._parent.read_core_registers_raw(reg_list)
 
     def write_core_register(self, reg, data):
-        """! Write a CPU register.
+        """! @brief Write a CPU register.
         
-        Will need to pack floating point register values before writing.
+        @param self The debug context.
+        @param reg The name of the register to write.
+        @param data New value of the register. Float registers accept float values.
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            write the register.
         """
-        regIndex = register_name_to_index(reg)
-        # Convert float to int.
-        if is_single_float_register(regIndex) and type(data) is float:
-            data = conversion.float32_to_u32(data)
-        elif is_double_float_register(regIndex) and type(data) is float:
-            data = conversion.float64_to_u64(data)
-        self.write_core_register_raw(regIndex, data)
+        reg_info = CortexMCoreRegisterInfo.get(reg)
+        self.write_core_register_raw(reg_info.index, reg_info.to_raw(data))
 
     def write_core_register_raw(self, reg, data):
-        """! @brief Write a core register.
+        """! @brief Write a CPU register without type conversion.
         
-        If reg is a string, find the number associated to this register
-        in the lookup table CORE_REGISTER
+        @param self The debug context.
+        @param reg The name of the register to write.
+        @param data New value of the register. Must be an integer, even for float registers.
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            write the register.
         """
         self.write_core_registers_raw([reg], [data])
 
     def write_core_registers_raw(self, reg_list, data_list):
+        """! @brief Write one or more core registers.
+
+        @param self The debug context.
+        @param reg_list List of registers to read. Each element in the list can be either the
+            register's name in lowercase or the integer register index.
+        @param data_list List of values for the registers in the corresponding positions of
+            _reg_list_. All values must be integers, even for float registers.
+        
+        @exception KeyError Invalid or unsupported register was requested.
+        @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
+            write one or more registers.
+        """
         self._parent.write_core_registers_raw(reg_list, data_list)
 
     def flush(self):

--- a/pyocd/gdbserver/context_facade.py
+++ b/pyocd/gdbserver/context_facade.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2016,2018 Arm Limited
+# Copyright (c) 2016,2018-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..utility import conversion
-from ..core.memory_map import MemoryType
-from . import signals
 import logging
 import six
 from xml.etree import ElementTree
+from itertools import groupby
+
+from ..utility import conversion
+from ..core import exceptions
+from ..core.target import Target
+from ..core.memory_map import MemoryType
+from ..core.core_registers import CoreRegisterInfo
+from . import signals
 
 LOG = logging.getLogger(__name__)
 
@@ -51,7 +56,21 @@ class GDBDebugContextFacade(object):
 
     def __init__(self, context):
         self._context = context
-        self._register_list = self._context.core.register_list
+        
+        # Note: Use the gdb 'maint print remote-registers' command to see it's view of the g/G commands.
+        
+        ## List of CoreRegisterInfos sorted by gdb_regnum, excluding any registers not communicated to gdb.
+        #
+        # This list is in the order expected by the g/G commands for reading/writing full register contexts.
+        # It contains de-duplicated core registers with a valid GDB regnum, sorted by regnum.
+        self._register_list = sorted(set(self._context.core.core_registers.iter_matching(
+                lambda reg: reg.gdb_regnum is not None)), key=lambda v: v.gdb_regnum)
+        
+        ## List of internal register numbers corresponding to gdb registers.
+        self._full_reg_num_list = [reg.index for reg in self._register_list]
+        
+        ## Map of gdb regnum to register info.
+        self._gdb_regnum_map = {reg.gdb_regnum: reg for reg in self._register_list}
 
     @property
     def context(self):
@@ -62,14 +81,21 @@ class GDBDebugContextFacade(object):
 
     def get_register_context(self):
         """! @brief Return hexadecimal dump of registers as expected by GDB.
+        
+        @exception CoreRegisterAccessError
         """
         LOG.debug("GDB getting register context")
         resp = b''
-        reg_num_list = [reg.reg_num for reg in self._register_list]
-        vals = self._context.read_core_registers_raw(reg_num_list)
-        #print("Vals: %s" % vals)
+        try:
+            vals = self._context.read_core_registers_raw(self._full_reg_num_list)
+        except exceptions.CoreRegisterAccessError:
+            vals = [None] * len(self._full_reg_num_list)
+            
         for reg, regValue in zip(self._register_list, vals):
-            if reg.bitsize == 64:
+            # Return x's to indicate unavailable register value.
+            if regValue is None:
+                resp += b"xx" * (reg.bitsize // 8)
+            elif reg.bitsize == 64:
                 resp += six.b(conversion.u64_to_hex16le(regValue))
             else:
                 resp += six.b(conversion.u32_to_hex8le(regValue))
@@ -79,50 +105,70 @@ class GDBDebugContextFacade(object):
 
     def set_register_context(self, data):
         """! @brief Set registers from GDB hexadecimal string.
+        
+        @exception CoreRegisterAccessError
         """
         LOG.debug("GDB setting register context")
         reg_num_list = []
         reg_data_list = []
+        offset = 0
         for reg in self._register_list:
+            if offset >= len(data):
+                break
             if reg.bitsize == 64:
-                regValue = conversion.hex16_to_u64be(data)
-                data = data[16:]
+                regValue = conversion.hex16_to_u64be(data[offset:offset+16])
+                offset += 16
             else:
-                regValue = conversion.hex8_to_u32be(data)
-                data = data[8:]
-            reg_num_list.append(reg.reg_num)
+                regValue = conversion.hex8_to_u32be(data[offset:offset+8])
+                offset += 8
+            reg_num_list.append(reg.index)
             reg_data_list.append(regValue)
             LOG.debug("GDB reg: %s = 0x%X", reg.name, regValue)
         self._context.write_core_registers_raw(reg_num_list, reg_data_list)
 
-    def set_register(self, reg, data):
+    def set_register(self, gdb_regnum, data):
         """! @brief Set single register from GDB hexadecimal string.
         
-        @param reg The index of register in targetXML sent to GDB.
+        @param self The object.
+        @param gdb_regnum The regnum of register in target XML sent to GDB.
+        @param data String of hex-encoded value for the register.
+        
+        @exception CoreRegisterAccessError
         """
-        if reg < 0:
-            return
-        elif reg < len(self._register_list):
-            regName = self._register_list[reg].name
-            regBits = self._register_list[reg].bitsize
-            if regBits == 64:
+        reg = self._gdb_regnum_map.get(gdb_regnum, None)
+        if reg is not None:
+            if reg.bitsize == 64:
                 value = conversion.hex16_to_u64be(data)
             else:
                 value = conversion.hex8_to_u32be(data)
-            LOG.debug("GDB: write reg %s: 0x%X", regName, value)
-            self._context.write_core_register_raw(regName, value)
+            LOG.debug("GDB: write reg %s: 0x%X", reg.name, value)
+            self._context.write_core_register_raw(reg.name, value)
+        else:
+            LOG.warining("GDB: attempt to set invalid register (regnum %d)", gdb_regnum)
 
-    def gdb_get_register(self, reg):
-        resp = ''
-        if reg < len(self._register_list):
-            regName = self._register_list[reg].name
-            regBits = self._register_list[reg].bitsize
-            regValue = self._context.read_core_register_raw(regName)
-            if regBits == 64:
+    def gdb_get_register(self, gdb_regnum):
+        """! @brief Set single core register.
+        
+        @param self The object.
+        @param gdb_regnum The regnum of register in target XML sent to GDB.
+        @return String of hex-encoded value for the register.
+        
+        @exception CoreRegisterAccessError
+        """
+        reg = self._gdb_regnum_map.get(gdb_regnum, None)
+        if reg is None:
+            return b''
+        
+        try:
+            regValue = self._context.read_core_register_raw(reg.name)
+            if reg.bitsize == 64:
                 resp = six.b(conversion.u64_to_hex16le(regValue))
             else:
                 resp = six.b(conversion.u32_to_hex8le(regValue))
-            LOG.debug("GDB reg: %s = 0x%X", regName, regValue)
+        except exceptions.CoreRegisterAccessError:
+            # Return x's if the register read failed.
+            resp = b"xx" * (reg.bitsize // 8)
+        LOG.debug("GDB reg: %s = 0x%X", reg.name, regValue)
         return resp
 
     def get_t_response(self, forceSignal=None):
@@ -138,7 +184,7 @@ class GDBDebugContextFacade(object):
             response = six.b('T' + conversion.byte_to_hex2(self.get_signal_value()))
 
         # Append fp(r7), sp(r13), lr(r14), pc(r15)
-        response += self.get_reg_index_value_pairs([7, 13, 14, 15])
+        response += self._get_reg_index_value_pairs(['r7', 'sp', 'lr', 'pc'])
 
         return response
 
@@ -151,6 +197,7 @@ class GDBDebugContextFacade(object):
 
         if self._context.core.is_vector_catch():
             fault = self._context.core.read_core_register('ipsr')
+            assert fault is not None, "Failed to read IPSR"
             try:
                 signal = FAULT[fault]
             except IndexError:
@@ -159,18 +206,30 @@ class GDBDebugContextFacade(object):
         LOG.debug("GDB lastSignal: %d", signal)
         return signal
 
-    def get_reg_index_value_pairs(self, regIndexList):
+    def _get_reg_index_value_pairs(self, reg_list):
         """! @brief Return register values as pairs.
         
         Returns a string like NN:MMMMMMMM;NN:MMMMMMMM;...
         for the T response string.  NN is the index of the
         register to follow MMMMMMMM is the value of the register.
         """
-        str = b''
-        regList = self._context.read_core_registers_raw(regIndexList)
-        for regIndex, reg in zip(regIndexList, regList):
-            str += six.b(conversion.byte_to_hex2(regIndex) + ':' + conversion.u32_to_hex8le(reg) + ';')
-        return str
+        result = b''
+        try:
+            reg_values = self._context.read_core_registers_raw(reg_list)
+        except exceptions.CoreRegisterAccessError:
+            reg_values = [None] * len(reg_list)
+
+        for reg_name, reg_value in zip(reg_list, reg_values):
+            reg = self._context.core.core_registers.by_name[reg_name]
+            # Return x's if the register read failed.
+            if reg_value is None:
+                encoded_reg = "xx" * (reg.bitsize // 8)
+            elif reg.bitsize == 64:
+                encoded_reg = conversion.u64_to_hex16le(reg_value)
+            else:
+                encoded_reg = conversion.u32_to_hex8le(reg_value)
+            result += six.b(conversion.byte_to_hex2(reg.gdb_regnum) + ':' + encoded_reg + ';')
+        return result
 
     def get_memory_map_xml(self):
         """! @brief Generate GDB memory map XML.

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -1042,7 +1042,7 @@ class GDBServer(threading.Thread):
         if query == b'memory_map':
             xml = self.target_facade.get_memory_map_xml()
         elif query == b'read_feature':
-            xml = self.target.get_target_xml()
+            xml = self.target_facade.get_target_xml()
         elif query == b'threads':
             xml = self.get_threads_xml()
         else:

--- a/pyocd/rtos/argon.py
+++ b/pyocd/rtos/argon.py
@@ -20,7 +20,7 @@ from ..core import exceptions
 from ..core.target import Target
 from ..core.plugin import Plugin
 from ..debug.context import DebugContext
-from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index)
+from ..coresight.cortex_m_core_registers import index_for_reg
 from ..trace import events
 from ..trace.sink import TraceEventFilter
 import logging
@@ -154,7 +154,7 @@ class ArgonThreadContext(DebugContext):
         self._has_fpu = self.core.has_fpu
 
     def read_core_registers_raw(self, reg_list):
-        reg_list = [register_name_to_index(reg) for reg in reg_list]
+        reg_list = [index_for_reg(reg) for reg in reg_list]
         reg_vals = []
 
         isCurrent = self._thread.is_current

--- a/pyocd/rtos/common.py
+++ b/pyocd/rtos/common.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 from .provider import (TargetThread, ThreadProvider)
-from ..debug.context import DebugContext
-from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index)
 from ..core import exceptions
 import logging
 

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -20,7 +20,7 @@ from ..core import exceptions
 from ..core.target import Target
 from ..core.plugin import Plugin
 from ..debug.context import DebugContext
-from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index)
+from ..coresight.cortex_m_core_registers import index_for_reg
 import logging
 
 FREERTOS_MAX_PRIORITIES	= 63
@@ -159,7 +159,7 @@ class FreeRTOSThreadContext(DebugContext):
         self._has_fpu = self.core.has_fpu
 
     def read_core_registers_raw(self, reg_list):
-        reg_list = [register_name_to_index(reg) for reg in reg_list]
+        reg_list = [index_for_reg(reg) for reg in reg_list]
         reg_vals = []
 
         isCurrent = self._thread.is_current

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -19,7 +19,7 @@ from ..core import exceptions
 from ..core.target import Target
 from ..core.plugin import Plugin
 from ..debug.context import DebugContext
-from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index)
+from ..coresight.cortex_m_core_registers import index_for_reg
 import logging
 
 # Create a logger for this module.
@@ -137,7 +137,7 @@ class RTXThreadContext(DebugContext):
         self._has_fpu = self.core.has_fpu
 
     def read_core_registers_raw(self, reg_list):
-        reg_list = [register_name_to_index(reg) for reg in reg_list]
+        reg_list = [index_for_reg(reg) for reg in reg_list]
         reg_vals = []
 
         isCurrent = self._thread.is_current

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -20,7 +20,7 @@ from ..core import exceptions
 from ..core.target import Target
 from ..core.plugin import Plugin
 from ..debug.context import DebugContext
-from ..coresight.cortex_m import (CORE_REGISTER, register_name_to_index)
+from ..coresight.cortex_m_core_registers import index_for_reg
 import logging
 
 # Create a logger for this module.
@@ -77,7 +77,7 @@ class ZephyrThreadContext(DebugContext):
         self._has_fpu = self.core.has_fpu
 
     def read_core_registers_raw(self, reg_list):
-        reg_list = [register_name_to_index(reg) for reg in reg_list]
+        reg_list = [index_for_reg(reg) for reg in reg_list]
         reg_vals = []
 
         isCurrent = self._thread.is_current

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -566,7 +566,7 @@ class PyOCDConsole(object):
             args = args[1:]
 
             # Handle register name as command.
-            if cmd in coresight.cortex_m.CORE_REGISTER:
+            if cmd in self.tool.target.selected_core.core_registers.by_name:
                 self.tool.handle_reg([cmd])
                 return
 
@@ -923,7 +923,7 @@ class PyOCDCommander(object):
         reg = args[0].lower()
         if reg == "all":
             self.dump_registers(True)
-        elif reg in coresight.cortex_m.CORE_REGISTER:
+        elif reg in self.target.selected_core.core_registers.by_name:
             if not self.target.is_halted():
                 print("Core is not halted; cannot read core registers")
                 return
@@ -965,7 +965,7 @@ class PyOCDCommander(object):
             do_readback = False
 
         reg = args[0].lower()
-        if reg in coresight.cortex_m.CORE_REGISTER:
+        if reg in self.target.selected_core.core_registers.by_name:
             if not self.target.is_halted():
                 print("Core is not halted; cannot write core registers")
                 return
@@ -2060,7 +2060,7 @@ Prefix line with ! to execute a shell command.""")
                 offset = int(offset.strip(), base=0)
 
         value = None
-        if arg.lower() in coresight.cortex_m.CORE_REGISTER:
+        if arg.lower() in self.target.selected_core.core_registers.by_name:
             value = self.target.read_core_register(arg.lower())
             print("%s = 0x%08x" % (arg.lower(), value))
         else:

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -29,6 +29,7 @@ import pprint
 import textwrap
 import colorama
 import atexit
+from natsort import natsort
 
 # Attempt to import readline.
 try:
@@ -50,10 +51,12 @@ from ..flash.eraser import FlashEraser
 from ..flash.file_programmer import FileProgrammer
 from ..gdbserver.gdbserver import GDBServer
 from ..utility import (mask, conversion)
-from ..utility.cmdline import (convert_session_options, convert_frequency)
+from ..utility.cmdline import (convert_session_options, convert_frequency, UniquePrefixMatcher)
 from ..utility.hex import (format_hex_width, dump_hex_data)
 from ..utility.progress import print_progress
 from ..utility.compatibility import get_terminal_size
+from ..utility.columns import ColumnFormatter
+from ..utility.mask import round_up_div
 
 # Make disasm optional.
 try:
@@ -426,6 +429,10 @@ INFO_HELP = {
             'aliases' : [],
             'help' : "Report whether the target is locked."
             },
+        'register-groups' : {
+            'aliases' : [],
+            'help' : "Display available register groups for the selected core."
+            },
         }
 
 OPTION_HELP = {
@@ -566,7 +573,7 @@ class PyOCDConsole(object):
             args = args[1:]
 
             # Handle register name as command.
-            if cmd in self.tool.target.selected_core.core_registers.by_name:
+            if cmd in self.tool.target.core_registers.by_name:
                 self.tool.handle_reg([cmd])
                 return
 
@@ -707,6 +714,7 @@ class PyOCDCommander(object):
                 'hprot' :               self.handle_show_hprot,
                 'graph' :               self.handle_show_graph,
                 'locked' :              self.handle_show_locked,
+                'register-groups' :     self.handle_show_register_groups,
             }
         self.option_list = {
                 'vector-catch' :        self.handle_set_vectorcatch,
@@ -922,34 +930,42 @@ class PyOCDCommander(object):
 
         reg = args[0].lower()
         if reg == "all":
-            self.dump_registers(True)
-        elif reg in self.target.selected_core.core_registers.by_name:
+            self.dump_registers(show_all=True)
+            return
+        
+        # Check register names first.
+        if reg in self.target.core_registers.by_name:
             if not self.target.is_halted():
                 print("Core is not halted; cannot read core registers")
                 return
 
+            info = self.target.core_registers.by_name[reg]
             value = self.target.read_core_register(reg)
-            if isinstance(value, six.integer_types):
-                print("%s = 0x%08x (%d)" % (reg, value, value))
-            elif type(value) is float:
-                print("%s = %g" % (reg, value))
-            else:
-                raise ToolError("Unknown register value type")
-        else:
-            subargs = reg.split('.')
-            if subargs[0] in self.peripherals:
-                p = self.peripherals[subargs[0]]
-                if len(subargs) > 1:
-                    r = [x for x in p.registers if x.name.lower() == subargs[1]]
-                    if len(r):
-                        self._dump_peripheral_register(p, r[0], show_fields)
-                    else:
-                        raise ToolError("invalid register '%s' for %s" % (subargs[1], p.name))
+            value_str = self._format_core_register(info, value)
+            print("%s = %s" % (reg, value_str))
+            return
+        
+        # Now look for matching group name.
+        matcher = UniquePrefixMatcher(self.target.core_registers.groups)
+        group_matches = matcher.find_all(reg)
+        if len(group_matches) == 1:
+            self.dump_registers(show_group=group_matches[0])
+            return
+        
+        subargs = reg.split('.')
+        if subargs[0] in self.peripherals:
+            p = self.peripherals[subargs[0]]
+            if len(subargs) > 1:
+                r = [x for x in p.registers if x.name.lower() == subargs[1]]
+                if len(r):
+                    self._dump_peripheral_register(p, r[0], show_fields)
                 else:
-                    for r in p.registers:
-                        self._dump_peripheral_register(p, r, show_fields)
+                    raise ToolError("invalid register '%s' for %s" % (subargs[1], p.name))
             else:
-                raise ToolError("invalid peripheral '%s'" % (subargs[0]))
+                for r in p.registers:
+                    self._dump_peripheral_register(p, r, show_fields)
+        else:
+            raise ToolError("invalid peripheral '%s'" % (subargs[0]))
 
     def handle_write_reg(self, args):
         if len(args) < 1:
@@ -965,7 +981,7 @@ class PyOCDCommander(object):
             do_readback = False
 
         reg = args[0].lower()
-        if reg in self.target.selected_core.core_registers.by_name:
+        if reg in self.target.core_registers.by_name:
             if not self.target.is_halted():
                 print("Core is not halted; cannot write core registers")
                 return
@@ -1897,6 +1913,10 @@ class PyOCDCommander(object):
         else:
             print("Taget is unlocked")
 
+    def handle_show_register_groups(self, args):
+        for g in sorted(self.target.core_registers.groups):
+            print(g)
+
     def handle_set(self, args):
         if len(args) < 1:
             raise ToolError("missing option name argument")
@@ -2060,7 +2080,7 @@ Prefix line with ! to execute a shell command.""")
                 offset = int(offset.strip(), base=0)
 
         value = None
-        if arg.lower() in self.target.selected_core.core_registers.by_name:
+        if arg.lower() in self.target.core_registers.by_name:
             value = self.target.read_core_register(arg.lower())
             print("%s = 0x%08x" % (arg.lower(), value))
         else:
@@ -2087,41 +2107,46 @@ Prefix line with ! to execute a shell command.""")
 
         return value
 
-    def dump_registers(self, show_all=False):
-        # Registers organized into columns for display.
-        regs = ['r0', 'r6', 'r12',
-                'r1', 'r7', 'sp',
-                'r2', 'r8', 'lr',
-                'r3', 'r9', 'pc',
-                'r4', 'r10', 'xpsr',
-                'r5', 'r11', 'primask']
+    def _format_core_register(self, info, value):
+        hex_width = round_up_div(info.bitsize, 4) + 2 # add 2 for the "0x" prefix
+        if info.is_float_register:
+            value_str = "{f:g} ({i:#0{w}x})".format(f=conversion.u32_to_float32(value), i=value, w=hex_width)
+        elif info.gdb_type in ('data_ptr', 'code_ptr'):
+            value_str = "{h:#0{w}x}".format(h=value, w=hex_width)
+        else:
+            value_str = "{h:#0{w}x} ({d:d})".format(h=value, w=hex_width, d=value)
+        return value_str
 
+    def dump_register_group(self, group_name):
+        regs = natsort(self.target.core_registers.iter_matching(
+                lambda r: r.group == group_name), key=lambda r: r.name)
+        reg_values = self.target.read_core_registers_raw(r.name for r in regs)
+        
+        col_printer = ColumnFormatter()
+        for info, value in zip(regs, reg_values):
+            value_str = self._format_core_register(info, value)
+            col_printer.add_items([(info.name, value_str)])
+        
+        col_printer.write()
+
+    def dump_registers(self, show_all=False, show_group=None):
         if not self.target.is_halted():
             print("Core is not halted; cannot read core registers")
             return
 
-        for i, reg in enumerate(regs):
-            regValue = self.target.read_core_register(reg)
-            print("{:>16} {:#010x} ".format(reg + ':', regValue), end=' ')
-            if i % 3 == 2:
-                print()
-        
+        all_groups = sorted(self.target.core_registers.groups)
         if show_all:
-            other_regs = sorted(r for r in self.target.selected_core.core_registers.by_name if r not in regs)
-            for i, reg in enumerate(other_regs):
-                value = self.target.read_core_register(reg)
-                info = coresight.core_registers.CoreRegisterInfo.get(reg)
-                if info.bitsize == 64:
-                    if isinstance(value, six.integer_types):
-                        value_str = "%s = %#018x (%d)" % (reg, value, value)
-                    elif isinstance(value, float):
-                        value_str = "%s = %g (%#018x)" % (reg, value, conversion.float64_to_u64(value))
-                else:
-                    if isinstance(value, six.integer_types):
-                        value_str = "%s = %#010x (%d)" % (reg, value, value)
-                    elif isinstance(value, float):
-                        value_str = "%s = %g (%#010x)" % (reg, value, conversion.float32_to_u32(value))
-                print("{:>16} {} ".format(reg + ':', value_str))
+            groups_to_show = all_groups
+        elif show_group:
+            if show_group not in all_groups:
+                raise ToolError("invalid register group %s" % show_group)
+            groups_to_show = [show_group]
+        else:
+            groups_to_show = ['general']
+        
+        for group in groups_to_show:
+            print("%s registers:" % group)
+            self.dump_register_group(group)
 
     def _dump_peripheral_register(self, periph, reg, show_fields):
         size = reg.size or 32

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -183,3 +183,36 @@ def convert_frequency(value):
     else:
         return int(float(value))
 
+class UniquePrefixMatcher(object):
+    """! @brief Manages detection of shortest unique prefix match of a set of strings."""
+    
+    def __init__(self, items):
+        """! @brief Constructor.
+        @param self This object.
+        @param items Sequence of strings.
+        """
+        self._items = items
+    
+    def find_all(self, prefix):
+        """! @brief Return all items matching the given prefix.
+        @param self This object.
+        @param prefix String that is compared as a prefix against the items passed to the constructor.
+            Must not be the empty string.
+        @return List of all items where `prefix` is a valid prefix.
+        @exception ValueError Raised for an empty `prefix`.
+        """
+        if len(prefix) == 0:
+            raise ValueError("empty prefix")
+        return tuple(i for i in self._items if i.startswith(prefix))
+    
+    def find_one(self, prefix):
+        """! @brief Return the item matching the given prefix, or None.
+        @param self This object.
+        @param prefix String that is compared as a prefix against the items passed to the constructor.
+        @return The full value of the matching item where `prefix` is a valid prefix.
+        @exception ValueError Raised for an empty `prefix`.
+        """
+        all_matches = self.find_all(prefix)
+        if len(all_matches) == 1:
+            return all_matches[0]
+        return None

--- a/pyocd/utility/columns.py
+++ b/pyocd/utility/columns.py
@@ -1,0 +1,92 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import logging
+
+from .compatibility import get_terminal_size
+
+LOG = logging.getLogger(__name__)
+
+class ColumnFormatter(object):
+    """! @brief Formats a set of values in multiple columns.
+    
+    The value_list must be a list of bi-tuples (name, value) sorted in the desired display order.
+    
+    The number of columns will be determined by the terminal width and maximum value width. The values
+    will be printed in column major order.
+    """
+    
+    def __init__(self, maxwidth=None, inset=2):
+        """! @brief Constructor.
+        @param self The object.
+        @param maxwidth Number of characters to which the output width must be constrained. If not provided,
+            then the width of the stdout terminal is used. If getting the terminal width fails, for instance
+            if stdout is not a terminal, then a default of 80 characters is used.
+        @param inset Number of characters to inset on each side of every column. Defaults to 2 characters.
+        """
+        self._inset = inset
+        self._term_width = (maxwidth or get_terminal_size()[0]) - inset * 4
+        self._items = []
+        self._max_name_width = 0
+        self._max_value_width = 0
+    
+    def add_items(self, item_list):
+        """! @brief Add items to the output.
+        @param self The object.
+        @param item_list Must be a list of bi-tuples (name, value) sorted in the desired display order.
+        """
+        self._items.extend(item_list)
+        
+        # Update max widths.
+        for name, value in item_list:
+            self._max_name_width = max(self._max_name_width, len(name))
+            self._max_value_width = max(self._max_value_width, len(value))
+    
+    def format(self):
+        """! @brief Return the formatted columns as a string.
+        @param self The object.
+        @return String containing the output of the column printer.
+        """
+        item_width = self._max_name_width + self._max_value_width  + self._inset * 2 + 2
+        column_count = self._term_width // item_width
+        row_count = (len(self._items) + column_count - 1) // column_count
+        
+        rows = [[i for i in self._items[r::row_count]]
+                for r in range(row_count)]
+
+        txt = ""
+        for r in rows:
+            txt += " " * self._inset
+            for i in r:
+                txt += "{inset}{name:>{name_width}}: {value:<{value_width}}{inset}".format(
+                    name=i[0], name_width=self._max_name_width,
+                    value=i[1], value_width=self._max_value_width,
+                    inset=(" " * self._inset))
+            txt += "\n"
+        return txt
+    
+    def write(self, output_file=None):
+        """! @brief Write the formatted columns to stdout or the specified file.
+        @param self The object.
+        @param output_file Optional file to which the column printer output will be written. If no specified,
+            then sys.stdout is used.
+        """
+        if output_file is None:
+            output_file = sys.stdout
+        output_file.write(self.format())
+        
+

--- a/pyocd/utility/mask.py
+++ b/pyocd/utility/mask.py
@@ -108,3 +108,7 @@ def align_up(value, multiple):
     """! @brief Return value aligned up to multiple."""
     return (value + multiple - 1) // multiple * multiple
 
+def round_up_div(value, divisor):
+    """! @brief Return value divided by the divisor, rounding up to the nearest multiple of the divisor."""
+    return (value + divisor - 1) // divisor
+

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'hidapi;platform_system=="Darwin"',
         'intelhex>=2.0,<3.0',
         'intervaltree>=3.0.2,<4.0',
+        'naturalsort>=1.5,<2.0',
         'prettytable',
         'pyelftools',
         'pylink-square',

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -84,11 +84,16 @@ def basic_test(board_id, file):
         psp = target.read_core_register('psp')
         print("MSP = 0x%08x; PSP = 0x%08x" % (msp, psp))
 
-        control = target.read_core_register('control')
-        faultmask = target.read_core_register('faultmask')
-        basepri = target.read_core_register('basepri')
-        primask = target.read_core_register('primask')
-        print("CONTROL = 0x%02x; FAULTMASK = 0x%02x; BASEPRI = 0x%02x; PRIMASK = 0x%02x" % (control, faultmask, basepri, primask))
+        if 'faultmask' in target.core_registers.by_name:
+            control = target.read_core_register('control')
+            faultmask = target.read_core_register('faultmask')
+            basepri = target.read_core_register('basepri')
+            primask = target.read_core_register('primask')
+            print("CONTROL = 0x%02x; FAULTMASK = 0x%02x; BASEPRI = 0x%02x; PRIMASK = 0x%02x" % (control, faultmask, basepri, primask))
+        else:
+            control = target.read_core_register('control')
+            primask = target.read_core_register('primask')
+            print("CONTROL = 0x%02x; PRIMASK = 0x%02x" % (control, primask))
 
         target.write_core_register('primask', 1)
         newPrimask = target.read_core_register('primask')

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -29,6 +29,10 @@ from .mockcore import MockCore
 def mockcore():
     return MockCore()
 
+@pytest.fixture(scope='function')
+def mockcore_no_fpu():
+    return MockCore(has_fpu=False)
+
 # Ignore semihosting test that currently crashes on Travis
 collect_ignore = [
     "test_semihosting.py",

--- a/test/unit/test_mockcore.py
+++ b/test/unit/test_mockcore.py
@@ -20,7 +20,7 @@ import logging
 from .mockcore import MockCore
 
 from pyocd.core import memory_map
-from pyocd.coresight.cortex_m import CORE_REGISTER
+from pyocd.coresight.cortex_m_core_registers import index_for_reg
 from pyocd.utility import conversion
 from pyocd.utility import mask
 
@@ -67,22 +67,26 @@ class TestMockCoreReg:
             assert mockcore.read_core_registers_raw([r]) == [1+r]
     
     def test_rw_cfbp(self, mockcore):
-        mockcore.write_core_registers_raw([CORE_REGISTER['cfbp']], [0x01020304])
-        assert mockcore.read_core_registers_raw([CORE_REGISTER['control'], CORE_REGISTER['faultmask'], CORE_REGISTER['basepri'], CORE_REGISTER['primask']]) == [0x01, 0x02, 0x03, 0x04]
+        mockcore.write_core_registers_raw([index_for_reg('cfbp')], [0x01020304])
+        assert mockcore.read_core_registers_raw([
+                index_for_reg('control'),
+                index_for_reg('faultmask'),
+                index_for_reg('basepri'),
+                index_for_reg('primask')]) == [0x01, 0x02, 0x03, 0x04]
 
     def test_w_control(self, mockcore):
-        mockcore.write_core_registers_raw([CORE_REGISTER['control']], [0xaa])
-        assert mockcore.read_core_registers_raw([CORE_REGISTER['cfbp']]) == [0xaa000000]
+        mockcore.write_core_registers_raw([index_for_reg('control')], [0xaa])
+        assert mockcore.read_core_registers_raw([index_for_reg('cfbp')]) == [0xaa000000]
 
     def test_w_faultmask(self, mockcore):
-        mockcore.write_core_registers_raw([CORE_REGISTER['faultmask']], [0xaa])
-        mockcore.read_core_registers_raw([CORE_REGISTER['cfbp']]) == [0x00aa0000]
+        mockcore.write_core_registers_raw([index_for_reg('faultmask')], [0xaa])
+        mockcore.read_core_registers_raw([index_for_reg('cfbp')]) == [0x00aa0000]
 
     def test_w_basepri(self, mockcore):
-        mockcore.write_core_registers_raw([CORE_REGISTER['basepri']], [0xaa])
-        mockcore.read_core_registers_raw([CORE_REGISTER['cfbp']]) == [0x0000aa00]
+        mockcore.write_core_registers_raw([index_for_reg('basepri')], [0xaa])
+        mockcore.read_core_registers_raw([index_for_reg('cfbp')]) == [0x0000aa00]
 
     def test_w_primask(self, mockcore):
-        mockcore.write_core_registers_raw([CORE_REGISTER['primask']], [0xaa])
-        mockcore.read_core_registers_raw([CORE_REGISTER['cfbp']]) == [0x000000aa]
+        mockcore.write_core_registers_raw([index_for_reg('primask')], [0xaa])
+        mockcore.read_core_registers_raw([index_for_reg('cfbp')]) == [0x000000aa]
 


### PR DESCRIPTION
This PR refactors the core register related code out of `CortexM` and into a set of classes with an architecture-independent base. The old `CORE_REGISTER` dict is gone. `CortexM` and subclasses provide a new `core_registers` property that is a `CoreRegistersIndex` object which gives you multiple ways to access core registers. Each core register is represented by a `CoreRegisterInfo` object.

Detailed changes:
- Added architecture-independent common classes to hold information about core registers in `core/core_registers.py`.
- Moved Cortex-M core register definitions to `coresight/cortex_m_core_registers.py`.
- `CortexM` has a `core_registers` property that is a `CoreRegistersIndex` with all registers available for the given core instance.
- Raising `CoreRegisterAccessError` on failure to read/write core reg, instead of the annoying assertion failure.
- Added check for the core being halted before attempting to read/write core regs, since the behaviour is unpredictable when the core is running. If the core is not halted, `CoreRegisterAccessError` is raised.
- Fixed assumptions in `GDBContextFacade` about gdb regnum and offsets in the gdb register context data with deterministic implementation.
- Moved target XML generated to `GDBContextFacade`.
- The register cache handles reads and writes while the core is running slightly better.
- Added test cases to `cortex_test.py`.
- Commander `reg` command improvements:
    - It accepts the name of a register group or a unique prefix thereof and will print the whole group.
    - Dynamic formatting of registers in columns based on the terminal width (or 80 cols for non-tty output).
    - 'show register-groups' command.
- Added some v8-M core registers like MSPLIM, PSPLIM, and related variants.
- Detecting the v8.1-M MVE extension.
- Added VPR register for MVE.
- Updated other code to match changes.

There are still some architecture-dependent sections of code that deals with core registers. Specifically, the register cache and RTOSes are dependent on Cortex-M registers.