### PR TITLE
A little CMSIS-DAP support cleanup

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -45,6 +45,14 @@ Whether to perform a chip erase or sector erases when programming flash. The val
 'auto', 'sector', or 'chip'.
 </td></tr>
 
+<tr><td>cmsis_dap.deferred_transfers</td>
+<td>bool</td>
+<td>True</td>
+<td>
+Whether to use deferred transfers in the CMSIS-DAP probe backend. By disabling deferred transfers,
+all writes take effect immediately. However, performance is negatively affected.
+</td></tr>
+
 <tr><td>commander.history_length</td>
 <td>int</td>
 <td>1000</td>

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -31,6 +31,8 @@ BUILTIN_OPTIONS = [
     OptionInfo('chip_erase', str, "sector",
         "Whether to perform a chip erase or sector erases when programming flash. The value must be"
         " one of \"auto\", \"sector\", or \"chip\"."),
+    OptionInfo('cmsis_dap.deferred_transfers', bool, True,
+        "Whether to use deferred transfers in the CMSIS-DAP probe backend."),
     OptionInfo('commander.history_length', int, 1000,
         "Number of entries in the pyOCD Commander command history. Set to -1 for unlimited. Default is 1000."),
     OptionInfo('config_file', str, None,

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -147,7 +147,7 @@ class CMSISDAPProbe(DebugProbe):
         try:
             self._link.open()
             self._is_open = True
-            self._link.set_deferred_transfer(True)
+            self._link.set_deferred_transfer(self.session.options.get('cmsis_dap.deferred_transfers'))
         
             # Read CMSIS-DAP capabilities
             self._capabilities = self._link.identify(DAPAccess.ID.CAPABILITIES)

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2006-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,27 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import platform
+import six
+
 from .interface import Interface
 from .common import filter_device_by_usage_page
 from ..dap_access_api import DAPAccessIntf
 from ....utility.compatibility import to_str_safe
-import logging
-import os
-import six
 
 LOG = logging.getLogger(__name__)
 
 try:
     import hid
 except:
-    if os.name == "posix" and os.uname()[0] == 'Darwin':
-        LOG.error("cython-hidapi is required on a Mac OS X Machine")
+    if platform.system() == 'Darwin':
+        LOG.error("hidapi is required for CMSIS-DAP support on macOS")
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True
 
 class HidApiUSB(Interface):
-    """! @brief CMSIS-DAP USB interface class using cython-hidapi backend.
+    """! @brief CMSIS-DAP USB interface class using hidapi backend.
     """
 
     isAvailable = IS_AVAILABLE

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -14,16 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .interface import Interface
-from .common import (USB_CLASS_HID, filter_device_by_class, is_known_cmsis_dap_vid_pid, check_ep)
-from ..dap_access_api import DAPAccessIntf
 import logging
-import os
 import threading
 import six
 from time import sleep
 import platform
 import errno
+
+from .interface import Interface
+from .common import (
+    USB_CLASS_HID,
+    filter_device_by_class,
+    is_known_cmsis_dap_vid_pid,
+    check_ep,
+    )
+from ..dap_access_api import DAPAccessIntf
+from ... import common
 
 LOG = logging.getLogger(__name__)
 
@@ -31,8 +37,8 @@ try:
     import usb.core
     import usb.util
 except:
-    if os.name == "posix" and not os.uname()[0] == 'Darwin':
-        LOG.error("PyUSB is required on a Linux Machine")
+    if platform.system() == "Linux":
+        LOG.error("PyUSB is required for CMSIS-DAP support on Linux")
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True
@@ -94,7 +100,7 @@ class PyUSB(Interface):
                 LOG.debug("Detaching Kernel Driver of Interface %d from USB device (VID=%04x PID=%04x).", interface_number, dev.idVendor, dev.idProduct)
                 dev.detach_kernel_driver(interface_number)
                 self.kernel_driver_was_attached = True
-        except (NotImplementedError,usb.core.USBError) as e:
+        except (NotImplementedError, usb.core.USBError) as e:
             # Some implementations don't don't have kernel attach/detach
             LOG.warning("USB Kernel Driver Detach Failed ([%s] %s). Attached driver may interfere with pyOCD operations.", e.errno, e.strerror)
             pass

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -48,6 +48,8 @@ class PyUSB(Interface):
     """
 
     isAvailable = IS_AVAILABLE
+    
+    did_show_no_libusb_warning = False
 
     def __init__(self):
         super(PyUSB, self).__init__()
@@ -152,7 +154,13 @@ class PyUSB(Interface):
         returns an array of PyUSB (Interface) objects
         """
         # find all cmsis-dap devices
-        all_devices = usb.core.find(find_all=True, custom_match=FindDap())
+        try:
+            all_devices = usb.core.find(find_all=True, custom_match=FindDap())
+        except usb.core.NoBackendError:
+            if not PyUSB.did_show_no_libusb_warning:
+                LOG.warning("CMSIS-DAPv1 probes may not be detected because no libusb library was found.")
+                PyUSB.did_show_no_libusb_warning = True
+            return []
 
         # iterate on all devices found
         boards = []

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019 Arm Limited
+# Copyright (c) 2019-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,18 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .interface import Interface
-from .common import (USB_CLASS_VENDOR_SPECIFIC, filter_device_by_class, is_known_cmsis_dap_vid_pid,
-                        check_ep)
-from ..dap_access_api import DAPAccessIntf
-from ... import common
 import logging
-import os
 import threading
 import six
 from time import sleep
 import errno
 import platform
+
+from .interface import Interface
+from .common import (
+    USB_CLASS_VENDOR_SPECIFIC,
+    filter_device_by_class,
+    is_known_cmsis_dap_vid_pid,
+    check_ep,
+    )
+from ..dap_access_api import DAPAccessIntf
+from ... import common
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2006-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import platform
+import collections
+from time import sleep
+import six
+
 from .interface import Interface
 from .common import filter_device_by_usage_page
 from ..dap_access_api import DAPAccessIntf
 from ....utility.timeout import Timeout
-import logging
-import os
-import collections
-from time import time, sleep
-import six
 
 OPEN_TIMEOUT_S = 60.0
 
@@ -31,7 +32,7 @@ LOG = logging.getLogger(__name__)
 try:
     import pywinusb.hid as hid
 except:
-    if os.name == "nt":
+    if platform.system() == "Windows":
         LOG.error("PyWinUSB is required on a Windows Machine")
     IS_AVAILABLE = False
 else:


### PR DESCRIPTION
The most visible change is a new `cmsis_dap.deferred_transfers` session option.

Includes a change to report a warning from the pyusb backend for CMSIS-DAPv1 if the libusb library cannot be loaded. This can occur in special situations on Linux, such as running pyOCD from within a Docker container.

Plus some code cleanup.