### PR TITLE
Documentation additions and clarification

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,41 +1,44 @@
 # pyOCD Documentation
 
-
 ## Table of Contents
 
 ### User documentation
 
-#### Introduction
+#### Topics
 
 - [Terminology](terminology.md)
 - [Target support](target_support.md)
 - [Configuration](configuration.md)
-- [Available options](options.md)
 - [User scripts](user_scripts.md)
 - [Remote probe access](remote_probe_access.md)
-
-#### Advanced
-
 - [Configuring logging](configuring_logging.md)
 - [Debugging multicore devices](multicore_debug.md)
 - [Target security features](security.md)
 
+#### Reference
+
+- [Session options reference](options.md)
+
 #### Python API
+
 - [Introduction to the pyOCD Python API](python_api.md)
 - [Python API examples](api_examples.md)
 
 #### Miscellaneous
+
 - [Installing on non-x86 platforms](installing_on_non_x86.md)
 
 ### Developer documentation
 
 #### How-tos
+
 - [Developers’ guide](developers_guide.md)
 - [How to add new targets](adding_new_targets.md)
 - [Building a standalone gdb server executable](how_to_build.md)
 - [Running the automated tests](automated_tests.md)
 
 #### Architecture and Design
+
 - [Architecture overview](architecture.md)
 - [Remote probe protocol](remote_probe_protocol.md)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ composition, not inheritance.
 ```
 
 The root of the runtime object graph is a `Session` object. This object holds references to the debug
-probe and the board. It is also responsible for managing per-session user options that control
+probe and the board. It is also responsible for managing per-session options that control
 various features and settings.
 
 Attached to the board is a `CoreSightTarget` instance, which represents an MCU. This owns the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,17 +5,17 @@ This guide documents how to configure pyOCD.
 
 ## Introduction
 
-pyOCD allows you to control many aspects of its behaviour by setting user options. There are
+pyOCD allows you to control many aspects of its behaviour by setting session options. There are
 multiple ways to set these options.
 
-- Many of the most commonly used user options have dedicated command line arguments.
+- Many of the most commonly used session options have dedicated command line arguments.
 - Options can be placed in a YAML config file.
 - Arbitrary options can be set individually with the `-Ooption=value` command line argument.
 - If you are using the Python API, you may pass any option values directly
     to the `ConnectHelper` methods or `Session` constructor as keyword arguments. You can also
     pass a dictionary for the `options` parameter of these methods.
 
-The priorities of the different user option sources, from highest to lowest:
+The priorities of the different session option sources, from highest to lowest:
 
 1. Keyword arguments to the `Session` constructor. Applies to most command-line arguments.
 2. _options_ parameter to constructor. Applies to `-O` command-line arguments.
@@ -37,7 +37,7 @@ uses the filename as-is. Otherwise, it looks for the file in the project directo
 
 ## Config file
 
-pyOCD supports a YAML configuration file that lets you set user options that either apply to
+pyOCD supports a YAML configuration file that lets you set session options that either apply to
 all probes or to a single probe, based on the probe's unique ID.
 
 The easiest way to use a config file is to place a `pyocd.yaml` file in the project directory.
@@ -47,13 +47,13 @@ optional dot prefix on the config file name are allowed. Alternatively, you can 
 `config_file` option.
 
 The top level of the YAML file is a dictionary. The keys in the top-level dictionary must be names
-of user options, or the key `probes`. User options are set to the value corresponding to the
+of session options, or the key `probes`. Session options are set to the value corresponding to the
 dictionary entry. Unrecognized option names are ignored.
 
 If there is a top-level `probes` key, its value must be a dictionary with keys that match a
 substring of debug probe unique IDs. Usually you would just use the complete unique ID shown by
 listing connected boards (i.e., `pyocd list`). The values for the unique ID entries are
-dictionaries containing user options, just like the top level of the YAML file. Of course, these
+dictionaries containing session options, just like the top level of the YAML file. Of course, these
 options are only applied when connecting with the given probe. If the probe unique ID
 substring listed in the config file matches more than one probe, the corresponding options
 will be applied to all matching probes.

--- a/docs/configuring_logging.md
+++ b/docs/configuring_logging.md
@@ -41,7 +41,7 @@ level of WARNING to INFO.
 Fine-grained control of pyOCD log output is available through logging configuration. The logging
 package supports loading a configuration dictionary to control almost all aspects of log output.
 
-The `logging` user option is used to specify the logging configuration. It can be set to either a
+The `logging` session option is used to specify the logging configuration. It can be set to either a
 logging configuration dictionary or the path to a YAML file containing a configuration dictionary.
 Usually it is easiest to include the configuration directly in a `pyocd.yaml` config file. See the
 [configuration documentation](configuration.md) for more on config files. The file path is most
@@ -74,7 +74,7 @@ logging:
       level: DEBUG
 ```
 
