### PR TITLE
Avoid Construct the flash region error

### DIFF
--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2019 Arm Limited
+# Copyright (c) 2020 Men Shiyun
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -428,6 +429,10 @@ class CmsisPackDevice(object):
                     end = region.end
                 else:
                     end = region.start + packAlgo.sector_sizes[j + 1][0] - 1
+                
+                # Skip wrong start and end addresses
+                if end < start:
+                    continue
                 
                 # Limit page size.
                 if page_size > sector_size:


### PR DESCRIPTION
When ‘end < start', an error will occur when executing to # Construct the flash region.
For example, execute "pyocd list -t" and add the parameter "--pack Keil.STM32F4xx_DFP.2.14.0.pack".
I tested most of the Keil.STM32F4xx_DFP software packages, all have this problem.

**BEFORE**
```
$ pyocd list -t --pack Keil.STM32F4xx_DFP.2.14.0.pack
0000348:CRITICAL:__main__:uncaught exception: Memory regions must have a non-zero length.
Traceback (most recent call last):
  File "/home/menshiyun/.local/lib/python3.8/site-packages/pyocd/__main__.py", line 362, in run
    self._COMMANDS\[self._args.cmd\](self)
  File "/home/menshiyun/.local/lib/python3.8/site-packages/pyocd/__main__.py", line 428, in do_list
    obj = ListGenerator.list_targets(name_filter=self._args.name,
  File "/home/menshiyun/.local/lib/python3.8/site-packages/pyocd/tools/lists.py", line 139, in list_targets
    t = TARGET[name](s)
  File "/home/menshiyun/.local/lib/python3.8/site-packages/pyocd/target/pack/pack_target.py", line 97, in _pack_target__init__
    super(self.__class__, self).__init__(session, self._pack_device.memory_map)
  File "/home/menshiyun/.local/lib/python3.8/site-packages/pyocd/target/pack/cmsis_pack.py", line 513, in memory_map
    self._build_flash_regions()
  File "/home/menshiyun/.local/lib/python3.8/site-packages/pyocd/target/pack/cmsis_pack.py", line 449, in _build_flash_regions
    rangeRegion = FlashRegion(name=region.name,
  File "/home/menshiyun/.local/lib/python3.8/site-packages/pyocd/core/memory_map.py", line 334, in __init__
    super(FlashRegion, self).__init__(start=start, end=end, length=length, **attrs)
  File "/home/menshiyun/.local/lib/python3.8/site-packages/pyocd/core/memory_map.py", line 192, in __init__
    assert self.length > 0, "Memory regions must have a non-zero length."
AssertionError: Memory regions must have a non-zero length.
```

**AFTER (Partial)**
```
$ pyocd list -t --pack Keil.STM32F4xx_DFP.2.14.0.pack
  Name                      Vendor                  Part Number                  Families                    Source   
----------------------------------------------------------------------------------------------------------------------
  stm32f407vetx             STMicroelectronics      STM32F407VETx                STM32F4 Series, STM32F407   pack     
  stm32f407vg               STMicroelectronics      STM32F407VG                  STM32F4 Series, STM32F407   pack     
  stm32f407vgtx             STMicroelectronics      STM32F407VGTx                STM32F4 Series, STM32F407   pack     
  stm32f407ze               STMicroelectronics      STM32F407ZE                  STM32F4 Series, STM32F407   pack     
  stm32f407zetx             STMicroelectronics      STM32F407ZETx                STM32F4 Series, STM32F407   pack     
  stm32f407zg               STMicroelectronics      STM32F407ZG                  STM32F4 Series, STM32F407   pack     
  stm32f407zgtx             STMicroelectronics      STM32F407ZGTx                STM32F4 Series, STM32F407   pack     
  stm32f410c8               STMicroelectronics      STM32F410C8                  STM32F4 Series, STM32F410   pack     
  stm32f410c8tx             STMicroelectronics      STM32F410C8Tx                STM32F4 Series, STM32F410   pack     
  stm32f410c8ux             STMicroelectronics      STM32F410C8Ux                STM32F4 Series, STM32F410   pack     
  stm32f410cb               STMicroelectronics      STM32F410CB                  STM32F4 Series, STM32F410   pack     
  stm32f410cbtx             STMicroelectronics      STM32F410CBTx                STM32F4 Series, STM32F410   pack     
  stm32f410cbux             STMicroelectronics      STM32F410CBUx                STM32F4 Series, STM32F410   pack     
  stm32f410r8               STMicroelectronics      STM32F410R8                  STM32F4 Series, STM32F410   pack     
  stm32f410r8ix             STMicroelectronics      STM32F410R8Ix                STM32F4 Series, STM32F410   pack     
  stm32f410r8tx             STMicroelectronics      STM32F410R8Tx                STM32F4 Series, STM32F410   pack     
  stm32f410rb               STMicroelectronics      STM32F410RB                  STM32F4 Series, STM32F410   pack     
  stm32f410rbix             STMicroelectronics      STM32F410RBIx                STM32F4 Series, STM32F410   pack     
```