### PR TITLE
SoC target refactoring

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -29,6 +29,14 @@ If the target is locked, it will by default be automatically mass erased in orde
 access. Set this option to False to disable auto unlock.
 </td></tr>
 
+<tr><td>cache.read_code_from_elf</td>
+<td>bool</td>
+<td>True</td>
+<td>
+Controls whether reads of code sections will be taken from an attached ELF file instead of the target memory.
+This can improve performance, especially over slow target connections. Requires an ELF file to be set.
+</td></tr>
+
 <tr><td>chip_erase</td>
 <td>str</td>
 <td>'sector'</td>

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -53,8 +53,8 @@ class CoreSightTarget(Target, GraphNode):
     at any time. You may also directly access specific cores and perform operations on them.
     """
     
-    def __init__(self, session, memoryMap=None):
-        Target.__init__(self, session, memoryMap)
+    def __init__(self, session, memory_map=None):
+        Target.__init__(self, session, memory_map)
         GraphNode.__init__(self)
         self.part_number = self.__class__.__name__
         self.cores = {}

--- a/pyocd/core/coresight_target.py
+++ b/pyocd/core/coresight_target.py
@@ -93,7 +93,9 @@ class CoreSightTarget(Target, GraphNode):
             self._elf = ELFBinaryFile(filename, self.memory_map)
             for core_number in range(len(self.cores)):
                 self.cores[core_number].elf = self._elf
-                self.cores[core_number].set_target_context(ElfReaderContext(self.cores[core_number].get_target_context(), self._elf))
+                if self.session.options['cache.read_code_from_elf']:
+                    self.cores[core_number].set_target_context(
+                            ElfReaderContext(self.cores[core_number].get_target_context(), self._elf))
 
     @property
     def aps(self):

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -25,6 +25,9 @@ BUILTIN_OPTIONS = [
         "Prevents raising an error if no core were found after CoreSight discovery."),
     OptionInfo('auto_unlock', bool, True,
         "Whether to unlock secured target by erasing."),
+    OptionInfo('cache.read_code_from_elf', bool, True,
+        "Controls whether reads of code sections will be taken from an attached ELF file instead of the "
+        "target memory."),
     OptionInfo('chip_erase', str, "sector",
         "Whether to perform a chip erase or sector erases when programming flash. The value must be"
         " one of \"auto\", \"sector\", or \"chip\"."),

--- a/pyocd/core/soc_target.py
+++ b/pyocd/core/soc_target.py
@@ -1,0 +1,247 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import six
+
+from .target import Target
+from .memory_map import MemoryType
+from . import exceptions
+from ..flash.eraser import FlashEraser
+from ..debug.cache import CachingDebugContext
+from ..debug.elf.elf import ELFBinaryFile
+from ..debug.elf.elf_reader import ElfReaderContext
+from ..utility.graph import GraphNode
+from ..utility.sequencer import CallSequence
+
+LOG = logging.getLogger(__name__)
+
+class SoCTarget(Target, GraphNode):
+    """! @brief Represents a microcontroller system-on-chip.
+    
+    An instance of this class is the root of the chip-level object graph. It has child
+    nodes for the DP and all cores. As a concrete subclass of Target, it provides methods
+    to control the device, access memory, adjust breakpoints, and so on.
+    
+    For single core devices, the SoCTarget has mostly equivalent functionality to
+    the Target object for the core. Multicore devices work differently. This class tracks
+    a "selected core", to which all actions are directed. The selected core can be changed
+    at any time. You may also directly access specific cores and perform operations on them.
+    """
+    
+    VENDOR = "Generic"
+
+    def __init__(self, session, memory_map=None):
+        Target.__init__(self, session, memory_map)
+        GraphNode.__init__(self)
+        self.vendor = self.VENDOR
+        self.part_families = getattr(self, 'PART_FAMILIES', [])
+        self.part_number = getattr(self, 'PART_NUMBER', self.__class__.__name__)
+        self._cores = {}
+        self._selected_core = None
+        self._new_core_num = 0
+        self._elf = None
+
+    @property
+    def cores(self):
+        return self._cores
+
+    @property
+    def selected_core(self):
+        if self._selected_core is None:
+            return None
+        return self.cores[self._selected_core]
+    
+    @selected_core.setter
+    def selected_core(self, core_number):
+        if core_number not in self.cores:
+            raise ValueError("invalid core number %d" % core_number)
+        LOG.debug("selected core #%d" % core_number)
+        self._selected_core = core_number
+
+    @property
+    def elf(self):
+        return self._elf
+
+    @elf.setter
+    def elf(self, filename):
+        if filename is None:
+            self._elf = None
+        else:
+            self._elf = ELFBinaryFile(filename, self.memory_map)
+            for core_number in range(len(self.cores)):
+                self.cores[core_number].elf = self._elf
+                if self.session.options['cache.read_code_from_elf']:
+                    self.cores[core_number].set_target_context(
+                            ElfReaderContext(self.cores[core_number].get_target_context(), self._elf))
+    
+    @property
+    def supported_security_states(self):
+        return self.selected_core.supported_security_states
+    
+    @property
+    def core_registers(self):
+        return self.selected_core.core_registers
+
+    def add_core(self, core):
+        core.delegate = self.delegate
+        core.set_target_context(CachingDebugContext(core))
+        self.cores[core.core_number] = core
+        self.add_child(core)
+        
+        if self._selected_core is None:
+            self._selected_core = core.core_number
+
+    def create_init_sequence(self):
+        # Return an empty call sequence. The subclass must override this.
+        return CallSequence()
+    
+    def init(self):
+        # If we don't have a delegate installed yet but there is a session delegate, use it.
+        if (self.delegate is None) and (self.session.delegate is not None):
+            self.delegate = self.session.delegate
+        
+        # Create and execute the init sequence.
+        seq = self.create_init_sequence()
+        self.call_delegate('will_init_target', target=self, init_sequence=seq)
+        seq.invoke()
+        self.call_delegate('did_init_target', target=self)
+    
+    def post_connect_hook(self):
+        """! @brief Hook function called after post_connect init task.
+        
+        This hook lets the target subclass configure the target as necessary.
+        """
+        pass
+
+    def disconnect(self, resume=True):
+        self.session.notify(Target.Event.PRE_DISCONNECT, self)
+        self.call_delegate('will_disconnect', target=self, resume=resume)
+        for core in self.cores.values():
+            core.disconnect(resume)
+        self.dp.power_down_debug()
+        self.call_delegate('did_disconnect', target=self, resume=resume)
+
+    @property
+    def run_token(self):
+        return self.selected_core.run_token
+
+    def halt(self):
+        return self.selected_core.halt()
+
+    def step(self, disable_interrupts=True, start=0, end=0):
+        return self.selected_core.step(disable_interrupts, start, end)
+
+    def resume(self):
+        return self.selected_core.resume()
+
+    def mass_erase(self):
+        if not self.call_delegate('mass_erase', target=self):
+            # The default mass erase implementation is to simply perform a chip erase.
+            FlashEraser(self.session, FlashEraser.Mode.CHIP).erase()
+        return True
+
+    def write_memory(self, addr, value, transfer_size=32):
+        return self.selected_core.write_memory(addr, value, transfer_size)
+
+    def read_memory(self, addr, transfer_size=32, now=True):
+        return self.selected_core.read_memory(addr, transfer_size, now)
+
+    def write_memory_block8(self, addr, value):
+        return self.selected_core.write_memory_block8(addr, value)
+
+    def write_memory_block32(self, addr, data):
+        return self.selected_core.write_memory_block32(addr, data)
+
+    def read_memory_block8(self, addr, size):
+        return self.selected_core.read_memory_block8(addr, size)
+
+    def read_memory_block32(self, addr, size):
+        return self.selected_core.read_memory_block32(addr, size)
+
+    def read_core_register(self, id):
+        return self.selected_core.read_core_register(id)
+
+    def write_core_register(self, id, data):
+        return self.selected_core.write_core_register(id, data)
+
+    def read_core_register_raw(self, reg):
+        return self.selected_core.read_core_register_raw(reg)
+
+    def read_core_registers_raw(self, reg_list):
+        return self.selected_core.read_core_registers_raw(reg_list)
+
+    def write_core_register_raw(self, reg, data):
+        self.selected_core.write_core_register_raw(reg, data)
+
+    def write_core_registers_raw(self, reg_list, data_list):
+        self.selected_core.write_core_registers_raw(reg_list, data_list)
+
+    def find_breakpoint(self, addr):
+        return self.selected_core.find_breakpoint(addr)
+
+    def set_breakpoint(self, addr, type=Target.BreakpointType.AUTO):
+        return self.selected_core.set_breakpoint(addr, type)
+
+    def get_breakpoint_type(self, addr):
+        return self.selected_core.get_breakpoint_type(addr)
+
+    def remove_breakpoint(self, addr):
+        return self.selected_core.remove_breakpoint(addr)
+
+    def set_watchpoint(self, addr, size, type):
+        return self.selected_core.set_watchpoint(addr, size, type)
+
+    def remove_watchpoint(self, addr, size, type):
+        return self.selected_core.remove_watchpoint(addr, size, type)
+
+    def reset(self, reset_type=None):
+        # Perform a hardware reset if there is not a core.
+        if self.selected_core is None:
+            self.session.probe.reset()
+            return
+        self.selected_core.reset(reset_type)
+
+    def reset_and_halt(self, reset_type=None):
+        return self.selected_core.reset_and_halt(reset_type)
+
+    def get_state(self):
+        return self.selected_core.get_state()
+        
+    def get_security_state(self):
+        return self.selected_core.get_security_state()
+
+    def get_halt_reason(self):
+        return self.selected_core.get_halt_reason()
+
+    def set_vector_catch(self, enableMask):
+        return self.selected_core.set_vector_catch(enableMask)
+
+    def get_vector_catch(self):
+        return self.selected_core.get_vector_catch()
+
+    def get_target_context(self, core=None):
+        if core is None:
+            core = self._selected_core
+        return self.cores[core].get_target_context()
+    
+    def trace_start(self):
+        self.call_delegate('trace_start', target=self, mode=0)
+    
+    def trace_stop(self):
+        self.call_delegate('trace_stop', target=self, mode=0)
+    
+        

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -174,14 +174,9 @@ class Target(MemoryInterface):
         ## PMU event. v8.1-M only.
         PMU = 7
 
-    VENDOR = "Generic"
-
     def __init__(self, session, memory_map=None):
         self._session = session
         self._delegate = None
-        self.vendor = self.VENDOR
-        self.part_families = []
-        self.part_number = ""
         # Make a target-specific copy of the memory map. This is safe to do without locking
         # because the memory map may not be mutated until target initialization.
         self.memory_map = memory_map.clone() if memory_map else MemoryMap()
@@ -317,10 +312,6 @@ class Target(MemoryInterface):
         raise NotImplementedError()
 
     def get_vector_catch(self):
-        raise NotImplementedError()
-
-    # GDB functions
-    def get_target_xml(self):
         raise NotImplementedError()
 
     def get_target_context(self, core=None):

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -176,7 +176,7 @@ class Target(MemoryInterface):
 
     VENDOR = "Generic"
 
-    def __init__(self, session, memoryMap=None):
+    def __init__(self, session, memory_map=None):
         self._session = session
         self._delegate = None
         self.vendor = self.VENDOR
@@ -184,7 +184,7 @@ class Target(MemoryInterface):
         self.part_number = ""
         # Make a target-specific copy of the memory map. This is safe to do without locking
         # because the memory map may not be mutated until target initialization.
-        self.memory_map = memoryMap.clone() if memoryMap else MemoryMap()
+        self.memory_map = memory_map.clone() if memory_map else MemoryMap()
         self._svd_location = None
         self._svd_device = None
 

--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -17,15 +17,13 @@
 import logging
 import six
 
-from .target import Target
-from .memory_map import MemoryType
-from . import exceptions
-from ..flash.eraser import FlashEraser
-from ..coresight import (dap, discovery, cortex_m, cortex_m_v8m, rom_table)
+from ..core.target import Target
+from ..core.memory_map import MemoryType
+from ..core.soc_target import SoCTarget
+from ..core import exceptions
+from . import (dap, discovery, cortex_m, cortex_m_v8m, rom_table)
 from ..debug.svd.loader import (SVDFile, SVDLoader)
 from ..debug.cache import CachingDebugContext
-from ..debug.elf.elf import ELFBinaryFile
-from ..debug.elf.elf_reader import ElfReaderContext
 from ..utility.graph import GraphNode
 from ..utility.sequencer import CallSequence
 from ..target.pack.flash_algo import PackFlashAlgo
@@ -38,76 +36,22 @@ except ImportError:
 
 LOG = logging.getLogger(__name__)
 
-class CoreSightTarget(Target, GraphNode):
-    """! @brief Represents a chip that uses CoreSight debug infrastructure.
+class CoreSightTarget(SoCTarget):
+    """! @brief Represents an SoC that uses CoreSight debug infrastructure.
     
-    An instance of this class is the root of the chip-level object graph. It has child
-    nodes for the DP and all cores. As a concrete subclass of Target, it provides methods
-    to control the device, access memory, adjust breakpoints, and so on.
-    
-    For single core devices, the CoreSightTarget has mostly equivalent functionality to
-    the CortexM object for the core. Multicore devices work differently. This class tracks
-    a "selected core", to which all actions are directed. The selected core can be changed
-    at any time. You may also directly access specific cores and perform operations on them.
+    This class adds Arm CoreSight-specific discovery and initialization code to SoCTarget.
     """
     