-The top level `logging` key is the user option. Under it must be a `loggers` key, which has the
+The top level `logging` key is the session option. Under it must be a `loggers` key, which has the
 name of each module you wish to configure as a child key. Then, under each module name, the `level`
 key specifies the log level for that module. Due to the way logging propagation works, you do not
 need to set the level of parent loggers to match the child levels. In fact, setting the level of a

--- a/docs/configuring_logging.md
+++ b/docs/configuring_logging.md
@@ -19,13 +19,15 @@ Each subcommand for the `pyocd` tool has a default logging level.
 
 Subcommand     | Default level
 ---------------|--------------
-`list`         | INFO
-`json`         | Logging fully disabled
-`flash`        | WARNING
-`erase`        | WARNING
-`gdbserver`    | INFO
 `commander`    | WARNING
+`erase`        | WARNING
+`flash`        | WARNING
+`gdbserver`    | INFO
+`json`         | Logging fully disabled
+`list`         | INFO
 `pack`         | INFO
+`reset`        | WARNING
+`server`       | INFO
 
 
 ## Basic control
@@ -100,7 +102,8 @@ will set the `disabled_existing_loggers` key to false unless it is specified in 
 Note that if you change the configuration for the root logger, you will need to define a handler
 and formatter in the configuration (see the example below).
 
-Here is a much more complex example configuration that sets a custom formatter:
+Here is a much more complex example configuration that sets a custom formatter and changes several log
+levels:
 
 ```yaml
 logging:
@@ -120,7 +123,24 @@ logging:
   loggers:
     pyocd:
       level: INFO        # set all pyocd loggers to INFO level
-    pyocd.core.coresight_target:
+    pyocd.probe:
       level: DEBUG       # set this logger to DEBUG level
 ```
 
+This example shows how to direct log output to a log file called `pyocd_log.txt`:
+
+```yaml
+logging:
+  root:
+    handlers: [logfile]
+  formatters:
+    precise:
+      format: "[%(relativeCreated)07d:%(levelname)s:%(module)s] %(message)s"
+  handlers:
+    logfile:
+      class: logging.FileHandler
+      formatter: precise
+      filename: pyocd_log.txt
+      mode: w
+      delay: false
+```

--- a/docs/multicore_debug.md
+++ b/docs/multicore_debug.md
@@ -11,7 +11,7 @@ user-specified port number. Additional cores have port numbers incremented from 
 To prevent reset requests from multiple connected gdb instances causing havoc, secondary cores have
 their default reset type set to core-only reset (VECTRESET), which will fall back to an emulated
 reset for non-v7-M architectures. This feature can be disabled by setting the
-`enable_multicore_debug` user option to false.
+`enable_multicore_debug` session option to false.
 
 To debug a multicore device, run `pyocd gdbserver` as usual. This will connect to the device, detect
 the cores, and create the gdb server instances on separate ports. Next, start up two gdb instances

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,4 +1,4 @@
-User options list
+Session options list
 =================
 
 _**Note:** The names of these options are expected to change before the 1.0 release of pyOCD, so
@@ -56,7 +56,7 @@ Number of entries in the pyOCD Commander command history. Set to -1 for unlimite
 <td>str</td>
 <td><i>See description</i></td>
 <td>
-Relative path to a YAML config file that lets you specify user options either globally or per probe.
+Relative path to a YAML config file that lets you specify session options either globally or per probe.
 The format of the file is documented above. The default is a <tt>pyocd.yaml</tt> or <tt>pyocd.yml</tt> file in the
 working directory.
 </td></tr>
@@ -272,7 +272,7 @@ type is used. The warning is never shown if the cortex_m target type is explicit
 
 ## GDB server options
 
