### PR TITLE
USB HID Detach Kernel Driver fix for FreeBSD.

### DIFF
--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -91,10 +91,12 @@ class PyUSB(Interface):
         self.kernel_driver_was_attached = False
         try:
             if dev.is_kernel_driver_active(interface_number):
+                LOG.debug("Detaching Kernel Driver of Interface %d from USB device (VID=%04x PID=%04x).", interface_number, dev.idVendor, dev.idProduct)
                 dev.detach_kernel_driver(interface_number)
                 self.kernel_driver_was_attached = True
-        except NotImplementedError as e:
+        except (NotImplementedError,usb.core.USBError) as e:
             # Some implementations don't don't have kernel attach/detach
+            LOG.warning("USB Kernel Driver Detach Failed ([%s] %s). Attached driver may interfere with pyOCD operations.", e.errno, e.strerror)
             pass
 
         # Explicitly claim the interface


### PR DESCRIPTION
This change catches all exceptions during kernel driver detach try.
It was blocking pyOCD on FreeBSD where HID was attached to DAPLink.

More generic kernel driver detach exception handling fixes crashes
on systems where user is not permitted (or even welcome) to detach
HID driver on the whole system just to use DAPLink.
On FreeBSD user is not allowed to detach HID kernel drivers because
that would impact whole OS and the rest of the workstation services,
while DAPLink works fine even with those HID drivers attached :-)

I have added one Debug message before detach and Warning after it fails.

Signed-off-by: Tomasz 'CeDeROM' CEDRO <tomek@cedro.info>