-    VENDOR = "Generic"
-
     def __init__(self, session, memory_map=None):
-        Target.__init__(self, session, memory_map)
-        GraphNode.__init__(self)
-        self.vendor = self.VENDOR
-        self.part_families = getattr(self, 'PART_FAMILIES', [])
-        self.part_number = getattr(self, 'PART_NUMBER', self.__class__.__name__)
-        self.cores = {}
+        super(CoreSightTarget, self).__init__(session, memory_map)
         self.dp = dap.DebugPort(session.probe, self)
-        self._selected_core = None
         self._svd_load_thread = None
-        self._new_core_num = 0
-        self._elf = None
         self._irq_table = None
         self._discoverer = None
 
     @property
-    def selected_core(self):
-        if self._selected_core is None:
-            return None
-        return self.cores[self._selected_core]
-    
-    @selected_core.setter
-    def selected_core(self, core_number):
-        if core_number not in self.cores:
-            raise ValueError("invalid core number %d" % core_number)
-        LOG.debug("selected core #%d" % core_number)
-        self._selected_core = core_number
-
-    @property
-    def elf(self):
-        return self._elf
-
-    @elf.setter
-    def elf(self, filename):
-        if filename is None:
-            self._elf = None
-        else:
-            self._elf = ELFBinaryFile(filename, self.memory_map)
-            for core_number in range(len(self.cores)):
-                self.cores[core_number].elf = self._elf
-                if self.session.options['cache.read_code_from_elf']:
-                    self.cores[core_number].set_target_context(
-                            ElfReaderContext(self.cores[core_number].get_target_context(), self._elf))
-
-    @property
     def aps(self):
         return self.dp.aps
-    
-    @property
-    def supported_security_states(self):
-        return self.selected_core.supported_security_states
-    
-    @property
-    def core_registers(self):
-        return self.selected_core.core_registers
 
     @property
     def svd_device(self):
@@ -127,15 +71,6 @@ class CoreSightTarget(Target, GraphNode):
             self._svd_load_thread = SVDLoader(self._svd_location, svd_load_completed_cb)
             self._svd_load_thread.load()
 
-    def add_core(self, core):
-        core.delegate = self.delegate
-        core.set_target_context(CachingDebugContext(core))
-        self.cores[core.core_number] = core
-        self.add_child(core)
-        
-        if self._selected_core is None:
-            self._selected_core = core.core_number
-
     def create_init_sequence(self):
         seq = CallSequence(
             ('load_svd',            self.load_svd),
@@ -152,17 +87,6 @@ class CoreSightTarget(Target, GraphNode):
             )
         
         return seq
-    
-    def init(self):
-        # If we don't have a delegate installed yet but there is a session delegate, use it.
-        if (self.delegate is None) and (self.session.delegate is not None):
-            self.delegate = self.session.delegate
-        
-        # Create and execute the init sequence.
-        seq = self.create_init_sequence()
-        self.call_delegate('will_init_target', target=self, init_sequence=seq)
-        seq.invoke()
-        self.call_delegate('did_init_target', target=self)
             
     def create_discoverer(self):
         """! @brief Init task to create the discovery object.
@@ -225,13 +149,6 @@ class CoreSightTarget(Target, GraphNode):
                 except exceptions.Error as err:
                     LOG.warning("Could not halt core #%d: %s", core.core_number, err,
                         exc_info=self.session.log_tracebacks)
-    
-    def post_connect_hook(self):
-        """! @brief Hook function called after post_connect init task.
-        
-        This hook lets the target subclass configure the target as necessary.
-        """
-        pass
     
     def create_flash(self):
         """! @brief Instantiates flash objects for memory regions.
@@ -301,118 +218,6 @@ class CoreSightTarget(Target, GraphNode):
                 LOG.error("No cores were discovered!")
             else:
                 raise exceptions.DebugError("No cores were discovered!")
-
-    def disconnect(self, resume=True):
-        self.session.notify(Target.Event.PRE_DISCONNECT, self)
-        self.call_delegate('will_disconnect', target=self, resume=resume)
-        for core in self.cores.values():
-            core.disconnect(resume)
-        self.dp.power_down_debug()
-        self.call_delegate('did_disconnect', target=self, resume=resume)
-
-    @property
-    def run_token(self):
-        return self.selected_core.run_token
-
-    def halt(self):
-        return self.selected_core.halt()
-
-    def step(self, disable_interrupts=True, start=0, end=0):
-        return self.selected_core.step(disable_interrupts, start, end)
-
-    def resume(self):
-        return self.selected_core.resume()
-
-    def mass_erase(self):
-        if not self.call_delegate('mass_erase', target=self):
-            # The default mass erase implementation is to simply perform a chip erase.
-            FlashEraser(self.session, FlashEraser.Mode.CHIP).erase()
-        return True
-
-    def write_memory(self, addr, value, transfer_size=32):
-        return self.selected_core.write_memory(addr, value, transfer_size)
-
-    def read_memory(self, addr, transfer_size=32, now=True):
-        return self.selected_core.read_memory(addr, transfer_size, now)
-
-    def write_memory_block8(self, addr, value):
-        return self.selected_core.write_memory_block8(addr, value)
-
-    def write_memory_block32(self, addr, data):
-        return self.selected_core.write_memory_block32(addr, data)
-
-    def read_memory_block8(self, addr, size):
-        return self.selected_core.read_memory_block8(addr, size)
-
-    def read_memory_block32(self, addr, size):
-        return self.selected_core.read_memory_block32(addr, size)
-
-    def read_core_register(self, id):
-        return self.selected_core.read_core_register(id)
-
-    def write_core_register(self, id, data):
-        return self.selected_core.write_core_register(id, data)
-
-    def read_core_register_raw(self, reg):
-        return self.selected_core.read_core_register_raw(reg)
-
-    def read_core_registers_raw(self, reg_list):
-        return self.selected_core.read_core_registers_raw(reg_list)
-
-    def write_core_register_raw(self, reg, data):
-        self.selected_core.write_core_register_raw(reg, data)
-
-    def write_core_registers_raw(self, reg_list, data_list):
-        self.selected_core.write_core_registers_raw(reg_list, data_list)
-
-    def find_breakpoint(self, addr):
-        return self.selected_core.find_breakpoint(addr)
-
-    def set_breakpoint(self, addr, type=Target.BreakpointType.AUTO):
-        return self.selected_core.set_breakpoint(addr, type)
-
-    def get_breakpoint_type(self, addr):
-        return self.selected_core.get_breakpoint_type(addr)
-
-    def remove_breakpoint(self, addr):
-        return self.selected_core.remove_breakpoint(addr)
-
-    def set_watchpoint(self, addr, size, type):
-        return self.selected_core.set_watchpoint(addr, size, type)
-
-    def remove_watchpoint(self, addr, size, type):
-        return self.selected_core.remove_watchpoint(addr, size, type)
-
-    def reset(self, reset_type=None):
-        # Perform a hardware reset if there is not a core.
-        if self.selected_core is None:
-            self.session.probe.reset()
-            return
-        self.selected_core.reset(reset_type)
-
-    def reset_and_halt(self, reset_type=None):
-        return self.selected_core.reset_and_halt(reset_type)
-
-    def get_state(self):
-        return self.selected_core.get_state()
-        
-    def get_security_state(self):
-        return self.selected_core.get_security_state()
-
-    def get_halt_reason(self):
-        return self.selected_core.get_halt_reason()
-
-    def set_vector_catch(self, enableMask):
-        return self.selected_core.set_vector_catch(enableMask)
-
-    def get_vector_catch(self):
-        return self.selected_core.get_vector_catch()
-
-    def get_target_context(self, core=None):
-        if core is None:
-            core = self._selected_core
-        return self.cores[core].get_target_context()
-
     @property
     def irq_table(self):
         if self._irq_table is None:
@@ -420,11 +225,5 @@ class CoreSightTarget(Target, GraphNode):
                 self._irq_table = {i.value : i.name for i in
                     [i for p in self.svd_device.peripherals for i in p.interrupts]}
         return self._irq_table
-    
-    def trace_start(self):
-        self.call_delegate('trace_start', target=self, mode=0)
-    
-    def trace_stop(self):
-        self.call_delegate('trace_stop', target=self, mode=0)
     
         

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -187,13 +187,13 @@ class CortexM(Target, CoreSightCoreComponent):
         
         return core
 
-    def __init__(self, session, ap, memoryMap=None, core_num=0, cmpid=None, address=None):
+    def __init__(self, session, ap, memory_map=None, core_num=0, cmpid=None, address=None):
         # Supply a default memory map.
-        if (memoryMap is None) or (memoryMap.region_count == 0):
-            memoryMap = self._create_default_cortex_m_memory_map()
+        if (memory_map is None) or (memory_map.region_count == 0):
+            memory_map = self._create_default_cortex_m_memory_map()
             LOG.debug("Using default memory map for core #%d (no memory map supplied)", core_num)
         
-        Target.__init__(self, session, memoryMap)
+        Target.__init__(self, session, memory_map)
         CoreSightCoreComponent.__init__(self, ap, cmpid, address)
 
         self._architecture = None

--- a/pyocd/coresight/cortex_m_v8m.py
+++ b/pyocd/coresight/cortex_m_v8m.py
@@ -54,8 +54,8 @@ class CortexM_v8M(CortexM):
     MVFR1_MVE__INTEGER = 0x1
     MVFR1_MVE__FLOAT = 0x2
 
-    def __init__(self, rootTarget, ap, memoryMap=None, core_num=0, cmpid=None, address=None):
-        super(CortexM_v8M, self).__init__(rootTarget, ap, memoryMap, core_num, cmpid, address)
+    def __init__(self, rootTarget, ap, memory_map=None, core_num=0, cmpid=None, address=None):
+        super(CortexM_v8M, self).__init__(rootTarget, ap, memory_map, core_num, cmpid, address)
 
         # Only v7-M supports VECTRESET.
         self._supports_vectreset = False

--- a/pyocd/coresight/generic_mem_ap.py
+++ b/pyocd/coresight/generic_mem_ap.py
@@ -94,7 +94,6 @@ class GenericMemAPTarget(Target, CoreSightCoreComponent):
 
     def reset_and_halt(self, reset_type=None):
         self.reset(reset_type)
-        pass
 
     def get_state(self):
         return Target.State.HALTED
@@ -152,9 +151,6 @@ class GenericMemAPTarget(Target, CoreSightCoreComponent):
 
     def get_vector_catch(self):
         return 0
-
-    def get_target_xml(self):
-        return None
 
     def get_halt_reason(self):
         return Target.HaltReason.DEBUG

--- a/pyocd/target/builtin/__init__.py
+++ b/pyocd/target/builtin/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ..family import target_kinetis
 from . import target_MIMXRT1011xxxxx
 from . import target_MIMXRT1015xxxxx

--- a/pyocd/target/builtin/cypress/target_CY8C64x5.py
+++ b/pyocd/target/builtin/cypress/target_CY8C64x5.py
@@ -27,7 +27,7 @@ class cy8c64x5(PSoC64):
     from .flash_algos.flash_algo_CY8C64x5 import flash_algo as flash_algo_main
     from .flash_algos.flash_algo_CY8C6xxA_SMIF_S25Hx512T import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -52,18 +52,18 @@ class cy8c64x5(PSoC64):
                     flash_class=Flash_PSoC64),
     )
 
-    def __init__(self, link, ap_num):
-        super(cy8c64x5, self).__init__(link, CortexM_PSoC64_A512K, self.memoryMap, ap_num)
+    def __init__(self, session, ap_num):
+        super(cy8c64x5, self).__init__(session, CortexM_PSoC64_A512K, self.MEMORY_MAP, ap_num)
 
 
 class cy8c64x5_cm0(cy8c64x5):
-    def __init__(self, link):
-        super(cy8c64x5_cm0, self).__init__(link, 1)
+    def __init__(self, session):
+        super(cy8c64x5_cm0, self).__init__(session, 1)
 
 
 class cy8c64x5_cm4(cy8c64x5):
-    def __init__(self, link):
-        super(cy8c64x5_cm4, self).__init__(link, 2)
+    def __init__(self, session):
+        super(cy8c64x5_cm4, self).__init__(session, 2)
 
 
 class cy8c64x5_cm4_full_flash(cy8c64x5_cm4):
@@ -71,7 +71,7 @@ class cy8c64x5_cm4_full_flash(cy8c64x5_cm4):
     from .flash_algos.flash_algo_CY8C6xxA_WFLASH import flash_algo as flash_algo_work
     from .flash_algos.flash_algo_CY8C6xxA_SMIF_S25Hx512T import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -111,7 +111,7 @@ class cy8c64x5_cm0_full_flash(cy8c64x5_cm0):
     from .flash_algos.flash_algo_CY8C6xxA_WFLASH import flash_algo as flash_algo_work
     from .flash_algos.flash_algo_CY8C6xxA_SMIF_S25Hx512T import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 