-These user options are currently only applied when running the GDB server.
+These session options are currently only applied when running the GDB server.
 
 <table>
 
@@ -419,7 +419,7 @@ presentation in gdb.
 
 ## J-Link probe options
 
-These user options are available when the SEGGER J-Link debug probe plugin is active.
+These session options are available when the SEGGER J-Link debug probe plugin is active.
 
 <table>
 

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -26,8 +26,8 @@ allow automatically picking the first available probe.
 One of the most useful parameters for `session_with_chosen_probe()` is `unique_id`. Pass whole or
 part of a probe's unique ID (aka serial number) to programmatically select a specific probe.
 
-User options may be passed to `session_with_chosen_probe()` in two ways. The `options`
-parameter accepts a dictionary of user options. Or, you may pass options as keyword parameters.
+Session options may be passed to `session_with_chosen_probe()` in two ways. The `options`
+parameter accepts a dictionary of session options. Or, you may pass options as keyword parameters.
 The two methods may be combined.
 
 

--- a/docs/target_support.md
+++ b/docs/target_support.md
@@ -47,7 +47,7 @@ The first is to pass the `--target` command line argument to the `pyocd` tool an
 type name. This argument must be passed every time you run `pyocd` with a subcommand that connects
 to the target.
 
-Another method is to set the `target_override` user option in a `pyocd.yaml` configuration file. The
+Another method is to set the `target_override` session option in a `pyocd.yaml` configuration file. The
 [configuration file documentation](configuration.md) describes how to do this for a specific debug
 probe instead of globally.
 
@@ -171,7 +171,7 @@ you might execute `pyocd gdbserver --pack=Keil.STM32L4xx_DFP.2.2.0.pack`. Note t
 multiple `--pack` arguments to pyOCD, which might be useful in a scripted execution of pyOCD.
 
 For a more permanent solution, use a [`pyocd.yaml` configuration file](configuration.md). In the
-config file, set the `pack` user option to either a single .pack file path or a list of paths. Now
+config file, set the `pack` session option to either a single .pack file path or a list of paths. Now
 when you run the `pyocd` tool, it will automatically pick up the pack file(s) to use.
 
 Here is an example config file that lists two packs.

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -5,18 +5,26 @@ These are the key terms used by pyOCD and its documentation.
 
 - **CoreSight** — A standard Arm architecture for debug subsystems. It defines a standardised way
     to discover the debug resources provided by a device.
+- **debug link** — The interface provided by a chip to allow for its debugging. Mostly SWD or JTAG.
 - **debug probe** — The device that drives SWD or JTAG. Usually connected to the host via USB.
 - **delegation** — A code pattern used to extend or modify functionality of a class by implementing
     methods in a companion object rather than through subclassing.
 - **flash algorithm** — A small piece of code downloaded to and executed from target RAM that
     performs flash erase and program operations.
-- **host** — The PC running pyOCD.
-- **session option** — A named value that controls some feature of pyOCD. Options can be set from the
+- **gdbserver** — A server that implements gdb's Remote Serial Protocol (RSP) to allow gdb to debug a remote
+    target. PyOCD acts as a bridge between gdb and the target.
+- **host** — The computer running pyOCD.
+- **JTAG** — Debug link standard defined by IEEE Std 1149.1-2001 and subsequent specifications.
+- **session** — Represents a connection to a debug probe and the runtime object graph.
+- **session option** — A named setting that controls some feature of pyOCD. Options are associated with
+    a session, and each session can have different values for a given option.. They can be set from the
     command line or configuration files.
+- **SWD** — Serial Wire Debug, an Arm standard for a 2-signal debug link.
 - **target** — The device that is being controlled by pyOCD through the debug probe.
 - **target type** — The part number for the target. Represented by an identifier that is either
     the full part number or a shortened form of it.
-- **unique ID** — The unique serial number of a debug probe.
+- **unique ID** — The unique identifier for a debug probe. Nominally a URI, but usually just the probe's
+    serial number.
 - **user script** — A Python script written by the user and loaded at runtime that can extend or
     modify pyOCD's behaviour.
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -11,12 +11,12 @@ These are the key terms used by pyOCD and its documentation.
 - **flash algorithm** — A small piece of code downloaded to and executed from target RAM that
     performs flash erase and program operations.
 - **host** — The PC running pyOCD.
