### PR TITLE
many fixes for ITM/SWO/SWV

### DIFF
--- a/pyocd/coresight/itm.py
+++ b/pyocd/coresight/itm.py
@@ -94,7 +94,7 @@ class ITM(CoreSightComponent):
                                     | ITM.TCR_TXENA_MASK
                                     | (ITM.TCR_TSPRESCALE_DIV_1 << ITM.TCR_TSPRESCALE_SHIFT)))
         self.ap.write32(self.address + ITM.TERn, enabled_ports)
-        self.ap.write32(self.address + ITM.TPR, 0xf) # Allow unprivileged access to all 32 ports.
+        self.ap.write32(self.address + ITM.TPR, 0) # Allow unprivileged access to all 32 ports.
         self._is_enabled = True
 
     def set_enabled_ports(self, enabled_ports):

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -135,7 +135,7 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_INFO:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_INFO")
 
         if resp[1] == 0:
             return
@@ -162,11 +162,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_LED:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_LED")
 
         if resp[1] != 0:
             # Second response byte must be 0
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_LED failed")
 
         return resp[1]
 
@@ -179,11 +179,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_CONNECT:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_CONNECT")
 
         if resp[1] == 0:
             # DAP connect failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_CONNECT failed")
 
         return resp[1]
 
@@ -195,11 +195,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_DISCONNECT:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_DISCONNECT")
 
         if resp[1] != DAP_OK:
             # DAP Disconnect failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_DISCONNECT failed")
 
         return resp[1]
 
@@ -216,11 +216,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_WRITE_ABORT:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_WRITE_ABORT")
 
         if resp[1] != DAP_OK:
             # DAP Write Abort failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_WRITE_ABORT failed")
 
         return True
 
@@ -232,11 +232,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_RESET_TARGET:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_RESET_TARGET")
 
         if resp[1] != DAP_OK:
             # DAP Reset target failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_RESET_TARGET failed")
 
         return resp[1]
 
@@ -253,11 +253,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_TRANSFER_CONFIGURE:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_TRANSFER_CONFIGURE")
 
         if resp[1] != DAP_OK:
             # DAP Transfer Configure failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_TRANSFER_CONFIGURE failed")
 
         return resp[1]
 
@@ -274,11 +274,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_SWJ_CLOCK:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_SWJ_CLOCK")
 
         if resp[1] != DAP_OK:
             # DAP SWJ Clock failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_SWJ_CLOCK failed")
 
         return resp[1]
 
@@ -296,7 +296,7 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_SWJ_PINS:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_SWJ_PINS")
 
         return resp[1]
 
@@ -312,11 +312,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_SWD_CONFIGURE:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_SWD_CONFIGURE")
 
         if resp[1] != DAP_OK:
             # DAP SWD Configure failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_SWD_CONFIGURE failed")
 
         return resp[1]
 
@@ -333,11 +333,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_SWJ_SEQUENCE:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_SWJ_SEQUENCE")
 
         if resp[1] != DAP_OK:
             # DAP SWJ Sequence failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_SWJ_SEQUENCE failed")
 
         return resp[1]
 
@@ -359,11 +359,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_JTAG_SEQUENCE:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("exected DAP_JTAG_SEQUENCE")
 
         if resp[1] != DAP_OK:
             # DAP JTAG Sequence failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_JTAG_SEQUENCE failed")
 
         return resp[2]
 
@@ -382,11 +382,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_JTAG_CONFIGURE:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_JTAG_CONFIGURE")
 
         if resp[1] != DAP_OK:
             # DAP JTAG Configure failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_JTAG_CONFIGURE failed")
 
         return resp[2:]
 
@@ -399,11 +399,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_JTAG_IDCODE:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_JTAG_IDCODE")
 
         if resp[1] != DAP_OK:
             # Operation failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_JTAG_IDCODE failed")
 
         return  (resp[2] << 0) | \
                 (resp[3] << 8) | \
@@ -417,13 +417,14 @@ class CMSISDAPProtocol(object):
         self.interface.write(cmd)
 
         resp = self.interface.read()
+
         if resp[0] != Command.DAP_SWO_TRANSPORT:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_SWO_TRANSPORT")
 
         if resp[1] != DAP_OK:
             # Operation failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_SWO_TRANSPORT failed")
 
         return resp[1]
 
