### PR TITLE
Debug probe client and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The `pyocd` command line tool gives you total control over your device with thes
 - `pack`: Manage [CMSIS Device Family Packs](http://arm-software.github.io/CMSIS_5/Pack/html/index.html)
     that provide additional target device support.
 - `commander`: Interactive REPL control and inspection of the MCU.
+- `server`: Share a debug probe with a TCP/IP server.
 - `list`: Show connected devices.
 
 The API and tools provide these features:

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 - [Configuration](configuration.md)
 - [Available options](options.md)
 - [User scripts](user_scripts.md)
+- [Remote probe access](remote_probe_access.md)
 
 #### Advanced
 
@@ -28,12 +29,15 @@
 
 ### Developer documentation
 
+#### How-tos
 - [Developers’ guide](developers_guide.md)
-- [Architecture overview](architecture.md)
 - [How to add new targets](adding_new_targets.md)
 - [Building a standalone gdb server executable](how_to_build.md)
 - [Running the automated tests](automated_tests.md)
 
+#### Architecture and Design
+- [Architecture overview](architecture.md)
+- [Remote probe protocol](remote_probe_protocol.md)
 
 
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -162,6 +162,13 @@ Path or list of paths to CMSIS Device Family Packs. Devices defined in the pack(
 list of available targets.
 </td></tr>
 
+<tr><td>probeserver.port</td>
+<td>int</td>
+<td>5555</td>
+<td>
+TCP port for the debug probe server.
+</td></tr>
+
 <tr><td>project_dir</td>
 <td>str</td>
 <td><i>See description.</i></td>

--- a/docs/remote_probe_access.md
+++ b/docs/remote_probe_access.md
@@ -1,0 +1,74 @@
+Remote probe access
+===================
+
+PyOCD provides a server and client for sharing and accessing debug probes across a TCP/IP
+network connection. This can be used to provide shared debug access for multiple developers, to
+simplify CI configurations, or simply to enable multiple applications or tools to simultaneously
+access a probe.
+
+Here are some example use cases for remote probe access.
+
+1. Debug a device that is in your office across a VPN connection from home.
+
+2. Access a device from across the room while using a laptop on your couch.
+
+3. While connected with pyOCD commander, upload new target firmware using the `pyocd flash`
+    subcommand.
+
+
+Server
+------
+
+The server side is quite simple. The `pyocd server` subcommand starts the server running for the
+specified probe.
+
+The probe is selected via the usual connection-related command line arguments,
+such as `--uid`. Also as usual, a console menu will be printed to allow you to choose a probe to
+serve if multiple are available an a unique ID is not specified.
+
+The probe server's default port number is 5555. You can change the port by passing the `--port`
+argument. The port the server uses will appear in the log when the server starts running.
+
+By default, the server allows remote connections. That is, other devices on the network can connect
+to the server. If the server is connected to the wider Internet, then any node on the Internet can
+connect to the server, so take appropriate caution. You may want to ensure that your network's
+firewall blocks the port being used (default 5555). If you don't need remote access to the server,
+for example if you are only connecting from other processes running on the same computer as the
+server, then you can use the `--local-only` argument to restrict access to local connections
+(localhost).
+
+Example command line to start the server and allow only localhost connections:
+
+```
+$ pyocd server --local-only
+```
+
+This command does not specify a unique ID for a probe, so it will show the console probe selection
+menu if there is more than one available.
+
+
+Client
+------
+
+Access to remote probes is available from all pyOCD commands. When using a remote probe, the
+behaviour should be exactly as if the probe were being controlled directly. Of course, there may
+be additional latency depending on network performance. For localhost-served probes, the connection
+is nearly transparent.
+
+The remote probe is selected by specifying a unique ID with a prefix of "remote:", followed by the
+server IP address or domain name. For instance, to connect to a probe being served on the same
+computer, pass `--uid=remote:localhost` on the command line.
+
+**Important:** Currently you must always specify the target type for the remote device, even in
+cases where the target type is automatically detected when you use the probe directly. To do this,
+pass the `--target` argument followed by the target type. See [Target support](target_support.md)
+for more information about target types.
+
+Note that remote probes will not appear in the list when you run `pyocd list --probes`.
+
+Example command line for running the gdbserver locally for a probe on a remote machine:
+
+```
+$ pyocd gdbserver -uremote:myserver.example.com
+```
+

--- a/docs/remote_probe_protocol.md
+++ b/docs/remote_probe_protocol.md
@@ -1,0 +1,100 @@
+Remote Probe Protocol
+=====================
+
+PyOCD provides a server and client for sharing and accessing debug probes across a TCP/IP
+network connection. This document describes the protocol design, available commands, and semantics.
+
+Protocol
+--------
+
+The protocol is very simple. Each request from the client is a single line comprised of the
+request encoded as JSON and followed by a single LF character (0x0A). The response from the server
+is the same format, with a JSON encoded reply plus LF.
+
+A unique request ID is sent with every request. The response includes the ID of the request to
+which it belongs.
+
+All requests are sent by the client. (A notification system from server to client may be added.)
+
+### Request structure
+
+```
+{
+  "id": <int>,
+  "request": <str>,
+  "arguments": [
+  ]
+}
+```
+
+The `arguments` key is a list of any arguments for the command. It may be elided if there are no
+arguments required.
+
+### Response structure
+
+```
+{
+  "id": <int>,
+  "status": <int>,
+  ["error": <str>,]
+  ["result": <value>]
+}
+```
+
+A successful response must have a `status` value of 0. A non-zero `status` indicates that an error
+occurred, and must be accompanied by an `error` key with an error message (may be the empty string).
+If the response is successful, then a `result` key may be included with the return value of the
+command. If there is no return value, then `result` is excluded.
+
+Commands
+--------
+
+The commands in the table below correspond directly to the methods of `DebugProbe`.
+
+
+Command                  | Arguments                                          | Result
+-------------------------|----------------------------------------------------|----------------
+`hello`                  | version:int                                        |
+`readprop`               |                                                    |
+`open`                   |                                                    |
+`close`                  |                                                    |
+`lock`                   |                                                    |
+`unlock`                 |                                                    |
+`connect`                | protocol:str                                       |
+`disconnect`             |                                                    |
+`swj_sequence`           | length:int, bits:int                               |
+`set_clock`              | freq:int                                           |
+`reset`                  |                                                    |
+`assert_reset`           | asserted:bool                                      |
+`is_reset_asserted`      |                                                    |
+`flush`                  |                                                    |
+`read_dp`                | addr:int                                           | int
+`write_dp`               | addr:int, data:int                                 |
+`read_ap`                | addr:int                                           | int
+`write_ap`               | addr:int, data:int                                 |
+`read_ap_multiple`       | addr:int, count:int                                | List[int]
+`write_ap_multiple`      | addr:int, data:List[int]                           |
+`swo_start`              | baudrate:int                                       |
+`swo_stop`               |                                                    |
+`swo_read`               |                                                    | List[int]
+`get_memory_interface_for_ap` | ap_address_version:int, ap_nominal_address:int | Option[int]
+`read_mem`               | handle:int, addr:int, xfer_size:int                | int
+`write_mem`              | handle:int, addr:int, value:int, xfer_size:int     |
+`read_block32`           | handle:int, addr:int, word_count:int               | List[int]
+`write_block32`          | handle:int, addr:int, data:List[int]               |
+
+
+Semantics
+---------
+
+The `hello` command includes the version of the remote probe protocol supported by the client. The
+server will return an error if this version doesn't match the version of the protocol supported by
+the server.
+
+Multiple clients may connect to a single remote probe. The server manages the requests to ensure
+that the underlying probe is only opened and connected once. The first client to connect a probe
+gets to choose the wire protocol (e.g., SWD or JTAG); subsequent connect are effectively ignored.
+Counts of clients who have opened and connected the probe are maintained so it is disconnected
+and closed when the last client disconnects and closes.
+
+

--- a/docs/remote_probe_protocol.md
+++ b/docs/remote_probe_protocol.md
@@ -82,6 +82,8 @@ Command                  | Arguments                                          | 
 `write_mem`              | handle:int, addr:int, value:int, xfer_size:int     |
 `read_block32`           | handle:int, addr:int, word_count:int               | List[int]
 `write_block32`          | handle:int, addr:int, data:List[int]               |
+`read_block8`            | handle:int, addr:int, word_count:int               | List[int]
+`write_block8`           | handle:int, addr:int, data:List[int]               |
 
 
 Semantics

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -47,6 +47,7 @@ from .utility.cmdline import (
     )
 from .probe.pydapaccess import DAPAccess
 from .probe.tcp_probe_server import DebugProbeServer
+from .probe.shared_probe_proxy import SharedDebugProbeProxy
 from .tools.lists import ListGenerator
 from .tools.pyocd import PyOCDCommander
 from .flash.eraser import FlashEraser
@@ -238,14 +239,22 @@ class PyOCDTool(object):
         # Create *gdbserver* subcommand parser.
         gdbserverParser = argparse.ArgumentParser(description='gdbserver', add_help=False)
         gdbserverOptions = gdbserverParser.add_argument_group("gdbserver options")
-        gdbserverOptions.add_argument("-p", "--port", dest="port_number", type=int, default=3333,
-            help="Set the port number that GDB server will open (default 3333).")
-        gdbserverOptions.add_argument("-T", "--telnet-port", dest="telnet_port", type=int, default=4444,
+        gdbserverOptions.add_argument("-p", "--port", metavar="PORT", dest="port_number", type=int,
+            default=3333,
+            help="Set starting port number for the GDB server (default 3333). Additional cores "
+                "will have a port number of this parameter plus the core number.")
+        gdbserverOptions.add_argument("-T", "--telnet-port", metavar="PORT", dest="telnet_port",
+            type=int, default=4444,
+            help="Specify starting telnet port for semihosting (default 4444).")
+        gdbserverOptions.add_argument("-R", "--probe-server-port",
+            dest="probe_server_port", metavar="PORT", type=int, default=5555,
             help="Specify the telnet port for semihosting (default 4444).")
         gdbserverOptions.add_argument("--allow-remote", dest="serve_local_only", default=True, action="store_false",
             help="Allow remote TCP/IP connections (default is no).")
         gdbserverOptions.add_argument("--persist", action="store_true",
             help="Keep GDB server running even after remote has detached.")
+        gdbserverOptions.add_argument("-r", "--probe-server", action="store_true", dest="enable_probe_server",
+            help="Enable the probe server in addition to the GDB server.")
         gdbserverOptions.add_argument("--core", metavar="CORE_LIST",
             help="Comma-separated list of cores for which gdbservers will be created. Default is all cores.")
         gdbserverOptions.add_argument("--elf", metavar="PATH",
@@ -675,6 +684,7 @@ class PyOCDTool(object):
         """! @brief Handle 'gdbserver' subcommand."""
         self._process_commands(self._args.commands)
 
+        probe_server = None
         gdbs = []
         try:
             # Build dict of session options.
@@ -701,8 +711,21 @@ class PyOCDTool(object):
             else:
                 core_list = None
             
-            session = ConnectHelper.session_with_chosen_probe(
-                blocking=(not self._args.no_wait),
+            # Get the probe.
+            probe = ConnectHelper.choose_probe(
+                        blocking=(not self._args.no_wait),
+                        return_first=False,
+                        unique_id=self._args.unique_id,
+                        )
+            if probe is None:
+                LOG.error("No probe selected.")
+                return
+            
+            # Create a proxy so the probe can be shared between the session and probe server.
+            probe_proxy = SharedDebugProbeProxy(probe)
+            
+            # Create the session.
+            session = Session(probe_proxy,
                 project_dir=self._args.project_dir,
                 user_script=self._args.script,
                 config_file=self._args.config,
@@ -722,7 +745,7 @@ class PyOCDTool(object):
                 if core_list is None:
                     core_list = all_cores
                 bad_cores = core_list.difference(all_cores)
-                if len(bad_cores): #x for x in core_list if x not in all_cores):
+                if len(bad_cores):
                     LOG.error("Invalid core number%s: %s",
                         "s" if len(bad_cores) > 1 else "",
                         ", ".join(str(x) for x in bad_cores))
@@ -731,6 +754,14 @@ class PyOCDTool(object):
                 # Set ELF if provided.
                 if self._args.elf:
                     session.board.target.elf = os.path.expanduser(self._args.elf)
+                    
+                # Run the probe server is requested.
+                if self._args.enable_probe_server:
+                    probe_server = DebugProbeServer(session, session.probe,
+                            self._args.probe_server_port, self._args.serve_local_only)
+                    probe_server.start()
+                    
+                # Start up the gdbservers.
                 for core_number, core in session.board.target.cores.items():
                     # Don't create a server for CPU-less memory Access Port. 
                     if isinstance(session.board.target.cores[core_number], GenericMemAPTarget):
@@ -743,11 +774,15 @@ class PyOCDTool(object):
                         server_listening_callback=self.server_listening)
                     gdbs.append(gdb)
                 gdb = gdbs[0]
-                while gdb.is_alive():
-                    gdb.join(timeout=0.5)
+                while any(g.is_alive() for g in gdbs):
+                    sleep(0.1)
+                if probe_server:
+                    probe_server.stop()
         except (KeyboardInterrupt, Exception):
-            for gdb in gdbs:
-                gdb.stop()
+            for server in gdbs:
+                server.stop()
+            if probe_server:
+                probe_server.stop()
             raise
     
     def do_commander(self):

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -63,6 +63,8 @@ BUILTIN_OPTIONS = [
     OptionInfo('pack', (str, list), None,
         "Path or list of paths to CMSIS Device Family Packs. Devices defined in the pack(s) are "
         "added to the list of available targets."),
+    OptionInfo('probeserver.port', int, 5555,
+        "TCP port for the debug probe server."),
     OptionInfo('project_dir', str, None,
         "Path to the session's project directory. Defaults to the working directory when the pyocd "
         "tool was executed."),

--- a/pyocd/probe/shared_probe_proxy.py
+++ b/pyocd/probe/shared_probe_proxy.py
@@ -1,0 +1,86 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from .debug_probe import DebugProbe
+
+LOG = logging.getLogger(__name__)
+
+class SharedDebugProbeProxy(object):
+    """! @brief Proxy for a DebugProbe that allows it to be shared by multiple clients.
+    
+    The main purpose of this class is to keep track of the number of times the probe has been
+    opened and connected, and to perform checks to ensure that probes don't interfere with each
+    other. Most probe APIs are simply passed to the underlying probe object.
+    """
+    
+    def __init__(self, probe):
+        self._session = None
+        self._probe = probe
+        self._open_count = 0
+        self._connect_count = 0
+        self._active_protocol = None
+
+    @property
+    def session(self):
+        """! @brief Session associated with this probe."""
+        return self._session
+    
+    @session.setter
+    def session(self, the_session):
+        self._session = the_session
+        self._probe.session = the_session
+    
+    @property
+    def probe(self):
+        return self._probe
+    
+    def open(self):
+        if self._open_count == 0:
+            self._probe.open()
+        self._open_count += 1
+    
+    def close(self):
+        if self._open_count == 1:
+            self._probe.close()
+        self._open_count -= 1
+
+    def connect(self, protocol=None):
+        # First to connect gets to choose the protocol.
+        if self._connect_count == 0:
+            self._probe.connect(protocol)
+        elif protocol not in (DebugProbe.Protocol.DEFAULT, self._probe.wire_protocol):
+            raise exception.ProbeError("probe already connected using %s protocol" % self._probe.wire_protocol.name)
+        self._connect_count += 1
+
+    def disconnect(self):
+        if self._connect_count == 1:
+            self._probe.disconnect()
+        self._connect_count -= 1
+
+    def swj_sequence(self, length, bits):
+        # Only the first connected client can perform SWJ sequences.
+        if self._connect_count == 1:
+            self._probe.swj_sequence(length, bits)
+    
+    def __getattr__(self, name):
+        """! @brief Redirect to underlying probe object methods."""
+        if hasattr(self._probe, name):
+            return getattr(self._probe, name)
+        else:
+            raise AttributeError(name)
+

--- a/pyocd/probe/tcp_client_probe.py
+++ b/pyocd/probe/tcp_client_probe.py
@@ -363,6 +363,12 @@ class RemoteMemoryInterface(MemoryInterface):
     def read_memory_block32(self, addr, size):
         return self._remote_probe._perform_request('read_block32', self._handle, addr, size)
 
+    def write_memory_block8(self, addr, data):
+        self._remote_probe._perform_request('write_block8', self._handle, addr, data)
+
+    def read_memory_block8(self, addr, size):
+        return self._remote_probe._perform_request('read_block8', self._handle, addr, size)
+
 class TCPClientProbePlugin(Plugin):
     """! @brief Plugin class for TCPClientProbePlugin."""
     

--- a/pyocd/probe/tcp_client_probe.py
+++ b/pyocd/probe/tcp_client_probe.py
@@ -1,0 +1,379 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import json
+import six
+import base64
+import threading
+
+from .debug_probe import DebugProbe
+from ..core import exceptions
+from ..core.memory_interface import MemoryInterface
+from ..core.plugin import Plugin
+from ..utility.sockets import ClientSocket
+from ..utility.concurrency import locked
+
+LOG = logging.getLogger(__name__)
+
+TRACE = LOG.getChild("trace")
+TRACE.setLevel(logging.CRITICAL)
+
+class TCPClientProbe(DebugProbe):
+    """! @brief Probe class that connects to a debug probe server."""
+    
+    DEFAULT_PORT = 5555
+    
+    PROTOCOL_VERSION = 1
+
+    class StatusCode:
+        """! @brief Constants for errors reported from the server."""
+        GENERAL_ERROR = 1
+        PROBE_DISCONNECTED = 2
+        PROBE_ERROR = 3
+        TRANSFER_ERROR = 10
+        TRANSFER_TIMEOUT = 11
+        TRANSFER_FAULT = 12
+    
+    ## Map from status code to exception class.
+    STATUS_CODE_CLASS_MAP = {
+        StatusCode.GENERAL_ERROR: exceptions.Error,
+        StatusCode.PROBE_DISCONNECTED: exceptions.ProbeDisconnected,
+        StatusCode.PROBE_ERROR: exceptions.ProbeError,
+        StatusCode.TRANSFER_ERROR: exceptions.TransferError,
+        StatusCode.TRANSFER_TIMEOUT: exceptions.TransferTimeoutError,
+        StatusCode.TRANSFER_FAULT: exceptions.TransferFaultError,
+        }
+    
+    def _extract_address(cls, unique_id):
+        parts = unique_id.split(':', 1)
+        if len(parts) == 1:
+            port = cls.DEFAULT_PORT
+        else:
+            port = int(parts[1])
+        return parts[0], port
+    
+    @classmethod
+    def get_all_connected_probes(cls, unique_id=None, is_explicit=False):
+        if is_explicit and unique_id is not None:
+            return [cls(unique_id)]
+        else:
+            return []
+    
+    @classmethod
+    def get_probe_with_id(cls, unique_id, is_explicit=False):
+        return cls(unique_id) if is_explicit else None
+
+    def __init__(self, unique_id):
+        """! @brief Constructor."""
+        super(TCPClientProbe, self).__init__()
+        self._uid = unique_id
+        hostname, port = self._extract_address(unique_id)
+        self._socket = ClientSocket(hostname, port)
+        self._is_open = False
+        self._request_id = 0
+        self._lock_count = 0
+        self._lock_count_lock = threading.RLock()
+    
+    @property
+    def vendor_name(self):
+        return self._read_property('vendor_name', "vendor")
+    
+    @property
+    def product_name(self):
+        return self._read_property('product_name', "product")
+    
+    @property
+    def supported_wire_protocols(self):
+        return self._read_property('supported_wire_protocols')
+
+    @property
+    def unique_id(self):
+        return self._uid
+
+    @property
+    def wire_protocol(self):
+        return self._read_property('wire_protocol')
+    
+    @property
+    def is_open(self):
+        return self._is_open
+    
+    @property
+    def capabilities(self):
+        return self._read_property('capabilities')
+    
+    @property
+    def request_id(self):
+        """! @brief Generate a new request ID."""
+        rid = self._request_id
+        self._request_id += 1
+        return rid
+    
+    def _perform_request(self, request, *args):
+        """! Execute a request-reply transaction with the server.
+
+        Request:
+        
+        ````
+        {
+          "id": <int>,
+          "request": <str>,
+          ["arguments": <list>]
+        }
+        ````
+
+        Response:
+        
+        ````
+        {
+          "id": <int>,
+          "status": <int>,
+          ["error": <str>,]
+          ["result": <value>]
+        }
+        ````
+        """
+        # Protect requests with the local lock.
+        with self._lock:
+            rq = {
+                    "id": self.request_id,
+                    "request": request,
+                }
+            if len(args):
+                rq["arguments"] = args
+            formatted_request = json.dumps(rq)
+            TRACE.debug("Request: %s", formatted_request)
+        
+            # Send request to server.
+            self._socket.write(formatted_request.encode('utf-8') + b"\n")
+        
+            # Read response.
+            response_data = self._socket.readline().decode('utf-8').strip()
+            decoded_response = json.loads(response_data)
+            TRACE.debug("decoded_response = %s", decoded_response)
+        
+            # Check for required keys.
+            if ('id' not in decoded_response) or ('status' not in decoded_response):
+                raise exceptions.ProbeError("malformed response from server; missing required field")
+        
+            # Check response status.
+            status = decoded_response['status']
+            if status != 0:
+                # Get the error message.
+                error = decoded_response.get('error', "(missing error message key)")
+                LOG.debug("error received from server for command %s (status code %i): %s",
+                        request, status, error)
+            
+                # Create an appropriate local exception based on the status code.
+                exc = self._create_exception_from_status_code(status,
+                        "error received from server for command %s (status code %i): %s"
+                        % (request, status, error))
+                raise exc
+        
+            # Get response value. If not present then there was no return value from the command
+            result = decoded_response.get('result', None)
+        
+            return result
+    
+    def _create_exception_from_status_code(self, status, message):
+        """! @brief Convert a status code into an exception instance."""
+        # The TransferFaultError class requires special handling because it doesn't take a
+        # message as the first argument.
+        if status == self.StatusCode.TRANSFER_FAULT:
+            return exceptions.TransferFaultError()
+        # Other status codes can use the map.
+        return self.STATUS_CODE_CLASS_MAP.get(status, exceptions.ProbeError)(message)
+
+    _PROPERTY_CONVERTERS = {
+            'capabilities':                 lambda value: [DebugProbe.Capability[v] for v in value],
+            'supported_wire_protocols':     lambda value: [DebugProbe.Protocol[v] for v in value],
+            'wire_protocol':                lambda value: DebugProbe.Protocol[value],
+        }
+
+    def _read_property(self, name, default=None):
+        if not self.is_open:
+            return default
+        result = self._perform_request('readprop', name)
+        if name in self._PROPERTY_CONVERTERS:
+            result = self._PROPERTY_CONVERTERS[name](result)
+        return result
+
+    def open(self):
+        if not self._is_open:
+            self._socket.connect()
+            self._is_open = True
+            self._socket.set_timeout(0.1)
+        
+        # Send hello message.
+        self._perform_request('hello', self.PROTOCOL_VERSION)
+        
+        self._perform_request('open')
+    
+    def close(self):
+        if self._is_open:
+            self._perform_request('close')
+            self._socket.close()
+            self._is_open = False
+    
+    def lock(self):
+        # The lock count is then used to only send the remote lock request once.
+        with self._lock_count_lock:
+            if self._lock_count == 0:
+                self._perform_request('lock')
+            self._lock_count += 1
+    
+    def unlock(self):
+        # The remote unlock request is only sent when the outermost nested locking is unlocked.
+        with self._lock_count_lock:
+            assert self._lock_count > 0
+            self._lock_count -= 1
+            if self._lock_count == 0:
+                self._perform_request('unlock')
+
+    ## @name Target control
+    ##@{
+
+    def connect(self, protocol=None):
+        self._perform_request('connect', protocol.name)
+
+    def disconnect(self):
+        self._perform_request('disconnect')
+
+    def swj_sequence(self, length, bits):
+        self._perform_request('swj_sequence', length, bits)
+
+    def set_clock(self, frequency):
+        self._perform_request('set_clock', frequency)
+
+    def reset(self):
+        self._perform_request('reset')
+
+    def assert_reset(self, asserted):
+        self._perform_request('assert_reset', asserted)
+    
+    def is_reset_asserted(self):
+        return self._perform_request('is_reset_asserted')
+
+    def flush(self):
+        self._perform_request('flush')
+
+    ##@}
+
+    ## @name DAP access
+    ##@{
+
+    def read_dp(self, addr, now=True):
+        result = self._perform_request('read_dp', addr)
+        
+        def read_dp_cb():
+            # TODO need to raise any exception from here
+            return result
+        
+        return result if now else read_dp_cb
+
+    def write_dp(self, addr, data):
+        self._perform_request('write_dp', addr, data)
+
+    def read_ap(self, addr, now=True):
+        result = self._perform_request('read_ap', addr)
+        
+        def read_ap_cb():
+            # TODO need to raise any exception from here
+            return result
+        
+        return result if now else read_ap_cb
+
+    def write_ap(self, addr, data):
+        self._perform_request('write_ap', addr, data)
+
+    def read_ap_multiple(self, addr, count=1, now=True):
+        results = self._perform_request('read_ap_multiple', addr, count)
+        
+        def read_ap_multiple_cb():
+            # TODO need to raise any exception from here
+            return results
+        
+        return results if now else read_ap_multiple_cb
+
+    def write_ap_multiple(self, addr, values):
+        self._perform_request('write_ap_multiple', addr, values)
+    
+    def get_memory_interface_for_ap(self, ap_address):
+        handle = self._perform_request('get_memory_interface_for_ap',
+                ap_address.ap_version.value, ap_address.nominal_address)
+        if handle is None:
+            return None
+        return RemoteMemoryInterface(self, handle)
+    
+    ##@}
+
+    ## @name SWO
+    ##@{
+
+    def has_swo(self):
+        return self._perform_request('has_swo')
+
+    def swo_start(self, baudrate):
+        self._perform_request('swo_start', baudrate)
+
+    def swo_stop(self):
+        self._perform_request('swo_stop')
+
+    def swo_read(self):
+        return self._perform_request('swo_read')
+
+    ##@}
+    
+class RemoteMemoryInterface(MemoryInterface):
+    """! @brief Local proxy for a remote memory interface."""
+    
+    def __init__(self, remote_probe, handle):
+        self._remote_probe = remote_probe
+        self._handle = handle
+
+    def write_memory(self, addr, data, transfer_size=32):
+        assert transfer_size in (8, 16, 32)
+        self._remote_probe._perform_request('write_mem', self._handle, addr, data, transfer_size)
+        
+    def read_memory(self, addr, transfer_size=32, now=True):
+        assert transfer_size in (8, 16, 32)
+        result = self._remote_probe._perform_request('read_mem', self._handle, addr, transfer_size)
+        
+        def read_callback():
+            return result
+        return result if now else read_callback
+
+    def write_memory_block32(self, addr, data):
+        self._remote_probe._perform_request('write_block32', self._handle, addr, data)
+
+    def read_memory_block32(self, addr, size):
+        return self._remote_probe._perform_request('read_block32', self._handle, addr, size)
+
+class TCPClientProbePlugin(Plugin):
+    """! @brief Plugin class for TCPClientProbePlugin."""
+    
+    def load(self):
+        return TCPClientProbe
+    
+    @property
+    def name(self):
+        return "remote"
+    
+    @property
+    def description(self):
+        return "Client for the pyOCD debug probe server"
+

--- a/pyocd/probe/tcp_probe_server.py
+++ b/pyocd/probe/tcp_probe_server.py
@@ -1,0 +1,442 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import threading
+import json
+import base64
+import socket
+from six.moves.socketserver import (ThreadingTCPServer, StreamRequestHandler)
+
+from .shared_probe_proxy import SharedDebugProbeProxy
+from ..core.session import Session
+from ..core import exceptions
+from .debug_probe import DebugProbe
+from ..coresight.ap import (APVersion, APv1Address, APv2Address)
+
+LOG = logging.getLogger(__name__)
+
+TRACE = LOG.getChild("trace")
+TRACE.setLevel(logging.CRITICAL)
+
+class DebugProbeServer(threading.Thread):
+    """! @brief Shares a debug probe over a TCP server.
+    
+    When the start() method is called, a new daemon thread is created to run the server. The server
+    can be terminated by calling the stop() method, which will also kill the server thread.
+    """
+    
+    def __init__(self, session, probe, port=None, serve_local_only=True):
+        """! @brief Constructor.
+        
+        @param self The object.
+        @param session A @ref pyocd.core.session.Session "Session" object. Does not need to have a
+            probe assigned to it.
+        @param probe Either the @ref pyocd.probe.debug_probe.DebugProbe "DebugProbe" object to serve
+            or a @ref pyocd.probe.shared_probe_proxy.SharedDebugProbeProxy "SharedDebugProbeProxy".
+            Doesn't have to be associated with a session, and should not be opened already. If not
+            already an instance of
+            @ref pyocd.probe.shared_probe_proxy.SharedDebugProbeProxy "SharedDebugProbeProxy"
+            then a new proxy is created to allow the probe to be shared by multiple connections.
+        @param port The TCP port number. Defaults to the 'probeserver.port' option if not provided.
+        @param serve_local_only Boolean. Whether to restrict the server to be accessible only from
+            localhost.
+        """
+        super(DebugProbeServer, self).__init__()
+        
+        # Configure the server thread.
+        self.name = "debug probe %s server" % probe.unique_id
+        self.daemon = True
+        
+        # Init instance variables.
+        self._session = session
+        self._probe = probe
+        self._is_running = False
+        
+        # Make sure we have a shared proxy for the probe.
+        if isinstance(probe, SharedDebugProbeProxy):
+            self._proxy = probe
+        else:
+            self._proxy = SharedDebugProbeProxy(probe)
+        
+        # Get the port from options if not specified.
+        if port is None:
+            self._port = session.options.get('probeserver.port')
+        else:
+            self._port = port
+        
+        host = 'localhost' if serve_local_only else ''
+        address = (host, self._port)
+        
+        # Create the server and bind to the address, but don't start running yet.
+        self._server = TCPProbeServer(address, session, self._proxy)
+        self._server.server_bind()
+        
+    def start(self):
+        """! @brief Start the server thread and begin listening."""
+        self._server.server_activate()
+        super(DebugProbeServer, self).start()
+    
+    def stop(self):
+        """! @brief Shut down the server.
+        
+        Any open connections will be forcibly closed. This function does not return until the
+        server thread has exited.
+        """
+        self._server.shutdown()
+        self.join()
+    
+    @property
+    def is_running(self):
+        """! @brief Whether the server thread is running."""
+        return self._is_running
+    
+    @property
+    def port(self):
+        """! @brief The server's port.
+        
+        If port 0 was specified in the constructor, then, after start() is called, this will reflect the actual port
+        on which the server is listening.
+        """
+        return self._port
+    
+    def run(self):
+        """! @brief The server thread implementation."""
+        self._is_running = True
+        
+        # Read back the actual port if 0 was specified.
+        if self._port == 0:
+            self._port = self._server.socket.getsockname()[1]
+        
+        LOG.info("Serving debug probe %s (%s) on port %i",
+                self._probe.description, self._probe.unique_id, self._port)
+        self._server.serve_forever()
+        self._is_running = False
+
+class TCPProbeServer(ThreadingTCPServer):
+    """! @brief TCP server subclass that carries the session and probe being served."""
+    
+    # Change the default SO_REUSEADDR setting.
+    allow_reuse_address = True
+    
+    def __init__(self, server_address, session, probe):
+        self._session = session
+        self._probe = probe
+        ThreadingTCPServer.__init__(self, server_address, DebugProbeRequestHandler,
+            bind_and_activate=False)
+    
+    @property
+    def session(self):
+        return self._session
+    
+    @property
+    def probe(self):
+        return self._probe
+    
+    def handle_error(self, request, client_address):
+        LOG.error("Error while handling client request (client address %s):", client_address,
+            exc_info=self._session.log_tracebacks)
+
+class DebugProbeRequestHandler(StreamRequestHandler):
+    """!
+    @brief Probe server request handler.
+    
+    This class implements the server side for the remote probe protocol.
+
+    request:
+    ````
+    {
+      "id": <int>,
+      "request": <str>,
+      ["arguments": <list>]
+    }
+    ````
+
+    response:
+    ````
+    {
+      "id": <int>,
+      "status": <int>,
+      ["error": <str>,]
+      ["response": <value>]
+    }
+    ````
+    """
+    
+    ## Current version of the remote probe protocol.
+    PROTOCOL_VERSION = 1
+    
+    class StatusCode:
+        """! @brief Constants for errors reported from the server."""
+        GENERAL_ERROR = 1
+        PROBE_DISCONNECTED = 2
+        PROBE_ERROR = 3
+        TRANSFER_ERROR = 10
+        TRANSFER_TIMEOUT = 11
+        TRANSFER_FAULT = 12
+
+    def setup(self):
+        # Do a DNS lookup on the client.
+        try:
+            info = socket.gethostbyaddr(self.client_address[0])
+            self._client_domain = info[0]
+        except socket.herror:
+            self._client_domain = self.client_address[0]
+        
+        LOG.info("Remote probe client connected (%s from port %i)", self._client_domain, self.client_address[1])
+        
+        # Get the session and probe we're serving from the server.
+        self._session = self.server.session
+        self._probe = self.server.probe
+        
+        # Give the probe a session if it doesn't have one, in case it needs to access settings.
+        # TODO: create a session proxy so client-side options can be accessed
+        if self._probe.session is None:
+            self._probe.session = self._session
+        
+        # Dict to store handles for AP memory interfaces.
+        self._next_ap_memif_handle = 0
+        self._ap_memif_handles = {}
+    
+        # Create the request handlers dict here so we can reference bound probe methods.
+        self._REQUEST_HANDLERS = {
+                # Command                Handler                            Arg count
+                'hello':                (self._request__hello,              1   ),
+                'readprop':             (self._request__read_property,      1   ),
+                'open':                 (self._probe.open,                  0   ), # 'open'
+                'close':                (self._probe.close,                 0   ), # 'close'
+                'lock':                 (self._probe.lock,                  0   ), # 'lock'
+                'unlock':               (self._probe.unlock,                0   ), # 'unlock'
+                'connect':              (self._request__connect,            1   ), # 'connect', protocol:str
+                'disconnect':           (self._probe.disconnect,            0   ), # 'disconnect'
+                'swj_sequence':         (self._probe.swj_sequence,          2   ), # 'swj_sequence', length:int, bits:int
+                'set_clock':            (self._probe.set_clock,             1   ), # 'set_clock', freq:int
+                'reset':                (self._probe.reset,                 0   ), # 'reset'
+                'assert_reset':         (self._probe.assert_reset,          1   ), # 'assert_reset', asserted:bool
+                'is_reset_asserted':    (self._probe.is_reset_asserted,     0   ), # 'is_reset_asserted'
+                'flush':                (self._probe.flush,                 0   ), # 'flush'
+                'read_dp':              (self._probe.read_dp,               1   ), # 'read_dp', addr:int -> int
+                'write_dp':             (self._probe.write_dp,              2   ), # 'write_dp', addr:int, data:int
+                'read_ap':              (self._probe.read_ap,               1   ), # 'read_ap', addr:int -> int
+                'write_ap':             (self._probe.write_ap,              2   ), # 'write_ap', addr:int, data:int
+                'read_ap_multiple':     (self._probe.read_ap_multiple,      2   ), # 'read_ap_multiple', addr:int, count:int -> List[int]
+                'write_ap_multiple':    (self._probe.write_ap_multiple,     2   ), # 'write_ap_multiple', addr:int, data:List[int]
+                'get_memory_interface_for_ap': (self._request__get_memory_interface_for_ap, 2), # 'get_memory_interface_for_ap', ap_address_version:int, ap_nominal_address:int -> handle:int|null
+                'swo_start':            (self._probe.swo_start,             1   ), # 'swo_start', baudrate:int
+                'swo_stop':             (self._probe.swo_stop,              0   ), # 'swo_stop'
+                'swo_read':             (self._probe.swo_read,              0   ), # 'swo_read' -> List[int]
+                'read_mem':             (self._request__read_mem,           3   ), # 'read_mem', handle:int, addr:int, xfer_size:int -> int
+                'write_mem':            (self._request__write_mem,          4   ), # 'write_mem', handle:int, addr:int, value:int, xfer_size:int
+                'read_block32':         (self._request__read_block32,       3   ), # 'read_block32', handle:int, addr:int, word_count:int -> List[int]
+                'write_block32':        (self._request__write_block32,      3   ), # 'write_block32', handle:int, addr:int, data:List[int]
+            }
+        
+        # Let superclass do its thing. (Can't use super() here because the superclass isn't derived
+        # from object in Py2.)
+        StreamRequestHandler.setup(self)
+    
+    def finish(self):
+        LOG.info("Remote probe client disconnected (%s from port %i)", self._client_domain, self.client_address[1])
+        
+        self._session = None
+        StreamRequestHandler.finish(self)
+    
+    def _send_error_response(self, status=1, message=""):
+        response_dict = {
+                "id": self._current_request_id,
+                "status": status,
+                "error": message,
+            }
+        response = json.dumps(response_dict)
+        TRACE.debug("response: %s", response)
+        response_encoded = response.encode('utf-8')
+        self.wfile.write(response_encoded + b"\n")
+        
+    def _send_response(self, result):
+        response_dict = {
+                "id": self._current_request_id,
+                "status": 0,
+            }
+        if result is not None:
+            response_dict["result"] = result
+        response = json.dumps(response_dict)
+        TRACE.debug("response: %s", response)
+        response_encoded = response.encode('utf-8')
+        self.wfile.write(response_encoded + b"\n")
+        
+    def handle(self):
+        # Process requests until the connection is closed.
+        while True:
+            try:
+                request = None
+                request_dict = None
+                request_id = -1
+                self._current_request_id = -1
+                
+                # Read request line.
+                request = self.rfile.readline()
+                TRACE.debug("request: %s", request)
+                if len(request) == 0:
+                    LOG.debug("empty request, closing connection")
+                    return
+                
+                try:
+                    request_dict = json.loads(request)
+                except json.JSONDecodeError:
+                    self._send_error_response(message="invalid request format")
+                    continue
+            
+                if not isinstance(request_dict, dict):
+                    self._send_error_response(message="invalid request format")
+                    continue
+                    
+                if 'id' not in request_dict:
+                    self._send_error_response(message="missing request ID")
+                    continue
+                request_id = request_dict['id']
+                self._current_request_id = request_dict['id']
+                
+                if 'request' not in request_dict:
+                    self._send_error_response(message="missing request field")
+                    continue
+                request_type = request_dict['request']
+                
+                # Get arguments. If the key isn't present then there are no arguments.
+                request_args = request_dict.get('arguments', [])
+            
+                if not isinstance(request_args, list):
+                    self._send_error_response(message="invalid request arguments format")
+                    continue
+                
+                if request_type not in self._REQUEST_HANDLERS:
+                    self._send_error_response(message="unknown request type")
+                    continue
+                handler, arg_count = self._REQUEST_HANDLERS[request_type]
+                self._check_args(request_args, arg_count)
+                result = handler(*request_args)
+                
+                # Send a success response.
+                self._send_response(result)
+            # Catch all exceptions so that an error response can be returned, to not leave the client hanging.
+            except Exception as err:
+                # Only send an error response if we received an request.
+                if request is not None:
+                    LOG.error("Error while processing %s request from client: %s", request, err,
+                            exc_info=self._session.log_tracebacks)
+                    self._send_error_response(status=self._get_exception_status_code(err),
+                            message=str(err))
+                else:
+                    LOG.error("Error before request was received: %s", err,
+                            exc_info=self._session.log_tracebacks)
+                # Reraise non-pyocd errors.
+                if not isinstance(err, exceptions.Error):
+                    raise
+    
+    def _get_exception_status_code(self, err):
+        """! @brief Convert an exception class into a status code."""
+        # Must test the exception class in order of specific to general.
+        if isinstance(err, exceptions.ProbeDisconnected):
+            return self.StatusCode.PROBE_DISCONNECTED
+        elif isinstance(err, exceptions.ProbeError):
+            return self.StatusCode.PROBE_ERROR
+        elif isinstance(err, exceptions.TransferFaultError):
+            return self.StatusCode.TRANSFER_FAULT
+        elif isinstance(err, exceptions.TransferTimeoutError):
+            return self.StatusCode.TRANSFER_TIMEOUT
+        elif isinstance(err, exceptions.TransferError):
+            return self.StatusCode.TRANSFER_ERROR
+        else:
+            return self.StatusCode.GENERAL_ERROR
+    
+    def _check_args(self, args, count):
+        if len(args) != count:
+            raise exceptions.Error("malformed request; invalid number of arguments")
+    
+    def _request__hello(self, version):
+        # 'hello', protocol-version:int
+        if version != self.PROTOCOL_VERSION:
+            raise exceptions.Error("client requested unsupported protocol version %i (expected %i)" %
+                    (version, self.PROTOCOL_VERSION))
+    
+    def _request__read_property(self, name):
+        # 'readprop', name:str
+        if not hasattr(self._probe, name):
+            raise exceptions.Error("unknown property name '%s' requested" % name)
+        value = getattr(self._probe, name)
+        # Run the property value through a value transformer if one is defined for this property.
+        if name in self._PROPERTY_CONVERTERS:
+            value = self._PROPERTY_CONVERTERS[name](value)
+        return value
+    
+    def _request__connect(self, protocol_name):
+        # 'connect', protocol:str
+        try:
+            protocol = DebugProbe.Protocol[protocol_name]
+        except KeyError:
+            raise exceptions.Error("invalid protocol name %s" % protocol_name)
+        self._probe.connect(protocol)
+    
+    def _request__get_memory_interface_for_ap(self, ap_address_version, ap_nominal_address):
+        # 'get_memory_interface_for_ap', ap_address_version:int, ap_nominal_address:int -> handle:int|null
+        ap_version = APVersion(ap_address_version)
+        if ap_version == APVersion.APv1:
+            ap_address = APv1Address(ap_nominal_address)
+        elif ap_version == APVersion.APv2:
+            ap_address = APv2Address(ap_nominal_address)
+        else:
+            raise exceptions.Error("invalid AP version in remote get_memory_interface_for_ap request")
+        memif = self._probe.get_memory_interface_for_ap(ap_address)
+        if memif is not None:
+            handle = self._next_ap_memif_handle
+            self._next_ap_memif_handle += 1
+            self._ap_memif_handles[handle] = memif
+            LOG.debug("creating memif for AP%s (handle %i)", ap_address, handle)
+        else:
+            handle = None
+        return handle
+    
+    def _request__read_mem(self, handle, addr, xfer_size):
+        # 'read_mem', handle:int, addr:int, xfer_size:int -> int
+        if handle not in self._ap_memif_handles:
+            raise exceptions.Error("invalid handle received from remote memory access")
+        return self._ap_memif_handles[handle].read_memory(addr, xfer_size, now=True)
+    
+    def _request__write_mem(self, handle, addr, value, xfer_size):
+        # 'write_mem', handle:int, addr:int, value:int, xfer_size:int
+        if handle not in self._ap_memif_handles:
+            raise exceptions.Error("invalid handle received from remote memory access")
+        self._ap_memif_handles[handle].write_memory(addr, value, xfer_size)
+    
+    def _request__read_block32(self, handle, addr, word_count):
+        # 'read_block32', handle:int, addr:int, word_count:int -> List[int]
+        # TODO use base64 data
+        if handle not in self._ap_memif_handles:
+            raise exceptions.Error("invalid handle received from remote memory access")
+        return self._ap_memif_handles[handle].read_memory_block32(addr, word_count)
+    
+    def _request__write_block32(self, handle, addr, data):
+        # 'write_block32', handle:int, addr:int, data:List[int]
+        # TODO use base64 data
+        if handle not in self._ap_memif_handles:
+            raise exceptions.Error("invalid handle received from remote memory access")
+        self._ap_memif_handles[handle].read_memory_block32(addr, data)
+
+    _PROPERTY_CONVERTERS = {
+            'capabilities':                 lambda value: [v.name for v in value],
+            'supported_wire_protocols':     lambda value: [v.name for v in value],
+            'wire_protocol':                lambda value: value.name,
+        }
+

--- a/pyocd/probe/tcp_probe_server.py
+++ b/pyocd/probe/tcp_probe_server.py
@@ -242,6 +242,8 @@ class DebugProbeRequestHandler(StreamRequestHandler):
                 'write_mem':            (self._request__write_mem,          4   ), # 'write_mem', handle:int, addr:int, value:int, xfer_size:int
                 'read_block32':         (self._request__read_block32,       3   ), # 'read_block32', handle:int, addr:int, word_count:int -> List[int]
                 'write_block32':        (self._request__write_block32,      3   ), # 'write_block32', handle:int, addr:int, data:List[int]
+                'read_block8':          (self._request__read_block8,        3   ), # 'read_block8', handle:int, addr:int, word_count:int -> List[int]
+                'write_block8':         (self._request__write_block8,       3   ), # 'write_block8', handle:int, addr:int, data:List[int]
             }
         
         # Let superclass do its thing. (Can't use super() here because the superclass isn't derived
@@ -432,7 +434,21 @@ class DebugProbeRequestHandler(StreamRequestHandler):
         # TODO use base64 data
         if handle not in self._ap_memif_handles:
             raise exceptions.Error("invalid handle received from remote memory access")
-        self._ap_memif_handles[handle].read_memory_block32(addr, data)
+        self._ap_memif_handles[handle].write_memory_block32(addr, data)
+    
+    def _request__read_block8(self, handle, addr, word_count):
+        # 'read_block8', handle:int, addr:int, word_count:int -> List[int]
+        # TODO use base64 data
+        if handle not in self._ap_memif_handles:
+            raise exceptions.Error("invalid handle received from remote memory access")
+        return self._ap_memif_handles[handle].read_memory_block8(addr, word_count)
+    
+    def _request__write_block8(self, handle, addr, data):
+        # 'write_block8', handle:int, addr:int, data:List[int]
+        # TODO use base64 data
+        if handle not in self._ap_memif_handles:
+            raise exceptions.Error("invalid handle received from remote memory access")
+        self._ap_memif_handles[handle].write_memory_block8(addr, data)
 
     _PROPERTY_CONVERTERS = {
             'capabilities':                 lambda value: [v.name for v in value],

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(
         'pyocd.probe': [
             'cmsisdap = pyocd.probe.cmsis_dap_probe:CMSISDAPProbePlugin',
             'jlink = pyocd.probe.jlink_probe:JLinkProbePlugin',
+            'remote = pyocd.probe.tcp_client_probe:TCPClientProbePlugin',
             'stlink = pyocd.probe.stlink_probe:StlinkProbePlugin',
         ],
         'pyocd.rtos': [


### PR DESCRIPTION
This PR adds a TCP/IP client and server to enable remote access to debug probes. This version can be considered an experimental implementation intended to gather feedback and contributions. However, the currently functionality is useful enough that I wanted to make it available quickly.

Basic documentation is included in `docs/remote_probe_access.md`.

### Design 
The design is fairly simple in that there is a 1:1 correspondence between server instance (and thus TCP port) and debug probe. The protocol uses JSON-encoded messages, but is not JSON-RPC. Locking is fully supported, so many clients can connect to a single server without causing issues (at least at the lower levels; don't expect two gdb instances to behave when controlling a single core).

There are a lot of opportunities for improvements. The main addition I'd like to see is the ability to run a single server to share all connected probes.

### Server
There are three ways to run the probe server.

1. A new `server` subcommand. Runs only the probe server. This example runs the probe server in the background:

    ```
    $ pyocd server -q -u0240 &
    ```

2. The new `--probe-server` argument on the `gdbserver` subcommand, which causes a probe server to run alongside the gdbserver. This example demonstrates the option:

    ```
    $ pyocd gdb -u0240 --probe-server
    ```

3. Commander has a `probeserver` command that accepts `start` and `stop` actions.

As usual, if there is more than one debug probe connected and you do not use `-u` to select one by its unique ID, then pyOCD will present a prompt asking you to choose a probe to use.

### Client
Connecting another pyOCD instance to a probe server is easy. This is done by selecting the `remote` debug probe and passing the server address using the `--uid` (or `-u`) argument to any pyOCD subcommand where you would normally use a local debug probe. The syntax is `remote:<server>[:<port>]`, where server is a domain name or IP and port is the TCP port number. If left off, the default port of 5555 is used.

Example to connect a commander to a running probe server on the default port 5555:
```
$ pyocd cmd -uremote:localhost:5555 -v
```

Remote probes do not appear in the list of available probes printed by `pyocd list --probes`.