--- a/pyocd/target/builtin/cypress/target_CY8C64xA.py
+++ b/pyocd/target/builtin/cypress/target_CY8C64xA.py
@@ -28,7 +28,7 @@ class cy8c64xA(PSoC64):
     from .flash_algos.flash_algo_CY8C6xxA_WFLASH import flash_algo as flash_algo_work
     from .flash_algos.flash_algo_CY8C6xxA_SMIF_S25FL512S import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -62,18 +62,18 @@ class cy8c64xA(PSoC64):
                     flash_class=Flash_PSoC64),
     )
 
-    def __init__(self, link, ap_num):
-        super(cy8c64xA, self).__init__(link, CortexM_PSoC64_A2M, self.memoryMap, ap_num)
+    def __init__(self, session, ap_num):
+        super(cy8c64xA, self).__init__(session, CortexM_PSoC64_A2M, self.MEMORY_MAP, ap_num)
 
 
 class cy8c64xA_cm0(cy8c64xA):
-    def __init__(self, link):
-        super(cy8c64xA_cm0, self).__init__(link, 1)
+    def __init__(self, session):
+        super(cy8c64xA_cm0, self).__init__(session, 1)
 
 
 class cy8c64xA_cm4(cy8c64xA):
-    def __init__(self, link):
-        super(cy8c64xA_cm4, self).__init__(link, 2)
+    def __init__(self, session):
+        super(cy8c64xA_cm4, self).__init__(session, 2)
 
 
 class cy8c64xA_cm4_full_flash(cy8c64xA_cm4):
@@ -81,7 +81,7 @@ class cy8c64xA_cm4_full_flash(cy8c64xA_cm4):
     from .flash_algos.flash_algo_CY8C6xxA_WFLASH import flash_algo as flash_algo_work
     from .flash_algos.flash_algo_CY8C6xxA_SMIF_S25FL512S import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -121,7 +121,7 @@ class cy8c64xA_cm0_full_flash(cy8c64xA_cm0):
     from .flash_algos.flash_algo_CY8C6xxA_WFLASH import flash_algo as flash_algo_work
     from .flash_algos.flash_algo_CY8C6xxA_SMIF_S25FL512S import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 

--- a/pyocd/target/builtin/cypress/target_CY8C64xx.py
+++ b/pyocd/target/builtin/cypress/target_CY8C64xx.py
@@ -28,7 +28,7 @@ class cy8c64xx(PSoC64):
     from .flash_algos.flash_algo_CY8C6xxx_WFLASH import flash_algo as flash_algo_work
     from .flash_algos.flash_algo_CY8C6xxx_SMIF_S25FL128S import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -62,8 +62,8 @@ class cy8c64xx(PSoC64):
                     flash_class=Flash_PSoC64),
     )
 
-    def __init__(self, link, ap_num):
-        super(cy8c64xx, self).__init__(link, CortexM_PSoC64_BLE2, self.memoryMap, ap_num)
+    def __init__(self, session, ap_num):
+        super(cy8c64xx, self).__init__(session, CortexM_PSoC64_BLE2, self.MEMORY_MAP, ap_num)
 
 
 class cy8c64xx_s25hx512t(PSoC64):
@@ -71,7 +71,7 @@ class cy8c64xx_s25hx512t(PSoC64):
     from .flash_algos.flash_algo_CY8C6xxx_WFLASH import flash_algo as flash_algo_work
     from .flash_algos.flash_algo_CY8C6xxx_SMIF_S25Hx512T import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -105,15 +105,15 @@ class cy8c64xx_s25hx512t(PSoC64):
                     flash_class=Flash_PSoC64),
     )
 
-    def __init__(self, link, ap_num):
-        super(cy8c64xx_s25hx512t, self).__init__(link, CortexM_PSoC64_BLE2, self.memoryMap, ap_num)
+    def __init__(self, session, ap_num):
+        super(cy8c64xx_s25hx512t, self).__init__(session, CortexM_PSoC64_BLE2, self.MEMORY_MAP, ap_num)
         
         
 class cy8c64xx_nosmif(PSoC64):
     from .flash_algos.flash_algo_CY8C64xx import flash_algo as flash_algo_main
     from .flash_algos.flash_algo_CY8C6xxx_WFLASH import flash_algo as flash_algo_work
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -136,38 +136,38 @@ class cy8c64xx_nosmif(PSoC64):
                     flash_class=Flash_PSoC64),
     )
 
-    def __init__(self, link, ap_num):
-        super(cy8c64xx_nosmif, self).__init__(link, CortexM_PSoC64_BLE2, self.memoryMap, ap_num)
+    def __init__(self, session, ap_num):
+        super(cy8c64xx_nosmif, self).__init__(session, CortexM_PSoC64_BLE2, self.MEMORY_MAP, ap_num)
 
 
 class cy8c64xx_cm0(cy8c64xx):
-    def __init__(self, link):
-        super(cy8c64xx_cm0, self).__init__(link, 1)
+    def __init__(self, session):
+        super(cy8c64xx_cm0, self).__init__(session, 1)
 
 
 class cy8c64xx_cm4(cy8c64xx):
-    def __init__(self, link):
-        super(cy8c64xx_cm4, self).__init__(link, 2)
+    def __init__(self, session):
+        super(cy8c64xx_cm4, self).__init__(session, 2)
 
 
 class cy8c64xx_cm0_s25hx512t(cy8c64xx_s25hx512t):
-    def __init__(self, link):
-        super(cy8c64xx_cm0_s25hx512t, self).__init__(link, 1)
+    def __init__(self, session):
+        super(cy8c64xx_cm0_s25hx512t, self).__init__(session, 1)
 
 
 class cy8c64xx_cm4_s25hx512t(cy8c64xx_s25hx512t):
-    def __init__(self, link):
-        super(cy8c64xx_cm4_s25hx512t, self).__init__(link, 2)
+    def __init__(self, session):
+        super(cy8c64xx_cm4_s25hx512t, self).__init__(session, 2)
         
         
 class cy8c64xx_cm0_nosmif(cy8c64xx_nosmif):
-    def __init__(self, link):
-        super(cy8c64xx_cm0_nosmif, self).__init__(link, 1)
+    def __init__(self, session):
+        super(cy8c64xx_cm0_nosmif, self).__init__(session, 1)
 
 
 class cy8c64xx_cm4_nosmif(cy8c64xx_nosmif):
-    def __init__(self, link):
-        super(cy8c64xx_cm4_nosmif, self).__init__(link, 2)
+    def __init__(self, session):
+        super(cy8c64xx_cm4_nosmif, self).__init__(session, 2)
 
 
 class cy8c64xx_cm4_full_flash(cy8c64xx_cm4):
@@ -175,7 +175,7 @@ class cy8c64xx_cm4_full_flash(cy8c64xx_cm4):
     from .flash_algos.flash_algo_CY8C6xxx_WFLASH import flash_algo as flash_algo_work
     from .flash_algos.flash_algo_CY8C6xxx_SMIF_S25Hx512T import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -215,7 +215,7 @@ class cy8c64xx_cm0_full_flash(cy8c64xx_cm0):
     from .flash_algos.flash_algo_CY8C6xxx_WFLASH import flash_algo as flash_algo_work
     from .flash_algos.flash_algo_CY8C6xxx_SMIF_S25Hx512T import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 

--- a/pyocd/target/builtin/cypress/target_CY8C6xx5.py
+++ b/pyocd/target/builtin/cypress/target_CY8C6xx5.py
@@ -29,7 +29,7 @@ class CY8C6xx5(PSoC6):
     from .flash_algos.flash_algo_CY8C6xxA_SFLASH import flash_algo as flash_algo_sflash
     from .flash_algos.flash_algo_CY8C6xxA_SMIF_S25FL512S import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -69,5 +69,5 @@ class CY8C6xx5(PSoC6):
                     program_page_weight=PSoC6FlashParams.SMIF_PROGRAM_PAGE_WEIGHT),
     )
 
-    def __init__(self, link):
-        super(CY8C6xx5, self).__init__(link, CortexM_PSoC6_A2M, self.memoryMap)
+    def __init__(self, session):
+        super(CY8C6xx5, self).__init__(session, CortexM_PSoC6_A2M, self.MEMORY_MAP)

--- a/pyocd/target/builtin/cypress/target_CY8C6xx7.py
+++ b/pyocd/target/builtin/cypress/target_CY8C6xx7.py
@@ -29,7 +29,7 @@ class CY8C6xx7(PSoC6):
     from .flash_algos.flash_algo_CY8C6xxx_SFLASH import flash_algo as flash_algo_sflash
     from .flash_algos.flash_algo_CY8C6xxx_SMIF_S25FL512S import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -69,8 +69,8 @@ class CY8C6xx7(PSoC6):
                     program_page_weight=PSoC6FlashParams.SMIF_PROGRAM_PAGE_WEIGHT),
     )
 
-    def __init__(self, link):
-        super(CY8C6xx7, self).__init__(link, CortexM_PSoC6_BLE2, self.memoryMap)
+    def __init__(self, session):
+        super(CY8C6xx7, self).__init__(session, CortexM_PSoC6_BLE2, self.MEMORY_MAP)
 
 class CY8C6xx7_S25FS512S(PSoC6):
     from .flash_algos.flash_algo_CY8C6xx7 import flash_algo as flash_algo_main
@@ -78,7 +78,7 @@ class CY8C6xx7_S25FS512S(PSoC6):
     from .flash_algos.flash_algo_CY8C6xxx_SFLASH import flash_algo as flash_algo_sflash
     from .flash_algos.flash_algo_CY8C6xxx_SMIF_S25FS512S import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -118,15 +118,15 @@ class CY8C6xx7_S25FS512S(PSoC6):
                     program_page_weight=PSoC6FlashParams.SMIF_PROGRAM_PAGE_WEIGHT),
     )
 
-    def __init__(self, link):
-        super(CY8C6xx7_S25FS512S, self).__init__(link, CortexM_PSoC6_BLE2, self.memoryMap)
+    def __init__(self, session):
+        super(CY8C6xx7_S25FS512S, self).__init__(session, CortexM_PSoC6_BLE2, self.MEMORY_MAP)
         
 class CY8C6xx7_nosmif(PSoC6):
     from .flash_algos.flash_algo_CY8C6xx7 import flash_algo as flash_algo_main
     from .flash_algos.flash_algo_CY8C6xxx_WFLASH import flash_algo as flash_algo_work
     from .flash_algos.flash_algo_CY8C6xxx_SFLASH import flash_algo as flash_algo_sflash
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -157,5 +157,5 @@ class CY8C6xx7_nosmif(PSoC6):
 
     )
 
-    def __init__(self, link):
-        super(CY8C6xx7_nosmif, self).__init__(link, CortexM_PSoC6_BLE2, self.memoryMap)
+    def __init__(self, session):
+        super(CY8C6xx7_nosmif, self).__init__(session, CortexM_PSoC6_BLE2, self.MEMORY_MAP)

--- a/pyocd/target/builtin/cypress/target_CY8C6xxA.py
+++ b/pyocd/target/builtin/cypress/target_CY8C6xxA.py
@@ -29,7 +29,7 @@ class CY8C6xxA(PSoC6):
     from .flash_algos.flash_algo_CY8C6xxA_SFLASH import flash_algo as flash_algo_sflash
     from .flash_algos.flash_algo_CY8C6xxA_SMIF_S25FL512S import flash_algo as flash_algo_smif
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         PSoC6FlashParams.defaultRomRegion,
         PSoC6FlashParams.defaultRamRegion,
 
@@ -69,5 +69,5 @@ class CY8C6xxA(PSoC6):
                     program_page_weight=PSoC6FlashParams.SMIF_PROGRAM_PAGE_WEIGHT),
     )
 
-    def __init__(self, link):
-        super(CY8C6xxA, self).__init__(link, CortexM_PSoC6_A2M, self.memoryMap)
+    def __init__(self, session):
+        super(CY8C6xxA, self).__init__(session, CortexM_PSoC6_A2M, self.MEMORY_MAP)

--- a/pyocd/target/builtin/target_CC3220SF.py
+++ b/pyocd/target/builtin/target_CC3220SF.py
@@ -116,14 +116,14 @@ class Flash_cc3220sf(Flash):
 class CC3220SF(CoreSightTarget):
     VENDOR = "Texas Instruments"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         RomRegion(start=0x00000000, length=0x00080000),
         FlashRegion(start=0x01000000, length=0x00100000, blocksize=0x800, is_boot_memory=True, flash_class=Flash_cc3220sf),
         RamRegion(start=0x20000000, length=0x40000)
     )
 