+- **session option** — A named value that controls some feature of pyOCD. Options can be set from the
+    command line or configuration files.
 - **target** — The device that is being controlled by pyOCD through the debug probe.
 - **target type** — The part number for the target. Represented by an identifier that is either
     the full part number or a shortened form of it.
 - **unique ID** — The unique serial number of a debug probe.
-- **user option** — A named value that controls some feature of pyOCD. Options can be set from the
-    command line or configuration files.
 - **user script** — A Python script written by the user and loaded at runtime that can extend or
     modify pyOCD's behaviour.
 

--- a/docs/user_scripts.md
+++ b/docs/user_scripts.md
@@ -93,7 +93,7 @@ both target related objects, as well as parts of the pyOCD Python API.
 | `LOG` | `Logger` object for the user script. |
 | `MemoryMap` | Class representing the device's memory map. |
 | `MemoryType` | Memory region type enumeration. |
-| `options` | The user options dictionary. |
+| `options` | The session options dictionary. |
 | `probe` | The connected debug probe object. |
 | `pyocd` | The root pyOCD package. |
 | `RamRegion` | RAM memory region. |

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -122,7 +122,7 @@ class PyOCDTool(object):
         
         parser.add_argument('-V', '--version', action='version', version=__version__)
         parser.add_argument('--help-options', action='store_true',
-            help="Display available user options.")
+            help="Display available session options.")
         
         # Define logging related options.
         loggingOptions = argparse.ArgumentParser(description='logging', add_help=False)
@@ -409,7 +409,7 @@ class PyOCDTool(object):
             return 1
     
     def show_options_help(self):
-        """! @brief Display help for user options."""
+        """! @brief Display help for session options."""
         for infoName in sorted(options.OPTIONS_INFO.keys()):
             info = options.OPTIONS_INFO[infoName]
             if isinstance(info.type, tuple):

--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -47,8 +47,8 @@ class ConnectHelper(object):
               available probes.
         @param unique_id String to match against probes' unique IDs using a contains match. If the
               default of None is passed, then all available probes are matched.
-        @param options Dictionary of user options.
-        @param kwargs User options passed as keyword arguments.
+        @param options Dictionary of session options.
+        @param kwargs Session options passed as keyword arguments.
         
         @return A list of Session objects. The returned Session objects are not yet active, in that
               open() has not yet been called. If _blocking_ is True, the list will contain at least
@@ -195,7 +195,7 @@ class ConnectHelper(object):
         This method provides an easy to use command line interface for selecting one of the
         connected debug probes, then creating and opening a Session instance. It has several
         parameters that control filtering of probes by unique ID and automatic selection of the
-        first discovered probe. In addition, you can pass user options to the Session either with
+        first discovered probe. In addition, you can pass session options to the Session either with
         the _options_ parameter or directly as keyword arguments.
         
         If, after application of the _unique_id_ and _return_first_ parameter, there are still
@@ -225,8 +225,8 @@ class ConnectHelper(object):
               default of None is passed, then all available probes are matched.
         @param auto_open Sets whether the returned Session object will be opened when used as a
               context manager.