@@ -436,11 +437,11 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_SWO_MODE:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_SWO_MODE")
 
         if resp[1] != DAP_OK:
             # Operation failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_SWO_MODE failed")
 
         return resp[1]
 
@@ -456,7 +457,7 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_SWO_BAUDRATE:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_SWO_BAUDRATE")
 
         return  (resp[1] << 0) | \
                 (resp[2] << 8) | \
@@ -470,13 +471,14 @@ class CMSISDAPProtocol(object):
         self.interface.write(cmd)
 
         resp = self.interface.read()
+
         if resp[0] != Command.DAP_SWO_CONTROL:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_SWO_CONTROL")
 
         if resp[1] != DAP_OK:
             # Operation failed
-            raise DAPAccessIntf.CommandError()
+            raise DAPAccessIntf.CommandError("DAP_SWO_CONTROL failed")
 
         return resp[1]
 
@@ -488,7 +490,7 @@ class CMSISDAPProtocol(object):
         resp = self.interface.read()
         if resp[0] != Command.DAP_SWO_STATUS:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_SWO_STATUS")
 
         return (resp[1],
                     (resp[2] << 0) | \
@@ -500,14 +502,18 @@ class CMSISDAPProtocol(object):
     def swo_data(self, count):
         cmd = []
         cmd.append(Command.DAP_SWO_DATA)
+
+        # Account for protocol overhead when setting the count
+        count = min(self.interface.get_packet_size() - 4, count)
         cmd.append(count & 0xff)
         cmd.append((count >> 8) & 0xff)
-        self.interface.write(cmd)
 
+        self.interface.write(cmd)
         resp = self.interface.read()
+
         if resp[0] != Command.DAP_SWO_DATA:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_SWO_DATA")
 
         status = resp[1]
         count = (resp[2] << 0) | \
@@ -528,6 +534,6 @@ class CMSISDAPProtocol(object):
 
         if resp[0] != Command.DAP_VENDOR0 + index:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError()
+            raise DAPAccessIntf.DeviceError("expected DAP_VENDOR0")
 
         return resp[1:]

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -534,6 +534,6 @@ class CMSISDAPProtocol(object):
 
         if resp[0] != Command.DAP_VENDOR0 + index:
             # Response is to a different command
-            raise DAPAccessIntf.DeviceError("expected DAP_VENDOR0")
+            raise DAPAccessIntf.DeviceError("expected DAP_VENDOR%i" % index)
 
         return resp[1:]

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -732,6 +732,10 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         if not self._has_swo_uart:
             return False
         
+        # Before we attempt any configuration, we must explicitly disable SWO
+        # (if SWO is enabled, setting any other configuration fails).
+        self._swo_disable()
+
         try:
             if enabled:
                 # Select the streaming SWO endpoint if available.
@@ -750,9 +754,8 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
                     self._swo_disable()
                     return False
                 self._swo_status = SWOStatus.CONFIGURED
-            else:
-                self._swo_disable()
-                return True
+
+            return True
         except DAPAccessIntf.CommandError as e:
             LOG.debug("Exception while configuring SWO: %s", e)
             self._swo_disable()

--- a/pyocd/probe/pydapaccess/interface/interface.py
+++ b/pyocd/probe/pydapaccess/interface/interface.py
@@ -58,5 +58,8 @@ class Interface(object):
     def set_packet_size(self, size):
         self.packet_size = size
 
+    def get_packet_size(self):
+        return self.packet_size
+
     def get_serial_number(self):
         return self.serial_number

--- a/pyocd/probe/tcp_probe_server.py
+++ b/pyocd/probe/tcp_probe_server.py
@@ -237,7 +237,7 @@ class DebugProbeRequestHandler(StreamRequestHandler):
                 'get_memory_interface_for_ap': (self._request__get_memory_interface_for_ap, 2), # 'get_memory_interface_for_ap', ap_address_version:int, ap_nominal_address:int -> handle:int|null
                 'swo_start':            (self._probe.swo_start,             1   ), # 'swo_start', baudrate:int
                 'swo_stop':             (self._probe.swo_stop,              0   ), # 'swo_stop'
-                'swo_read':             (self._probe.swo_read,              0   ), # 'swo_read' -> List[int]
+                'swo_read':             (self._request__swo_read,           0   ), # 'swo_read' -> List[int]
                 'read_mem':             (self._request__read_mem,           3   ), # 'read_mem', handle:int, addr:int, xfer_size:int -> int
                 'write_mem':            (self._request__write_mem,          4   ), # 'write_mem', handle:int, addr:int, value:int, xfer_size:int
                 'read_block32':         (self._request__read_block32,       3   ), # 'read_block32', handle:int, addr:int, word_count:int -> List[int]
@@ -400,6 +400,7 @@ class DebugProbeRequestHandler(StreamRequestHandler):
             ap_address = APv2Address(ap_nominal_address)
         else:
             raise exceptions.Error("invalid AP version in remote get_memory_interface_for_ap request")
+
         memif = self._probe.get_memory_interface_for_ap(ap_address)
         if memif is not None:
             handle = self._next_ap_memif_handle
@@ -410,6 +411,9 @@ class DebugProbeRequestHandler(StreamRequestHandler):
             handle = None
         return handle
     
+    def _request__swo_read(self):
+        return list(self._probe.swo_read())
+
     def _request__read_mem(self, handle, addr, xfer_size):
         # 'read_mem', handle:int, addr:int, xfer_size:int -> int
         if handle not in self._ap_memif_handles:

--- a/pyocd/target/family/target_lpc5500.py
+++ b/pyocd/target/family/target_lpc5500.py
@@ -126,6 +126,12 @@ class LPC5500Family(CoreSightTarget):
         
         self.call_delegate('trace_start', target=self, mode=0)
 
+        # On a reset when ITM is enabled, TRACECLKDIV/TRACECLKSEL will be reset
+        # even though ITM will remain enabled -- which will cause ITM stimulus
+        # writes to hang in the target because the FIFO will never appear ready.
+        # To prevent this, we explicitly (re)enable traceclk.
+        self._enable_traceclk()
+
 class CortexM_LPC5500(CortexM_v8M):
 
     def reset_and_halt(self, reset_type=None):


### PR DESCRIPTION
This work addresses a total of 9 issues that were preventing ITM + SWO from working on pyOCD + LPC55S69 + CMSIS-DAP.  Some of these are particular to our use case, but many are generic to pyOCD + SWO.  

1. When ITM is enabled, TPR is incorrectly modified to *disable* unprivileged writes when it intended the exact opposite, causing unprivileged stimulus writes to be silently dropped.  This work modifies TPR as intended:  to allow all unprivileged stimulus writes.  

2. The remote probe interface doesn't correctly return SWO data; the `swo_read` fails on a bad JSON encoding.  This work correctly returns a list of integers representing bytes.  

3. On CMSIS-DAP, when enabling SWO when SWO is already enabled, SWO is not first disabled, causing subsequent configuration to fail and the SWO reader to malfunction.  This work always disables SWO before configuring it.

4. On CMSIS-DAP, the size sent in a `DAP_SWO_DATA` request does not correctly adjust for the protocol overhead, potentially causing the last four bytes of the SWO packet to be left unread.  These trailing bytes will then be read on a subsequent read, causing an exception when the data payload does not constitute the expected bytes.  This work adjusts the size sent in `DAP_SWO_DATA` to reflect the protocol overhead.

5. On CMSIS-DAP, both `CommandError` and `DeviceError` are constructed without error messages, making it hard to debug failures from a stack trace.  This work modifies the construction of these errors to always specify an error message.

6. For reasons that are unclear, the SWO parser silently drops any ITM instrumentation packet for any stimulus port other than port 0.  This work modifies the SWO parser to not drop any ITM packets.  

7. The GDB server creates a separate SWO reader for each core (even though there is nothing core-specific with respect to SWO).  Because there is no locking between these threads, having multiple threads reading SWO causes more or less causes rampant corruption of the ITM stream on multicore targets.  This work creates only a single SWO reader thread, regardless of the number of cores.  

8. There is no serialization between the SWO reader thread and the GDB server.  As a result, if SWO and GDB are both simultaneously active, both the SWO reader and the GDB server are likely to experience protocol errors.  (This is likely the cause of issue #855.) This work adds a very coarse grain locking scheme between the two to assure that only one thread is talking to the underlying probe at at a time.

9. On the LPC55, resets with SWO enabled will cause ITM stimulus writes in the target to hang:  because ITM is enabled but `TRACECLKDIV` and `TRACECLKSEL` are reset, the stimulus port is not disabled but the FIFO never becomes ready.  This work explicitly sets `TRACECLKDIV` and `TRACECLKSEL` on a reset on the LPC55.  