-    def __init__(self, link):
-        super(CC3220SF, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(CC3220SF, self).__init__(session, self.MEMORY_MAP)
 
     def post_connect_hook(self):
         self.cores[0].default_reset_type = self.ResetType.SW_VECTRESET

--- a/pyocd/target/builtin/target_CC3220SF.py
+++ b/pyocd/target/builtin/target_CC3220SF.py
@@ -16,7 +16,7 @@
 
 from ...flash.flash import Flash
 from ...core import exceptions
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...coresight.cortex_m import CortexM
 from ...coresight import (ap, dap)
 from ...core.memory_map import (RomRegion, FlashRegion, RamRegion, MemoryMap)

--- a/pyocd/target/builtin/target_HC32F46x.py
+++ b/pyocd/target/builtin/target_HC32F46x.py
@@ -156,7 +156,7 @@ class HC32F46x(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x80000, page_size=0x200, sector_size=0x2000,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
@@ -168,8 +168,8 @@ class HC32F46x(CoreSightTarget):
         RamRegion(   start=0x200F0000, length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(HC32F46x, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32F46x, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32F46x.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_HC32F46x.py
+++ b/pyocd/target/builtin/target_HC32F46x.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_HC32F4A0.py
+++ b/pyocd/target/builtin/target_HC32F4A0.py
@@ -106,7 +106,7 @@ class HC32F4A0xG(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x100000, page_size=0x800, sector_size=0x2000,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
@@ -114,8 +114,8 @@ class HC32F4A0xG(CoreSightTarget):
         RamRegion(   start=0x200F0000, length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(HC32F4A0xG, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32F4A0xG, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32F4A0.svd")
 
     def post_connect_hook(self):
@@ -128,7 +128,7 @@ class HC32F4A0xI(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x200000, page_size=0x800, sector_size=0x2000,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
@@ -136,8 +136,8 @@ class HC32F4A0xI(CoreSightTarget):
         RamRegion(   start=0x200F0000, length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(HC32F4A0xI, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32F4A0xI, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32F4A0.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_HC32F4A0.py
+++ b/pyocd/target/builtin/target_HC32F4A0.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_HC32L07x.py
+++ b/pyocd/target/builtin/target_HC32L07x.py
@@ -70,15 +70,15 @@ class HC32L072(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x20000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x4000)
         )
 
-    def __init__(self, transport):
-        super(HC32L072, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32L072, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32L07x.svd")
 
     def post_connect_hook(self):
@@ -89,15 +89,15 @@ class HC32L073(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x20000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x4000)
         )
 
-    def __init__(self, transport):
-        super(HC32L073, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32L073, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32L07x.svd")
 
     def post_connect_hook(self):
@@ -108,15 +108,15 @@ class HC32F072(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x20000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x4000)
         )
 
-    def __init__(self, transport):
-        super(HC32F072, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32F072, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32L07x.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_HC32L07x.py
+++ b/pyocd/target/builtin/target_HC32L07x.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_HC32L110.py
+++ b/pyocd/target/builtin/target_HC32L110.py
@@ -67,15 +67,15 @@ class HC32L110(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x8000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(HC32L110, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32L110, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32L110.svd")
 
     def post_connect_hook(self):
@@ -86,15 +86,15 @@ class HC32F003(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x4000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x800)
         )
 
-    def __init__(self, transport):
-        super(HC32F003, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32F003, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32F003.svd")
 
     def post_connect_hook(self):
@@ -105,15 +105,15 @@ class HC32F005(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x8000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(HC32F005, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32F005, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32F005.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_HC32L110.py
+++ b/pyocd/target/builtin/target_HC32L110.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_HC32L13x.py
+++ b/pyocd/target/builtin/target_HC32L13x.py
@@ -68,15 +68,15 @@ class HC32L136(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x10000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x2000)
         )
 
-    def __init__(self, transport):
-        super(HC32L136, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32L136, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32L136.svd")
 
     def post_connect_hook(self):
@@ -87,15 +87,15 @@ class HC32L130(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x8000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(HC32L130, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32L130, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32L130.svd")
 
     def post_connect_hook(self):
@@ -106,15 +106,15 @@ class HC32F030(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x8000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(HC32F030, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32F030, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32F030.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_HC32L13x.py
+++ b/pyocd/target/builtin/target_HC32L13x.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_HC32L19x.py
+++ b/pyocd/target/builtin/target_HC32L19x.py
@@ -72,15 +72,15 @@ class HC32L196(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x40000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x8000)
         )
 
-    def __init__(self, transport):
-        super(HC32L196, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32L196, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32L19x.svd")
 
     def post_connect_hook(self):
@@ -91,15 +91,15 @@ class HC32L190(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x40000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x8000)
         )
 
-    def __init__(self, transport):
-        super(HC32L190, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32L190, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32L19x.svd")
 
     def post_connect_hook(self):
@@ -110,15 +110,15 @@ class HC32F190(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x40000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x8000)
         )
 
-    def __init__(self, transport):
-        super(HC32F190, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32F190, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32L19x.svd")
 
     def post_connect_hook(self):
@@ -129,15 +129,15 @@ class HC32F196(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x40000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x8000)
         )
 
-    def __init__(self, transport):
-        super(HC32F196, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32F196, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32L19x.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_HC32L19x.py
+++ b/pyocd/target/builtin/target_HC32L19x.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_HC32M423.py
+++ b/pyocd/target/builtin/target_HC32M423.py
@@ -76,15 +76,15 @@ class HC32M423(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x20000, page_size=0x200, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x1FFFE000, length=0x4000)
         )
 
-    def __init__(self, transport):
-        super(HC32M423, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32M423, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32M423.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_HC32M423.py
+++ b/pyocd/target/builtin/target_HC32M423.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_HC32x120.py
+++ b/pyocd/target/builtin/target_HC32x120.py
@@ -79,15 +79,15 @@ class HC32F120x6TA(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x8000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(HC32F120x6TA, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32F120x6TA, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32F120.svd")
 
     def post_connect_hook(self):
@@ -98,15 +98,15 @@ class HC32F120x8TA(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x10000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(HC32F120x8TA, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32F120x8TA, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32F120.svd")
 
     def post_connect_hook(self):
@@ -117,15 +117,15 @@ class HC32M120(CoreSightTarget):
 
     VENDOR = "HDSC"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x8000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(HC32M120, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(HC32M120, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32M120.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_HC32x120.py
+++ b/pyocd/target/builtin/target_HC32x120.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_K32L2B.py
+++ b/pyocd/target/builtin/target_K32L2B.py
@@ -90,13 +90,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class K32L2B3(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x40000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fffe000,  length=0x8000)
         )
 
-    def __init__(self, transport):
-        super(K32L2B3, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(K32L2B3, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("K32L2B31A.xml")
 

--- a/pyocd/target/builtin/target_K32W042S1M2xxx.py
+++ b/pyocd/target/builtin/target_K32W042S1M2xxx.py
@@ -18,7 +18,7 @@ from ..family.target_kinetis import Kinetis
 from ...flash.flash import Flash
 from ...core import exceptions
 from ...core.target import Target
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 from ...coresight import ap

--- a/pyocd/target/builtin/target_K32W042S1M2xxx.py
+++ b/pyocd/target/builtin/target_K32W042S1M2xxx.py
@@ -159,7 +159,7 @@ FLASH_ALGO = {
 
 class K32W042S(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(name='flash0',      start=         0,   length=0x100000,    blocksize=0x1000,
             is_boot_memory=True, algo=FLASH_ALGO),
         FlashRegion(name='flash1',      start= 0x1000000,   length=0x40000,     blocksize=0x800,
@@ -172,8 +172,8 @@ class K32W042S(Kinetis):
         RamRegion(  name='usb ram',     start=0x48010000,   length=0x800),
         )
 
-    def __init__(self, link):
-        super(K32W042S, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(K32W042S, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("K32W042S1M2_M4.xml")
 
     def perform_halt_on_connect(self):

--- a/pyocd/target/builtin/target_LPC1114FN28_102.py
+++ b/pyocd/target/builtin/target_LPC1114FN28_102.py
@@ -53,7 +53,7 @@ class LPC11XX_32(CoreSightTarget):
 
     VENDOR = "NXP"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x8000,       is_boot_memory=True,
                                                                 blocksize=4096,
                                                                 page_size=256,
@@ -61,8 +61,8 @@ class LPC11XX_32(CoreSightTarget):
         RamRegion(      start=0x10000000,  length=0x1000)
         )
 
-    def __init__(self, link):
-        super(LPC11XX_32, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC11XX_32, self).__init__(session, self.MEMORY_MAP)
 
     def reset_and_halt(self, reset_type=None, map_to_user=True):
         super(LPC11XX_32, self).reset_and_halt(reset_type)

--- a/pyocd/target/builtin/target_LPC1114FN28_102.py
+++ b/pyocd/target/builtin/target_LPC1114FN28_102.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 
 FLASH_ALGO = {

--- a/pyocd/target/builtin/target_LPC11U24FBD64_401.py
+++ b/pyocd/target/builtin/target_LPC11U24FBD64_401.py
@@ -51,7 +51,7 @@ FLASH_ALGO = { 'load_address' : 0x10000000,
 class LPC11U24(CoreSightTarget):
     VENDOR = "NXP"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x8000,   is_boot_memory=True,
                                                             blocksize=0x1000,
                                                             page_size=0x400,
@@ -60,8 +60,8 @@ class LPC11U24(CoreSightTarget):
         RamRegion(      start=0x10000000,  length=0x1000)
         )
 
-    def __init__(self, link):
-        super(LPC11U24, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC11U24, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("LPC11Uxx_v7.svd")
 
     def reset_and_halt(self, reset_type=None, map_to_user=True):

--- a/pyocd/target/builtin/target_LPC11U24FBD64_401.py
+++ b/pyocd/target/builtin/target_LPC11U24FBD64_401.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_LPC1768.py
+++ b/pyocd/target/builtin/target_LPC1768.py
@@ -16,7 +16,7 @@
 
 import logging
 from ...core.target import Target
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap, DefaultFlashWeights)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_LPC1768.py
+++ b/pyocd/target/builtin/target_LPC1768.py
@@ -68,7 +68,7 @@ class LPC1768(CoreSightTarget):
 
     VENDOR = "NXP"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x10000,      is_boot_memory=True,
                                                                 blocksize=0x1000,
                                                                 page_size=0x400,
@@ -84,8 +84,8 @@ class LPC1768(CoreSightTarget):
         RamRegion(      start=0x2007C000,  length=0x8000)
         )
 
-    def __init__(self, link):
-        super(LPC1768, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC1768, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("LPC176x5x_v0.2.svd")
         self._saved_vc = False
         self._reset_handler = 0

--- a/pyocd/target/builtin/target_LPC4088FBD144.py
+++ b/pyocd/target/builtin/target_LPC4088FBD144.py
@@ -65,7 +65,7 @@ class LPC4088(CoreSightTarget):
 
     VENDOR = "NXP"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x10000,      is_boot_memory=True,
                                                                 blocksize=0x1000,
                                                                 page_size=0x200,
@@ -78,10 +78,10 @@ class LPC4088(CoreSightTarget):
         RamRegion(      start=0x10000000,  length=0x10000),
         )
 
-    def __init__(self, link, mem_map=None):
+    def __init__(self, session, mem_map=None):
         if mem_map is None:
-            mem_map = self.memoryMap
-        super(LPC4088, self).__init__(link, mem_map)
+            mem_map = self.MEMORY_MAP
+        super(LPC4088, self).__init__(session, mem_map)
         self.ignoreReset = False
         self._svd_location = SVDFile.from_builtin("LPC408x_7x_v0.7.svd")
 

--- a/pyocd/target/builtin/target_LPC4088FBD144.py
+++ b/pyocd/target/builtin/target_LPC4088FBD144.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap, DefaultFlashWeights)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_LPC4330.py
+++ b/pyocd/target/builtin/target_LPC4330.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_LPC4330.py
+++ b/pyocd/target/builtin/target_LPC4330.py
@@ -317,7 +317,7 @@ class LPC4330(CoreSightTarget):
 
     VENDOR = "NXP"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x14000000,  length=0x4000000,    blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO),
         RamRegion(      start=0x10000000,  length=0x20000),
@@ -326,8 +326,8 @@ class LPC4330(CoreSightTarget):
         RamRegion(      start=0x20008000,  length=0x8000)
         )
 
-    def __init__(self, link):
-        super(LPC4330, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC4330, self).__init__(session, self.MEMORY_MAP)
         self.ignoreReset = False
         self._svd_location = SVDFile.from_builtin("LPC43xx_svd_v5.svd")
 

--- a/pyocd/target/builtin/target_LPC54114J256BD64.py
+++ b/pyocd/target/builtin/target_LPC54114J256BD64.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...coresight import ap
 from ...coresight.cortex_m import CortexM

--- a/pyocd/target/builtin/target_LPC54114J256BD64.py
+++ b/pyocd/target/builtin/target_LPC54114J256BD64.py
@@ -61,7 +61,7 @@ class LPC54114(CoreSightTarget):
 
     VENDOR = "NXP"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(name='flash',   start=0,           length=0x40000,  is_boot_memory=True,
                                                                         blocksize=0x8000,
                                                                         page_size=0x100,
@@ -72,8 +72,8 @@ class LPC54114(CoreSightTarget):
         RamRegion(  name='sram2',   start=0x20020000,  length=0x8000)
         )
 
-    def __init__(self, link):
-        super(LPC54114, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC54114, self).__init__(session, self.MEMORY_MAP)
         self.ignoreReset = False
         self._svd_location = SVDFile.from_builtin("LPC54114_cm4.xml")
 

--- a/pyocd/target/builtin/target_LPC54608J512ET180.py
+++ b/pyocd/target/builtin/target_LPC54608J512ET180.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...coresight import ap
 from ...coresight.cortex_m import CortexM

--- a/pyocd/target/builtin/target_LPC54608J512ET180.py
+++ b/pyocd/target/builtin/target_LPC54608J512ET180.py
@@ -57,7 +57,7 @@ class LPC54608(CoreSightTarget):
 
     VENDOR = "NXP"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(name='flash',   start=0,           length=0x80000,  is_boot_memory=True,
                                                                         blocksize=0x8000,
                                                                         page_size=0x100,
@@ -68,8 +68,8 @@ class LPC54608(CoreSightTarget):
         RamRegion(  name='sram2',   start=0x20020000,  length=0x8000)
         )
 
-    def __init__(self, link):
-        super(LPC54608, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC54608, self).__init__(session, self.MEMORY_MAP)
         self.ignoreReset = False
         self._svd_location = SVDFile.from_builtin("LPC54608.xml")
 

--- a/pyocd/target/builtin/target_LPC55S28Jxxxxx.py
+++ b/pyocd/target/builtin/target_LPC55S28Jxxxxx.py
@@ -105,7 +105,7 @@ FLASH_ALGO = {
 
 class LPC55S28(LPC5500Family):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(name='nsflash',     start=0x00000000, length=0x00080000, access='rx',
             blocksize=0x200,
             is_boot_memory=True,
@@ -133,6 +133,6 @@ class LPC55S28(LPC5500Family):
             alias='nsram4'),
         )
 
-    def __init__(self, link):
-        super(LPC55S28, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC55S28, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("LPC55S28.xml")

--- a/pyocd/target/builtin/target_LPC55S69Jxxxxx.py
+++ b/pyocd/target/builtin/target_LPC55S69Jxxxxx.py
@@ -105,7 +105,7 @@ FLASH_ALGO = {
 
 class LPC55S69(LPC5500Family):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(name='nsflash',     start=0x00000000, length=0x00098000, access='rx',
             blocksize=0x200,
             is_boot_memory=True,
@@ -130,6 +130,6 @@ class LPC55S69(LPC5500Family):
             alias='nsram'),
         )
 
-    def __init__(self, link):
-        super(LPC55S69, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC55S69, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("LPC55S69_cm33_core0.xml")

--- a/pyocd/target/builtin/target_LPC824M201JHI33.py
+++ b/pyocd/target/builtin/target_LPC824M201JHI33.py
@@ -52,7 +52,7 @@ class LPC824(CoreSightTarget):
 
     VENDOR = "NXP"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x8000,       is_boot_memory=True,
                                                                 blocksize=1024,
                                                                 page_size=512,
@@ -60,8 +60,8 @@ class LPC824(CoreSightTarget):
         RamRegion(      start=0x10000000,  length=0x2000)
         )
 
-    def __init__(self, link):
-        super(LPC824, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC824, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("LPC824.xml")
 
     def reset_and_halt(self, reset_type=None, map_to_user=True):

--- a/pyocd/target/builtin/target_LPC824M201JHI33.py
+++ b/pyocd/target/builtin/target_LPC824M201JHI33.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_M252KG6AE.py
+++ b/pyocd/target/builtin/target_M252KG6AE.py
@@ -194,7 +194,7 @@ FLASH_ALGO_LD_4 = {
 class M252KG6AE(CoreSightTarget):
     VENDOR = "Nuvoton"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x40000,  sector_size=0x0200,
                                                         page_size=0x0200,
                                                         is_boot_memory=True,
@@ -205,6 +205,6 @@ class M252KG6AE(CoreSightTarget):
         RamRegion(   start=0x20000000, length=0x8000)
         )
 
-    def __init__(self, link):
-        super(M252KG6AE, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(M252KG6AE, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("M251_v1.svd")

--- a/pyocd/target/builtin/target_M252KG6AE.py
+++ b/pyocd/target/builtin/target_M252KG6AE.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_M263KIAAE.py
+++ b/pyocd/target/builtin/target_M263KIAAE.py
@@ -146,7 +146,7 @@ FLASH_ALGO_LD_4 = {
 class M263KIAAE(CoreSightTarget):
     VENDOR = "Nuvoton"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x00000000, length=0x80000,  sector_size=0x0800,
                                                         page_size=0x0800,
                                                         is_boot_memory=True,
@@ -157,6 +157,6 @@ class M263KIAAE(CoreSightTarget):
         RamRegion(   start=0x20000000, length=0x18000)
         )
 
-    def __init__(self, link):
-        super(M263KIAAE, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(M263KIAAE, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("M261_v1.svd")

--- a/pyocd/target/builtin/target_M263KIAAE.py
+++ b/pyocd/target/builtin/target_M263KIAAE.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_MAX32600.py
+++ b/pyocd/target/builtin/target_MAX32600.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, DeviceRegion, MemoryMap)
 import logging
 

--- a/pyocd/target/builtin/target_MAX32600.py
+++ b/pyocd/target/builtin/target_MAX32600.py
@@ -58,12 +58,12 @@ class MAX32600(CoreSightTarget):
 
     VENDOR = "Maxim"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x40000,      blocksize=0x800, is_boot_memory=True, algo=FLASH_ALGO),
         RamRegion(      start=0x20000000,  length=0x8000),
         DeviceRegion(   start=0x40000000,  length=0x100000),
         DeviceRegion(   start=0xe0000000,  length=0x100000)
         )
 
-    def __init__(self, link):
-        super(MAX32600, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(MAX32600, self).__init__(session, self.MEMORY_MAP)

--- a/pyocd/target/builtin/target_MAX32620.py
+++ b/pyocd/target/builtin/target_MAX32620.py
@@ -61,11 +61,11 @@ class MAX32620(CoreSightTarget):
 
     VENDOR = "Maxim"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x200000,  blocksize=0x2000, is_boot_memory=True, algo=FLASH_ALGO),
         RamRegion(      start=0x20000000,  length=0x40000),
         )
 
-    def __init__(self, link):
-        super(MAX32620, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(MAX32620, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("max32620.svd")

--- a/pyocd/target/builtin/target_MAX32620.py
+++ b/pyocd/target/builtin/target_MAX32620.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_MAX32625.py
+++ b/pyocd/target/builtin/target_MAX32625.py
@@ -61,11 +61,11 @@ class MAX32625(CoreSightTarget):
 
     VENDOR = "Maxim"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,            length=0x80000, blocksize=0x2000, is_boot_memory=True, algo=FLASH_ALGO),
         RamRegion(      start=0x20000000,   length=0x28000),
         )
 
-    def __init__(self, link):
-        super(MAX32625, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(MAX32625, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("max32625.svd")

--- a/pyocd/target/builtin/target_MAX32625.py
+++ b/pyocd/target/builtin/target_MAX32625.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_MAX32630.py
+++ b/pyocd/target/builtin/target_MAX32630.py
@@ -61,11 +61,11 @@ class MAX32630(CoreSightTarget):
 
     VENDOR = "Maxim"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x200000,  blocksize=0x2000, is_boot_memory=True, algo=FLASH_ALGO),
         RamRegion(      start=0x20000000,  length=0x40000),
         )
 
-    def __init__(self, link):
-        super(MAX32630, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(MAX32630, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("max32630.svd")

--- a/pyocd/target/builtin/target_MAX32630.py
+++ b/pyocd/target/builtin/target_MAX32630.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_MIMXRT1011xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1011xxxxx.py
@@ -718,7 +718,7 @@ class MIMXRT1011xxxxx(CoreSightTarget):
     # divided between those regions (this is called FlexRAM). Thus, the memory map regions for
     # each of these RAMs allocate the maximum possible of 128 KB, but that is the maximum and
     # will not actually be available in all regions simultaneously.
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         RamRegion(name="itcm",      start=0x00000000, length=0x8000), # 32 KB
         RomRegion(name="romcp",     start=0x00200000, length=0x18000), # 96 KB
         RamRegion(name="dtcm",      start=0x20000000, length=0x8000), # 32 KB
@@ -727,6 +727,6 @@ class MIMXRT1011xxxxx(CoreSightTarget):
             algo=FLASH_ALGO_QUADSPI, page_size=0x100),
         )
 
-    def __init__(self, link):
-        super(MIMXRT1011xxxxx, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(MIMXRT1011xxxxx, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MIMXRT1011.xml")

--- a/pyocd/target/builtin/target_MIMXRT1011xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1011xxxxx.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RomRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_MIMXRT1015xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1015xxxxx.py
@@ -731,7 +731,7 @@ class MIMXRT1015xxxxx(CoreSightTarget):
     # divided between those regions (this is called FlexRAM). Thus, the memory map regions for
     # each of these RAMs allocate the maximum possible of 128 KB, but that is the maximum and
     # will not actually be available in all regions simultaneously.
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         RamRegion(name="itcm",      start=0x00000000, length=0x8000), # 32 KB
         RomRegion(name="romcp",     start=0x00200000, length=0x18000), # 96 KB
         RamRegion(name="dtcm",      start=0x20000000, length=0x8000), # 32 KB
@@ -740,6 +740,6 @@ class MIMXRT1015xxxxx(CoreSightTarget):
             algo=FLASH_ALGO_QUADSPI, page_size=0x100),
         )
 
-    def __init__(self, link):
-        super(MIMXRT1015xxxxx, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(MIMXRT1015xxxxx, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MIMXRT1015.xml")

--- a/pyocd/target/builtin/target_MIMXRT1015xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1015xxxxx.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RomRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
@@ -635,7 +635,7 @@ class MIMXRT1021xxxxx(CoreSightTarget):
     # divided between those regions (this is called FlexRAM). Thus, the memory map regions for
     # each of these RAMs allocate the maximum possible of 256 KB, but that is the maximum and
     # will not actually be available in all regions simultaneously.
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         RamRegion(name="itcm",      start=0x00000000, length=0x40000), # 256 KB
         RomRegion(name="romcp",     start=0x00200000, length=0x18000), # 96 KB
         RamRegion(name="dtcm",      start=0x20000000, length=0x40000), # 256 KB
@@ -645,6 +645,6 @@ class MIMXRT1021xxxxx(CoreSightTarget):
         RamRegion(name="semc",      start=0x80000000, end=0xdfffffff, is_external=True)
         )
 
-    def __init__(self, link):
-        super(MIMXRT1021xxxxx, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(MIMXRT1021xxxxx, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MIMXRT1021.xml")

--- a/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RomRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
+++ b/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
@@ -1102,7 +1102,7 @@ class MIMXRT1052xxxxB_hyperflash(CoreSightTarget):
     # divided between those regions (this is called FlexRAM). Thus, the memory map regions for
     # each of these RAMs allocate the maximum possible of 512 KB, but that is the maximum and
     # will not actually be available in all regions simultaneously.
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         RamRegion(name="itcm",              start=0x00000000, length=0x80000), # 512 KB
         RomRegion(name="romcp",             start=0x00200000, length=0x18000), # 96 KB
         RomRegion(name="flexspi_alias",     start=0x08000000, length=0x8000000, alias='flexspi'), # 128 MB
@@ -1114,8 +1114,8 @@ class MIMXRT1052xxxxB_hyperflash(CoreSightTarget):
         RamRegion(name="semc",              start=0x80000000, end=0xdfffffff, is_external=True)
         )
 
-    def __init__(self, link):
-        super(MIMXRT1052xxxxB_hyperflash, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(MIMXRT1052xxxxB_hyperflash, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MIMXRT1052.xml")
 
     def create_init_sequence(self):
@@ -1140,7 +1140,7 @@ class MIMXRT1052xxxxB_quadspi(CoreSightTarget):
     # divided between those regions (this is called FlexRAM). Thus, the memory map regions for
     # each of these RAMs allocate the maximum possible of 512 KB, but that is the maximum and
     # will not actually be available in all regions simultaneously.
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         RamRegion(name="itcm",              start=0x00000000, length=0x80000), # 512 KB
         RomRegion(name="romcp",             start=0x00200000, length=0x18000), # 96 KB
         RomRegion(name="flexspi_alias",     start=0x08000000, length=0x8000000, alias='flexspi'), # 128 MB
@@ -1152,8 +1152,8 @@ class MIMXRT1052xxxxB_quadspi(CoreSightTarget):
         RamRegion(name="semc",              start=0x80000000, end=0xdfffffff, is_external=True)
         )
 
-    def __init__(self, link):
-        super(MIMXRT1052xxxxB_quadspi, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(MIMXRT1052xxxxB_quadspi, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MIMXRT1052.xml")
 
     def create_init_sequence(self):

--- a/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
+++ b/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
@@ -17,7 +17,7 @@
 
 import logging
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RomRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 from ...coresight.cortex_m import CortexM

--- a/pyocd/target/builtin/target_MK20DX128xxx5.py
+++ b/pyocd/target/builtin/target_MK20DX128xxx5.py
@@ -74,13 +74,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class K20D50M(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x20000,     blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fffe000,  length=0x4000)
         )
 
-    def __init__(self, link):
-        super(K20D50M, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(K20D50M, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MK20D5.svd")
 

--- a/pyocd/target/builtin/target_MK22FN1M0Axxx12.py
+++ b/pyocd/target/builtin/target_MK22FN1M0Axxx12.py
@@ -92,14 +92,14 @@ FLASH_ALGO = {
 class K22FA12(Kinetis):
 
     # 1MB flash with 4kB sectors, 128kB RAM
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x100000,     blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fff0000,  length=0x20000)
         )
 
-    def __init__(self, link):
-        super(K22FA12, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(K22FA12, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MK22FA12.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_MK22FN512xxx12.py
+++ b/pyocd/target/builtin/target_MK22FN512xxx12.py
@@ -76,13 +76,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 class K22F(Kinetis):
 
     # 512kB flash with 2kB sectors, 128kB RAM
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x80000,     blocksize=0x800, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fff0000,  length=0x20000)
         )
 
-    def __init__(self, link):
-        super(K22F, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(K22F, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MK22F51212.svd")
 

--- a/pyocd/target/builtin/target_MK28FN2M0xxx15.py
+++ b/pyocd/target/builtin/target_MK28FN2M0xxx15.py
@@ -75,7 +75,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class K28F15(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x200000,     blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1ffC0000,  length=0x80000),
@@ -83,7 +83,7 @@ class K28F15(Kinetis):
         RamRegion(      start=0x14000000,  length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(K28F15, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(K28F15, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MK28FA15.xml")
 

--- a/pyocd/target/builtin/target_MK64FN1M0xxx12.py
+++ b/pyocd/target/builtin/target_MK64FN1M0xxx12.py
@@ -74,13 +74,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class K64F(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x100000,     blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fff0000,  length=0x40000)
         )
 
-    def __init__(self, link):
-        super(K64F, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(K64F, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MK64F12.svd")
 

--- a/pyocd/target/builtin/target_MK66FN2M0xxx18.py
+++ b/pyocd/target/builtin/target_MK66FN2M0xxx18.py
@@ -75,14 +75,14 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class K66F18(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x200000,     blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fff0000,  length=0x40000),
         RamRegion(      start=0x14000000,  length=0x1000)
         )
 
-    def __init__(self, transport):
-        super(K66F18, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(K66F18, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MK66F18.svd")
 

--- a/pyocd/target/builtin/target_MK82FN256xxx15.py
+++ b/pyocd/target/builtin/target_MK82FN256xxx15.py
@@ -84,12 +84,12 @@ FLASH_ALGO = {
 
 class K82F25615(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x40000,     blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fff0000,  length=0x40000)
         )
-    def __init__(self, transport):
-        super(K82F25615, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(K82F25615, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MK82F25615.svd")
 

--- a/pyocd/target/builtin/target_MKE15Z256xxx7.py
+++ b/pyocd/target/builtin/target_MKE15Z256xxx7.py
@@ -86,14 +86,14 @@ FLASH_ALGO = {
 
 class KE15Z7(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x40000,       blocksize=0x800, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fffe000,  length=0x8000)
         )
 
-    def __init__(self, link):
-        super(KE15Z7, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(KE15Z7, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKE15Z7.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_MKE18F256xxx16.py
+++ b/pyocd/target/builtin/target_MKE18F256xxx16.py
@@ -87,14 +87,14 @@ FLASH_ALGO = {
 
 class KE18F16(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x80000,       blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fff8000,  length=0x10000)
         )
 
-    def __init__(self, link):
-        super(KE18F16, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(KE18F16, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKE18F16.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_MKL02Z32xxx4.py
+++ b/pyocd/target/builtin/target_MKL02Z32xxx4.py
@@ -85,13 +85,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KL02Z(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x8000,       blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1ffffc00,  length=0x1000)
         )
 
-    def __init__(self, link):
-        super(KL02Z, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(KL02Z, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKL02Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL05Z32xxx4.py
+++ b/pyocd/target/builtin/target_MKL05Z32xxx4.py
@@ -85,13 +85,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KL05Z(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x8000,       blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1ffffc00,  length=0x1000)
         )
 
-    def __init__(self, link):
-        super(KL05Z, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(KL05Z, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKL05Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL25Z128xxx4.py
+++ b/pyocd/target/builtin/target_MKL25Z128xxx4.py
@@ -87,13 +87,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KL25Z(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x20000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1ffff000,  length=0x4000)
         )
 
-    def __init__(self, link):
-        super(KL25Z, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(KL25Z, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKL25Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL26Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL26Z256xxx4.py
@@ -87,13 +87,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KL26Z(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x20000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1ffff000,  length=0x4000)
         )
 
-    def __init__(self, link):
-        super(KL26Z, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(KL26Z, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKL26Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL27Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL27Z256xxx4.py
@@ -89,13 +89,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KL27Z4(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x10000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1ffff000,  length=0x4000)
         )
 
-    def __init__(self, transport):
-        super(KL27Z4, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(KL27Z4, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKL27Z644.svd")
 

--- a/pyocd/target/builtin/target_MKL28Z512xxx7.py
+++ b/pyocd/target/builtin/target_MKL28Z512xxx7.py
@@ -161,7 +161,7 @@ class Flash_kl28z(Flash_Kinetis):
 
 class KL28x(Kinetis):
 
-    singleMap = MemoryMap(
+    SINGLE_MAP = MemoryMap(
         FlashRegion(name='flash', start=0, length=0x80000, blocksize=0x800, is_boot_memory=True,
             flash_class=Flash_kl28z,
             algo=FLASH_ALGO),
@@ -169,7 +169,7 @@ class KL28x(Kinetis):
         RamRegion(name='usb ram', start=0x40100000, length=0x800)
         )
 
-    dualMap = MemoryMap(
+    DUAL_MAP = MemoryMap(
         FlashRegion(name='flash', start=0, length=0x80000, blocksize=0x800, is_boot_memory=True,
             flash_class=Flash_kl28z,
             algo=FLASH_ALGO),
@@ -180,8 +180,8 @@ class KL28x(Kinetis):
         RamRegion(name='usb ram', start=0x40100000, length=0x800)
         )
 
-    def __init__(self, link):
-        super(KL28x, self).__init__(link, self.singleMap)
+    def __init__(self, session):
+        super(KL28x, self).__init__(session, self.SINGLE_MAP)
         self.is_dual_core = False
 
         self._svd_location = SVDFile.from_builtin("MKL28T7_CORE0.svd")
@@ -214,7 +214,7 @@ class KL28x(Kinetis):
         self.is_dual_core = (keyattr == KEYATTR_DUAL_CORE)
         if self.is_dual_core:
             LOG.info("KL28 is dual core")
-            self.memory_map = self.dualMap
+            self.memory_map = self.DUAL_MAP
 
     def post_connect_hook(self):
         # Disable ROM vector table remapping.

--- a/pyocd/target/builtin/target_MKL43Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL43Z256xxx4.py
@@ -90,13 +90,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KL43Z4(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x40000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fffe000,  length=0x8000)
         )
 
-    def __init__(self, transport):
-        super(KL43Z4, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(KL43Z4, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKL43Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL46Z256xxx4.py
+++ b/pyocd/target/builtin/target_MKL46Z256xxx4.py
@@ -87,13 +87,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KL46Z(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x40000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fffe000,  length=0x8000)
         )
 
-    def __init__(self, link):
-        super(KL46Z, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(KL46Z, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKL46Z4.svd")
 

--- a/pyocd/target/builtin/target_MKL82Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKL82Z128xxx7.py
@@ -85,7 +85,7 @@ FLASH_ALGO = {
 
 class KL82Z7(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x20000,      blocksize=0x800, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RomRegion(      start=0x1c000000,  end=0x1c007fff),
@@ -93,8 +93,8 @@ class KL82Z7(Kinetis):
         RamRegion(      start=0x1fffA000,  length=0x18000)
         )
 
-    def __init__(self, link):
-        super(KL82Z7, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(KL82Z7, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKL82Z7.svd")
 
 

--- a/pyocd/target/builtin/target_MKV10Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKV10Z128xxx7.py
@@ -91,13 +91,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KV10Z7(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x8000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1ffff800,  length=0x2000)
         )
 
-    def __init__(self, transport):
-        super(KV10Z7, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(KV10Z7, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKV10Z7.svd")
 

--- a/pyocd/target/builtin/target_MKV11Z128xxx7.py
+++ b/pyocd/target/builtin/target_MKV11Z128xxx7.py
@@ -92,13 +92,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KV11Z7(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x20000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1ffff000,  length=0x4000)
         )
 
-    def __init__(self, transport):
-        super(KV11Z7, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(KV11Z7, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKV11Z7.svd")
 

--- a/pyocd/target/builtin/target_MKW01Z128xxx4.py
+++ b/pyocd/target/builtin/target_MKW01Z128xxx4.py
@@ -90,13 +90,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KW01Z4(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x20000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1ffff000,  length=0x4000)
         )
 
-    def __init__(self, transport):
-        super(KW01Z4, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(KW01Z4, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKW01Z4.svd")
 

--- a/pyocd/target/builtin/target_MKW24D512xxx5.py
+++ b/pyocd/target/builtin/target_MKW24D512xxx5.py
@@ -82,13 +82,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KW24D5(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x80000,      blocksize=0x800, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fff8000,  length=0x10000)
         )
 
-    def __init__(self, transport):
-        super(KW24D5, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(KW24D5, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKW24D5.svd")
 

--- a/pyocd/target/builtin/target_MKW36Z512xxx4.py
+++ b/pyocd/target/builtin/target_MKW36Z512xxx4.py
@@ -153,7 +153,7 @@ FLASH_ALGO = {
 
 class KW36Z4(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(name="Pflash",       start=0,           length=0x40000,      blocksize=0x800,
             is_boot_memory=True, algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RomRegion(name="Dflash alias",   start=0x00040000,  length=0x40000,      blocksize=0x800, alias='dflash'),
@@ -163,7 +163,7 @@ class KW36Z4(Kinetis):
         RamRegion(  name="SRAM",         start=0x1fffc000,  length=0x10000)
         )
 
-    def __init__(self, transport):
-        super(KW36Z4, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(KW36Z4, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKW36Z4.svd")
 

--- a/pyocd/target/builtin/target_MKW40Z160xxx4.py
+++ b/pyocd/target/builtin/target_MKW40Z160xxx4.py
@@ -91,13 +91,13 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class KW40Z4(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x28000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1ffff000,  length=0x5000)
         )
 
-    def __init__(self, transport):
-        super(KW40Z4, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(KW40Z4, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKW40Z4.svd")
 

--- a/pyocd/target/builtin/target_MKW41Z512xxx4.py
+++ b/pyocd/target/builtin/target_MKW41Z512xxx4.py
@@ -81,13 +81,13 @@ FLASH_ALGO = {
 
 class KW41Z4(Kinetis):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x80000,      blocksize=0x800, is_boot_memory=True,
             algo=FLASH_ALGO, flash_class=Flash_Kinetis),
         RamRegion(      start=0x1fff8000,  length=0x20000)
         )
 
-    def __init__(self, transport):
-        super(KW41Z4, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(KW41Z4, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("MKW41Z4.svd")
 

--- a/pyocd/target/builtin/target_MPS3_AN522.py
+++ b/pyocd/target/builtin/target_MPS3_AN522.py
@@ -30,6 +30,6 @@ class AN522(CoreSightTarget):
         RamRegion(  name='dram9_s',     start=0x90000000, length=0x10000000, access='rwxs'),
         )
 
-    def __init__(self, link):
-        super(AN522, self).__init__(link, self.MEMORY_MAP)
+    def __init__(self, session):
+        super(AN522, self).__init__(session, self.MEMORY_MAP)
 

--- a/pyocd/target/builtin/target_MPS3_AN522.py
+++ b/pyocd/target/builtin/target_MPS3_AN522.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (RamRegion, MemoryMap)
 
 class AN522(CoreSightTarget):

--- a/pyocd/target/builtin/target_MPS3_AN540.py
+++ b/pyocd/target/builtin/target_MPS3_AN540.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (RamRegion, MemoryMap)
 
 class AN540(CoreSightTarget):

--- a/pyocd/target/builtin/target_MPS3_AN540.py
+++ b/pyocd/target/builtin/target_MPS3_AN540.py
@@ -34,6 +34,6 @@ class AN540(CoreSightTarget):
         RamRegion(  name='dram9_s',     start=0x90000000, length=0x10000000, access='rwxs'),
         )
 
-    def __init__(self, link):
-        super(AN540, self).__init__(link, self.MEMORY_MAP)
+    def __init__(self, session):
+        super(AN540, self).__init__(session, self.MEMORY_MAP)
 

--- a/pyocd/target/builtin/target_RTL8195AM.py
+++ b/pyocd/target/builtin/target_RTL8195AM.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (RamRegion, MemoryMap)
 
 class RTL8195AM(CoreSightTarget):

--- a/pyocd/target/builtin/target_RTL8195AM.py
+++ b/pyocd/target/builtin/target_RTL8195AM.py
@@ -21,12 +21,12 @@ class RTL8195AM(CoreSightTarget):
 
     VENDOR = "Realtek Semiconductor"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         RamRegion(      start=0x00000000,  length=0x400000),
         RamRegion(      start=0x10000000,  length=0x80000),
         RamRegion(      start=0x30000000,  length=0x200000),
         RamRegion(      start=0x40000000,  length=0x40000)
         )
 
-    def __init__(self, link):
-        super(RTL8195AM, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(RTL8195AM, self).__init__(session, self.MEMORY_MAP)

--- a/pyocd/target/builtin/target_STM32F051T8.py
+++ b/pyocd/target/builtin/target_STM32F051T8.py
@@ -70,14 +70,14 @@ class STM32F051(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x08000000,  length=0x10000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO),
         RamRegion(      start=0x20000000,  length=0x2000)
         )
 
-    def __init__(self, link):
-        super(STM32F051, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(STM32F051, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32F0xx.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_STM32F051T8.py
+++ b/pyocd/target/builtin/target_STM32F051T8.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_STM32F103RC.py
+++ b/pyocd/target/builtin/target_STM32F103RC.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_STM32F103RC.py
+++ b/pyocd/target/builtin/target_STM32F103RC.py
@@ -53,14 +53,14 @@ class STM32F103RC(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x08000000,  length=0x80000,      blocksize=0x800, is_boot_memory=True,
             algo=FLASH_ALGO),
         RamRegion(      start=0x20000000,  length=0x10000)
         )
 
-    def __init__(self, link):
-        super(STM32F103RC, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(STM32F103RC, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32F103xx.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_STM32F412xx.py
+++ b/pyocd/target/builtin/target_STM32F412xx.py
@@ -65,7 +65,7 @@ class STM32F412xE(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x08000000, length=0x10000, sector_size=0x4000,
                         page_size=0x1000,
                         is_boot_memory=True,
@@ -79,8 +79,8 @@ class STM32F412xE(CoreSightTarget):
         RamRegion(   start=0x20000000, length=0x40000)
         )
 
-    def __init__(self, transport):
-        super(STM32F412xE, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(STM32F412xE, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32F41x.svd")
 
     def post_connect_hook(self):
@@ -92,7 +92,7 @@ class STM32F412xG(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x08000000, length=0x10000, sector_size=0x4000,
                         page_size=0x1000,
                         is_boot_memory=True,
@@ -106,8 +106,8 @@ class STM32F412xG(CoreSightTarget):
         RamRegion(   start=0x20000000, length=0x40000)
         )
 
-    def __init__(self, transport):
-        super(STM32F412xG, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(STM32F412xG, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32F41x.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_STM32F412xx.py
+++ b/pyocd/target/builtin/target_STM32F412xx.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_STM32F429xx.py
+++ b/pyocd/target/builtin/target_STM32F429xx.py
@@ -68,7 +68,7 @@ class STM32F429xG(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x08000000, length=0x10000,  sector_size=0x4000,
                                                         page_size=0x1000,
                                                         is_boot_memory=True,
@@ -85,8 +85,8 @@ class STM32F429xG(CoreSightTarget):
         RamRegion(   start=0x20000000, length=0x40000)
         )
 
-    def __init__(self, transport):
-        super(STM32F429xG, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(STM32F429xG, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32F429x.svd")
 
     def post_connect_hook(self):
@@ -98,7 +98,7 @@ class STM32F429xI(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x08000000, length=0x10000,  sector_size=0x4000,
                                                         page_size=0x1000,
                                                         is_boot_memory=True,
@@ -127,8 +127,8 @@ class STM32F429xI(CoreSightTarget):
         RamRegion(   start=0x20000000, length=0x30000)
         )
 
-    def __init__(self, transport):
-        super(STM32F429xI, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(STM32F429xI, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32F429x.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_STM32F429xx.py
+++ b/pyocd/target/builtin/target_STM32F429xx.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_STM32F439xx.py
+++ b/pyocd/target/builtin/target_STM32F439xx.py
@@ -68,7 +68,7 @@ class STM32F439xG(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x08000000, length=0x10000,  sector_size=0x4000,
                                                         page_size=0x1000, 
                                                         is_boot_memory=True,
@@ -85,8 +85,8 @@ class STM32F439xG(CoreSightTarget):
         RamRegion(   start=0x20000000, length=0x40000)
         )
 
-    def __init__(self, transport):
-        super(STM32F439xG, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(STM32F439xG, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32F439x.svd")
 
     def post_connect_hook(self):
@@ -98,7 +98,7 @@ class STM32F439xI(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x08000000, length=0x10000,  sector_size=0x4000,
                                                         page_size=0x1000,
                                                         is_boot_memory=True,
@@ -127,8 +127,8 @@ class STM32F439xI(CoreSightTarget):
         RamRegion(   start=0x20000000, length=0x30000)
         )
 
-    def __init__(self, transport):
-        super(STM32F439xI, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(STM32F439xI, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32F439x.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_STM32F439xx.py
+++ b/pyocd/target/builtin/target_STM32F439xx.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_STM32F767xx.py
+++ b/pyocd/target/builtin/target_STM32F767xx.py
@@ -18,7 +18,7 @@ import time
 import logging
 from ...utility import timeout
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...core import exceptions
 from ...coresight.cortex_m import CortexM

--- a/pyocd/target/builtin/target_STM32F767xx.py
+++ b/pyocd/target/builtin/target_STM32F767xx.py
@@ -104,7 +104,7 @@ class STM32F767xx(CoreSightTarget):
     # flash sectors structure.
     # For Single bank there is 12 sectors, for dual bank there is 24 sectors.
     # For dual bank configurations sectors are half size.
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x08000000, length=0x20000,  sector_size=0x8000,
                                                         page_size=0x400,
                                                         is_boot_memory=True,
@@ -120,8 +120,8 @@ class STM32F767xx(CoreSightTarget):
         RamRegion(   start=0x20000000, length=0x80000)
         )
 
-    def __init__(self, transport):
-        super(STM32F767xx, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(STM32F767xx, self).__init__(session, self.MEMORY_MAP)
 
     def assert_reset_for_connect(self):
         self.dp.probe.assert_reset(1)

--- a/pyocd/target/builtin/target_STM32L031x6.py
+++ b/pyocd/target/builtin/target_STM32L031x6.py
@@ -81,14 +81,14 @@ class STM32L031x6(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(name='Flash', start=0x08000000, length=0x8000, blocksize=0x1000,  is_boot_memory=True, algo=FLASH_ALGO),
         RamRegion(name='RAM', start=0x20000000, length=0x2000),
         FlashRegion(name='EEPROM', start=0x08080000, length=0x400, blocksize=0x400, algo=FLASH_ALGO)
         )
 
-    def __init__(self, link):
-        super(STM32L031x6, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(STM32L031x6, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32L0x1.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_STM32L031x6.py
+++ b/pyocd/target/builtin/target_STM32L031x6.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_STM32L475xx.py
+++ b/pyocd/target/builtin/target_STM32L475xx.py
@@ -77,7 +77,7 @@ class STM32L475xx(CoreSightTarget):
 
 class STM32L475xC(STM32L475xx):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(name='flash', start=0x08000000, length=0x40000,
                         sector_size=0x800,
                         page_size=0x400,
@@ -87,13 +87,13 @@ class STM32L475xC(STM32L475xx):
         RamRegion(name='sram2',   start=0x10000000, length=0x8000)
         )
 
-    def __init__(self, transport):
-        super(STM32L475xC, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(STM32L475xC, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32L4x5.svd")
 
 class STM32L475xE(STM32L475xx):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(name='flash', start=0x08000000, length=0x80000,
                         sector_size=0x800,
                         page_size=0x400,
@@ -103,13 +103,13 @@ class STM32L475xE(STM32L475xx):
         RamRegion(name='sram2',   start=0x10000000, length=0x8000)
         )
 
-    def __init__(self, transport):
-        super(STM32L475xE, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(STM32L475xE, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32L4x5.svd")
 
 class STM32L475xG(STM32L475xx):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(name='flash', start=0x08000000, length=0x100000,
                         sector_size=0x800,
                         page_size=0x400,
@@ -119,8 +119,8 @@ class STM32L475xG(STM32L475xx):
         RamRegion(name='sram2',   start=0x10000000, length=0x8000)
         )
 
-    def __init__(self, transport):
-        super(STM32L475xG, self).__init__(transport, self.memoryMap)
+    def __init__(self, session):
+        super(STM32L475xG, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("STM32L4x5.svd")
 
 

--- a/pyocd/target/builtin/target_STM32L475xx.py
+++ b/pyocd/target/builtin/target_STM32L475xx.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_lpc4088dm.py
+++ b/pyocd/target/builtin/target_lpc4088dm.py
@@ -72,7 +72,7 @@ FLASH_ALGO = {
 
 class LPC4088dm(LPC4088):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x10000,      is_boot_memory=True,
                                                                 blocksize=0x1000,
                                                                 page_size=0x200,
@@ -88,5 +88,5 @@ class LPC4088dm(LPC4088):
         RamRegion(      start=0x10000000,  length=0x10000),
         )
 
-    def __init__(self, link):
-        super(LPC4088dm, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC4088dm, self).__init__(session, self.MEMORY_MAP)

--- a/pyocd/target/builtin/target_lpc4088qsb.py
+++ b/pyocd/target/builtin/target_lpc4088qsb.py
@@ -72,7 +72,7 @@ FLASH_ALGO = {
 
 class LPC4088qsb(LPC4088):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x10000,      is_boot_memory=True,
                                                                 blocksize=0x1000,
                                                                 page_size=0x200,
@@ -88,5 +88,5 @@ class LPC4088qsb(LPC4088):
         RamRegion(      start=0x10000000,  length=0x10000),
         )
 
-    def __init__(self, link):
-        super(LPC4088qsb, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC4088qsb, self).__init__(session, self.MEMORY_MAP)

--- a/pyocd/target/builtin/target_lpc800.py
+++ b/pyocd/target/builtin/target_lpc800.py
@@ -52,13 +52,13 @@ class LPC800(CoreSightTarget):
 
     VENDOR = "NXP"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x4000,       blocksize=0x400, is_boot_memory=True, algo=FLASH_ALGO),
         RamRegion(      start=0x10000000,  length=0x1000)
         )
 
-    def __init__(self, link):
-        super(LPC800, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(LPC800, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("LPC800_v0.3.svd")
 
     def reset_and_halt(self, reset_type=None, map_to_user=True):

--- a/pyocd/target/builtin/target_lpc800.py
+++ b/pyocd/target/builtin/target_lpc800.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_musca_a1.py
+++ b/pyocd/target/builtin/target_musca_a1.py
@@ -97,7 +97,7 @@ class MuscaA1(CoreSightTarget):
 
     VENDOR = "Arm"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         # Due to an errata, only the first 256 kB of QSPI is memory mapped. The remainder
         # of the 8 MB region can be read and written via register accesses only.
         FlashRegion(name='nqspi',    start=0x00200000, length=0x00040000, access='rx',
@@ -140,7 +140,7 @@ class MuscaA1(CoreSightTarget):
                         alias='nsysram'),
         )
 
-    def __init__(self, link):
-        super(MuscaA1, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(MuscaA1, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("Musca.svd")
 

--- a/pyocd/target/builtin/target_musca_a1.py
+++ b/pyocd/target/builtin/target_musca_a1.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_musca_b1.py
+++ b/pyocd/target/builtin/target_musca_b1.py
@@ -248,7 +248,7 @@ class MuscaB1(CoreSightTarget):
 
     VENDOR = "Arm"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(name='neflash',     start=0x0A000000, length=0x00200000, access='rx',
                         blocksize=0x4000,
                         page_size=0x4000,
@@ -284,8 +284,8 @@ class MuscaB1(CoreSightTarget):
                         alias='nsysram'),
         )
 
-    def __init__(self, link):
-        super(MuscaB1, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(MuscaB1, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("Musca_B1.svd")
 
     def create_init_sequence(self):

--- a/pyocd/target/builtin/target_musca_b1.py
+++ b/pyocd/target/builtin/target_musca_b1.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 

--- a/pyocd/target/builtin/target_nRF51822_xxAA.py
+++ b/pyocd/target/builtin/target_nRF51822_xxAA.py
@@ -53,7 +53,7 @@ class NRF51(CoreSightTarget):
 
     VENDOR = "Nordic Semiconductor"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x40000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO),
         # User Information Configation Registers (UICR) as a flash region
@@ -62,8 +62,8 @@ class NRF51(CoreSightTarget):
         RamRegion(      start=0x20000000,  length=0x4000)
         )
 
-    def __init__(self, link):
-        super(NRF51, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(NRF51, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("nrf51.svd")
 
     def resetn(self):

--- a/pyocd/target/builtin/target_nRF51822_xxAA.py
+++ b/pyocd/target/builtin/target_nRF51822_xxAA.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 import logging

--- a/pyocd/target/builtin/target_nRF52832_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52832_xxAA.py
@@ -44,7 +44,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class NRF52832(NRF52):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x0,         length=0x80000,      blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO),
         # User Information Configation Registers (UICR) as a flash region
@@ -53,8 +53,8 @@ class NRF52832(NRF52):
         RamRegion(      start=0x20000000,  length=0x10000)
         )
 
-    def __init__(self, link):
-        super(NRF52832, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(NRF52832, self).__init__(session, self.MEMORY_MAP)
 
     def resetn(self):
         """

--- a/pyocd/target/builtin/target_nRF52840_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52840_xxAA.py
@@ -45,7 +45,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 
 class NRF52840(NRF52):
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x0,         length=0x100000,     blocksize=0x1000, is_boot_memory=True,
             algo=FLASH_ALGO),
         # User Information Configation Registers (UICR) as a flash region
@@ -54,8 +54,8 @@ class NRF52840(NRF52):
         RamRegion(      start=0x20000000,  length=0x40000)
         )
 
-    def __init__(self, link):
-        super(NRF52840, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(NRF52840, self).__init__(session, self.MEMORY_MAP)
 
     def resetn(self):
         """

--- a/pyocd/target/builtin/target_nRF52840_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52840_xxAA.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 from ..family.target_nRF52 import NRF52

--- a/pyocd/target/builtin/target_ncs36510.py
+++ b/pyocd/target/builtin/target_ncs36510.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 
 FLASH_ALGO = {

--- a/pyocd/target/builtin/target_ncs36510.py
+++ b/pyocd/target/builtin/target_ncs36510.py
@@ -83,11 +83,11 @@ class NCS36510(CoreSightTarget):
 
     VENDOR = "ONSemiconductor"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x2000,           length=0x50000,      blocksize=0x800, is_boot_memory=True,
             algo=FLASH_ALGO),
         RamRegion(      start=0x3FFF4000,  length=0xC000)
         )
 
-    def __init__(self, link):
-        super(NCS36510, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(NCS36510, self).__init__(session, self.MEMORY_MAP)

--- a/pyocd/target/builtin/target_s5js100.py
+++ b/pyocd/target/builtin/target_s5js100.py
@@ -17,7 +17,7 @@
 import logging
 from time import sleep
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...coresight import (ap, dap)
 from ...core.memory_map import (RomRegion, FlashRegion, RamRegion, MemoryMap)
 from ...core.target import Target

--- a/pyocd/target/builtin/target_s5js100.py
+++ b/pyocd/target/builtin/target_s5js100.py
@@ -150,7 +150,7 @@ class S5JS100(CoreSightTarget):
     AP_NUM = 0
     ROM_ADDR = 0xE00FE000
 
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(start=0x406f4000, length=0x00100000,
                     page_size=0x400, blocksize=0x1000,
                     is_boot_memory=True,
@@ -163,8 +163,8 @@ class S5JS100(CoreSightTarget):
         RamRegion(start=0x00100000, length=0x80000)
     )
 
-    def __init__(self, link):
-        super(S5JS100, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(S5JS100, self).__init__(session, self.MEMORY_MAP)
         self.AP_NUM = 0
 
     def create_init_sequence(self):

--- a/pyocd/target/builtin/target_w7500.py
+++ b/pyocd/target/builtin/target_w7500.py
@@ -42,12 +42,12 @@ class W7500(CoreSightTarget):
 
     VENDOR = "WIZnet"
     
-    memoryMap = MemoryMap(
+    MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x00000000,  length=0x20000,      blocksize=0x100, is_boot_memory=True,
             algo=FLASH_ALGO),
         RamRegion(      start=0x20000000,  length=0x4000)
         )
 
-    def __init__(self, link):
-        super(W7500, self).__init__(link, self.memoryMap)
+    def __init__(self, session):
+        super(W7500, self).__init__(session, self.MEMORY_MAP)
 

--- a/pyocd/target/builtin/target_w7500.py
+++ b/pyocd/target/builtin/target_w7500.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from ...flash.flash import Flash
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 
 FLASH_ALGO = { 'load_address' : 0x20000000,

--- a/pyocd/target/family/target_kinetis.py
+++ b/pyocd/target/family/target_kinetis.py
@@ -18,7 +18,7 @@ from ...coresight import (dap, ap)
 from ...coresight.cortex_m import CortexM
 from ...core import exceptions
 from ...core.target import Target
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...utility.timeout import Timeout
 import logging
 from time import sleep

--- a/pyocd/target/family/target_kinetis.py
+++ b/pyocd/target/family/target_kinetis.py
@@ -55,8 +55,8 @@ class Kinetis(CoreSightTarget):
 
     VENDOR = "NXP"
 
-    def __init__(self, link, memoryMap=None):
-        super(Kinetis, self).__init__(link, memoryMap)
+    def __init__(self, session, memory_map=None):
+        super(Kinetis, self).__init__(session, memory_map)
         self.mdm_ap = None
         self._force_halt_on_connect = False
 

--- a/pyocd/target/family/target_lpc5500.py
+++ b/pyocd/target/family/target_lpc5500.py
@@ -18,7 +18,7 @@ from time import sleep
 import logging
 
 from ...core.target import Target
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...coresight.cortex_m import CortexM
 from ...coresight.cortex_m_v8m import CortexM_v8M

--- a/pyocd/target/family/target_nRF52.py
+++ b/pyocd/target/family/target_nRF52.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from ...core import exceptions
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...debug.svd.loader import SVDFile
 from ...utility.timeout import Timeout
 import logging

--- a/pyocd/target/family/target_nRF52.py
+++ b/pyocd/target/family/target_nRF52.py
@@ -56,8 +56,8 @@ class NRF52(CoreSightTarget):
 
     VENDOR = "Nordic Semiconductor"
 
-    def __init__(self, link, memoryMap=None):
-        super(NRF52, self).__init__(link, memoryMap)
+    def __init__(self, session, memory_map=None):
+        super(NRF52, self).__init__(session, memory_map)
         self._svd_location = SVDFile.from_builtin("nrf52.svd")
         self.ctrl_ap = None
 

--- a/pyocd/target/family/target_psoc6.py
+++ b/pyocd/target/family/target_psoc6.py
@@ -19,7 +19,7 @@ from time import sleep
 
 from pyocd.coresight.generic_mem_ap import GenericMemAPTarget
 from ...core import exceptions
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (MemoryMap, RamRegion)
 from ...core.target import Target
 from ...coresight.cortex_m import CortexM

--- a/pyocd/target/family/target_psoc6.py
+++ b/pyocd/target/family/target_psoc6.py
@@ -128,11 +128,11 @@ class CortexM_PSoC6_A2M(CortexM_PSoC6):
 
 class PSoC6(CoreSightTarget):
     VENDOR = "Cypress"
-    CoretxM_Core = None
+    cortex_m_core_class = None
 
-    def __init__(self, link, CoretxM_Core, MemoryMap):
-        self.CoretxM_Core = CoretxM_Core
-        super(PSoC6, self).__init__(link, MemoryMap)
+    def __init__(self, session, cortex_m_core_class, memory_map):
+        self.cortex_m_core_class = cortex_m_core_class
+        super(PSoC6, self).__init__(session, memory_map)
 
     def create_init_sequence(self):
         seq = super(PSoC6, self).create_init_sequence()
@@ -142,9 +142,9 @@ class PSoC6(CoreSightTarget):
         return seq
 
     def create_psoc_cores(self):
-        core0 = self.CoretxM_Core(self.session, self.aps[1], self.memory_map, 0)
+        core0 = self.cortex_m_core_class(self.session, self.aps[1], self.memory_map, 0)
         core0.default_reset_type = self.ResetType.SW_SYSRESETREQ
-        core1 = self.CoretxM_Core(self.session, self.aps[2], self.memory_map, 1)
+        core1 = self.cortex_m_core_class(self.session, self.aps[2], self.memory_map, 1)
         core1.default_reset_type = self.ResetType.SW_SYSRESETREQ
 
         self.aps[1].core = core0
@@ -164,10 +164,10 @@ class CortexM_PSoC64(CortexM):
     TEST_MODE_VALUE = 0x80000000
     CM4_PWR_CTL_VALUE = 0x05FA0003
 
-    def __init__(self, session, ap, memoryMap, core_num, acquire_timeout):
+    def __init__(self, session, ap, memory_map, core_num, acquire_timeout):
         self._acquire_timeout = acquire_timeout
         self._skip_reset_and_halt = False
-        super(CortexM_PSoC64, self).__init__(session, ap, memoryMap, core_num)
+        super(CortexM_PSoC64, self).__init__(session, ap, memory_map, core_num)
 
     @property
     def acquire_timeout(self):
@@ -349,10 +349,10 @@ class CortexM_PSoC64_A512K(CortexM_PSoC64):
 
 
 class SYS_AP_PSoC64(GenericMemAPTarget):
-    def __init__(self, session, ap, memoryMap, core_num, acquire_timeout):
+    def __init__(self, session, ap, memory_map, core_num, acquire_timeout):
         self._acquire_timeout = acquire_timeout
         self._skip_reset_and_halt = False
-        super(SYS_AP_PSoC64, self).__init__(session, ap, memoryMap, core_num)
+        super(SYS_AP_PSoC64, self).__init__(session, ap, memory_map, core_num)
 
     @property
     def acquire_timeout(self):
@@ -392,13 +392,13 @@ class SYS_AP_PSoC64(GenericMemAPTarget):
 class PSoC64(CoreSightTarget):
     VENDOR = "Cypress"
     AP_NUM = None
-    CoretxM_Core = None
+    cortex_m_core_class = None
 
-    def __init__(self, link, CoretxM_Core, MemoryMap, ap_num):
-        self.CoretxM_Core = CoretxM_Core
+    def __init__(self, session, cortex_m_core_class, memory_map, ap_num):
+        self.cortex_m_core_class = cortex_m_core_class
         self.AP_NUM = ap_num
         self.DEFAULT_ACQUIRE_TIMEOUT = 25.0
-        super(PSoC64, self).__init__(link, MemoryMap)
+        super(PSoC64, self).__init__(session, memory_map)
 
     def create_init_sequence(self):
         seq = super(PSoC64, self).create_init_sequence()
@@ -426,7 +426,7 @@ class PSoC64(CoreSightTarget):
         self.add_core(sysap)
 
         if self.AP_NUM:
-            core = self.CoretxM_Core(self.session, self.aps[self.AP_NUM], self.memory_map, 1,
+            core = self.cortex_m_core_class(self.session, self.aps[self.AP_NUM], self.memory_map, 1,
                                      self.DEFAULT_ACQUIRE_TIMEOUT)
             core.default_reset_type = self.ResetType.SW_SYSRESETREQ
             self.aps[self.AP_NUM].core = core
@@ -436,7 +436,7 @@ class PSoC64(CoreSightTarget):
 
 
 class cy8c64_sysap(PSoC64):
-    memoryMap = MemoryMap(RamRegion(start=0, length=0x100000000))
+    MEMORY_MAP = MemoryMap(RamRegion(start=0, length=0x100000000))
 
-    def __init__(self, link):
-        super(cy8c64_sysap, self).__init__(link, None, self.memoryMap, 0)
+    def __init__(self, session):
+        super(cy8c64_sysap, self).__init__(session, None, self.MEMORY_MAP, 0)

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -22,7 +22,7 @@ import os
 from .cmsis_pack import (CmsisPack, MalformedCmsisPackError)
 from ..family import FAMILIES
 from .. import TARGET
-from ...core.coresight_target import CoreSightTarget
+from ...coresight.coresight_target import CoreSightTarget
 from ...debug.svd.loader import SVDFile
 from ...utility.compatibility import FileNotFoundError_
 

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -1615,7 +1615,7 @@ class PyOCDCommander(object):
             return
         original_core_ap = core_ap = self.target.selected_core.ap
         core = int(args[0], base=0)
-        self.target.select_core(core)
+        self.target.selected_core = core
         core_ap = self.target.selected_core.ap
         self.selected_ap = core_ap.address
         print("Selected core {} ({})".format(core, core_ap.short_description))


### PR DESCRIPTION
This changeset splits `CoreSightTarget` in two:
- `SoCTarget` is an architecture-independent representation of the SoC. It replaces `CoreSightTarget` under `pyocd.core`.
- `CoreSightTarget` moves to `pyocd.coresight` (where it should have been in the first place) and adds the Arm specifics to the SoC representation.

A few other changes:
- Moved the vendor and part number related attributes from `Target` to `SoCTarget`.
- The part number and part families will be set to `PART_NUMBER` and `PART_FAMILIES` class attributes if they exist.
- Added a `cache.read_code_from_elf` option to control whether the `ElfReaderContext` gets added to the target context stack when an ELF file is set on the target (mostly affecting the gdbserver).

And some target-related cleanup:
- Corrected names of the target constructor parameters for built-in targets. (Nothing was broken, just misleading.)
- Changed to PEP8-compliant name `MEMORY_MAP` for the built-in target class-attribute memory maps.