-        @param options Dictionary of user options.
-        @param kwargs User options passed as keyword arguments.
+        @param options Dictionary of session options.
+        @param kwargs Session options passed as keyword arguments.
         
         @return Either None or a Session instance.
         """

--- a/pyocd/core/options_manager.py
+++ b/pyocd/core/options_manager.py
@@ -38,7 +38,7 @@ LOG = logging.getLogger(__name__)
 OptionChangeInfo = namedtuple('OptionChangeInfo', 'new_value old_value')
 
 class OptionsManager(Notifier):
-    """! @brief Handles user option management for a session.
+    """! @brief Handles session option management for a session.
     
     The options manager supports multiple layers of option priority. When an option's value is
     accessed, the highest priority layer that contains a value for the option is used. This design
@@ -91,7 +91,7 @@ class OptionsManager(Notifier):
         self._update_layers(new_options, self._layers.append)
     
     def _convert_options(self, new_options):
-        """! @brief Prepare a dictionary of user options for use by the manager.
+        """! @brief Prepare a dictionary of session options for use by the manager.
         
         1. Strip dictionary entries with a value of None.
         2. Replace double-underscores ("__") with a dot (".").

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -55,7 +55,16 @@ class Session(Notifier):
     graph, where it owns the debug probe and the board objects.
     
     Another important function of this class is that it contains a dictionary of session-scope
-    session options. These would normally be passed in from the command line, or perhaps a config file.
+    options. These would normally be passed in from the command line. Options can also be loaded
+    from a config file.
+
+    Precedence for session options:
+    
+    1. Keyword arguments to constructor.
+    2. _options_ parameter to constructor.
+    3. Probe-specific options from a config file.
+    4. General options from a config file.
+    5. _option_defaults_ parameter to constructor.
     
     See the @ref pyocd.core.helpers.ConnectHelper "ConnectHelper" class for several methods that
     make it easy to create new sessions, with or without user interaction in the case of multiple
@@ -98,13 +107,6 @@ class Session(Notifier):
         _options_ parameter and any keyword arguments. Normally a board instance is created that can
         either be a generic board or a board associated with the debug probe.
         
-        Precedence for session options:
-        1. Keyword arguments to constructor.
-        2. _options_ parameter to constructor.
-        3. Probe-specific options from a config file.
-        4. General options from a config file.
-        5. _option_defaults_ parameter to constructor.
-        
         Note that the 'project_dir' and 'config' options must be set in either keyword arguments or
         the _options_ parameter.
         
@@ -113,7 +115,7 @@ class Session(Notifier):
         #board attribute will be None. Such a Session cannot be opened.
         
         @param self
-        @param probe The DebugProbe instance. May be None.
+        @param probe The @ref pyocd.probe.debug_probe. "DebugProbe" instance. May be None.
         @param auto_open Whether to automatically open the session when used as a context manager.
         @param options Optional session options dictionary.
         @param option_defaults Optional dictionary of session option values. This dictionary has the
@@ -261,38 +263,50 @@ class Session(Notifier):
     
     @property
     def is_open(self):
+        """! @brief Boolean of whether the session has been opened."""
         return self._inited and not self._closed
     
     @property
     def probe(self):
+        """! @brief The @ref pyocd.probe.debug_probe.DebugProbe "DebugProbe" instance."""
         return self._probe
     
     @property
     def board(self):
+        """! @brief The @ref pyocd.board.board.Board "Board" object."""
         return self._board
     
     @property
     def target(self):
+        """! @brief The @ref pyocd.core.target.soc_target "SoCTarget" object representing the SoC.
+        
+        This is the @ref pyocd.core.target.soc_target "SoCTarget" instance owned by the board.
+        """
         return self.board.target
     
     @property
     def options(self):
+        """! @brief The @ref pyocd.core.options_manager.OptionsManager "OptionsManager" object."""
         return self._options
     
     @property
     def project_dir(self):
+        """! @brief Path to the project directory."""
         return self._project_dir
     
     @property
     def delegate(self):
+        """! @brief An optional delegate object for customizing behaviour."""
         return self._delegate
     
     @delegate.setter
     def delegate(self, new_delegate):
+        """! @brief Setter for the `delegate` property."""
         self._delegate = new_delegate
     
     @property
     def user_script_proxy(self):
+        """! @brief The UserScriptDelegateProxy object for a loaded user script."""
         return self._user_script_proxy
     
     @property

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -55,7 +55,7 @@ class Session(Notifier):
     graph, where it owns the debug probe and the board objects.
     
     Another important function of this class is that it contains a dictionary of session-scope
-    user options. These would normally be passed in from the command line, or perhaps a config file.
+    session options. These would normally be passed in from the command line, or perhaps a config file.
     
     See the @ref pyocd.core.helpers.ConnectHelper "ConnectHelper" class for several methods that
     make it easy to create new sessions, with or without user interaction in the case of multiple
@@ -82,7 +82,7 @@ class Session(Notifier):
         still alive. If no live session exists, a new default session will be created and returned.
         That at least provides access to the user's config file(s).
         
-        Used primarily so code that doesn't have a session reference can access user options. This
+        Used primarily so code that doesn't have a session reference can access session options. This
         method should only be used to access options that are unlikely to differ between sessions,
         or for debug or other purposes.
         """
@@ -94,11 +94,11 @@ class Session(Notifier):
     def __init__(self, probe, auto_open=True, options=None, option_defaults=None, **kwargs):
         """! @brief Session constructor.
         
-        Creates a new session using the provided debug probe. User options are merged from the
+        Creates a new session using the provided debug probe. Session options are merged from the
         _options_ parameter and any keyword arguments. Normally a board instance is created that can
         either be a generic board or a board associated with the debug probe.
         
-        Precedence for user options:
+        Precedence for session options:
         1. Keyword arguments to constructor.
         2. _options_ parameter to constructor.
         3. Probe-specific options from a config file.
@@ -109,17 +109,17 @@ class Session(Notifier):
         the _options_ parameter.
         
         Passing in a _probe_ that is None is allowed. This is useful to create a session that operates
-        only as a container for user options. In this case, the board instance is not created, so the
+        only as a container for session options. In this case, the board instance is not created, so the
         #board attribute will be None. Such a Session cannot be opened.
         
         @param self
         @param probe The DebugProbe instance. May be None.
         @param auto_open Whether to automatically open the session when used as a context manager.
-        @param options Optional user options dictionary.
-        @param option_defaults Optional dictionary of user option values. This dictionary has the
-            lowest priority in determining final user option values, and is intended to set new
+        @param options Optional session options dictionary.
+        @param option_defaults Optional dictionary of session option values. This dictionary has the
+            lowest priority in determining final session option values, and is intended to set new
             defaults for option if they are not set through any other method.
-        @param kwargs User options passed as keyword arguments.
+        @param kwargs Session options passed as keyword arguments.
         """
         super(Session, self).__init__()
         

--- a/pyocd/coresight/discovery.py
+++ b/pyocd/coresight/discovery.py
@@ -102,7 +102,7 @@ class ADIv5Discovery(CoreSightDiscovery):
         """! @brief Find valid APs using the ADIv5 method.
         
         Scans for valid APs starting at APSEL=0. The default behaviour is to stop after reading
-        0 for the AP's IDR twice in succession. If the `scan_all_aps` user option is set to True,
+        0 for the AP's IDR twice in succession. If the `scan_all_aps` session option is set to True,
         then the scan will instead probe every APSEL from 0-255.
         
         If there is already a list of valid APs defined for the @ref pyocd.coresight.dap.DebugPort

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -364,7 +364,7 @@ COMMAND_INFO = {
             'aliases' : [],
             'args' : "ACTION",
             'help' : "Start or stop the gdbserver.",
-            'extra_help' : "The action argument should be either 'start' or 'stop'. Use the 'gdbserver_port' and 'telnet_port' user options to control the ports the gdbserver uses.",
+            'extra_help' : "The action argument should be either 'start' or 'stop'. Use the 'gdbserver_port' and 'telnet_port' session options to control the ports the gdbserver uses.",
             },
         'probeserver' : {
             'aliases' : [],
@@ -415,7 +415,7 @@ INFO_HELP = {
             },
         'option' : {
             'aliases' : [],
-            'help' : "Show the current value of one or more user options.",
+            'help' : "Show the current value of one or more session options.",
             },
         'mem-ap' : {
             'aliases' : [],
@@ -470,7 +470,7 @@ OPTION_HELP = {
             },
         'option' : {
             'aliases' : [],
-            'help' : "Change the value of one or more user options.",
+            'help' : "Change the value of one or more session options.",
             'extra_help' : "Each parameter should follow the form OPTION=VALUE.",
             },
         'mem-ap' : {
@@ -1904,7 +1904,7 @@ class PyOCDCommander(object):
 
     def handle_show_option(self, args):
         if len(args) < 1:
-            raise ToolError("missing user option name argument")
+            raise ToolError("missing session option name argument")
         for name in args:
             try:
                 value = self.session.options[name]
@@ -2066,7 +2066,7 @@ Prefix line with ! to execute a shell command.""")
 
     def handle_set_option(self, args):
         if len(args) < 1:
-            raise ToolError("missing user option setting")
+            raise ToolError("missing session option setting")
         opts = convert_session_options(args)
         self.session.options.update(opts)
 


### PR DESCRIPTION
- Normalized docs to use the term "session options".
- Additions to the terminology docs.
- Improvement of logging docs.
- `Session` documentation comment improvements.