### PR TITLE
Clean up some exceptions

### DIFF
--- a/pyocd/core/exceptions.py
+++ b/pyocd/core/exceptions.py
@@ -62,11 +62,22 @@ class TransferTimeoutError(TransferError):
     pass
 
 class TransferFaultError(TransferError):
-    """! @brief An SWD Fault occurred"""
-    def __init__(self, faultAddress=None, length=None):
-        super(TransferFaultError, self).__init__(faultAddress)
-        self._address = faultAddress
-        self._length = length
+    """! @brief A memory fault occurred.
+    
+    This exception class is extended to optionally record the start address and an optional length of the
+    attempted memory access that caused the fault. The address and length, if available, will be included
+    in the description of the exception when it is converted to a string.
+    
+    Positional arguments passed to the constructor are passed through to the superclass'
+    constructor, and thus operate like any other standard exception class. Keyword arguments of
+    'fault_address' and 'length' can optionally be passed to the constructor to initialize the fault
+    start address and length. Alternatively, the corresponding property setters can be used after
+    the exception is created.
+    """
+    def __init__(self, *args, **kwargs):
+        super(TransferFaultError, self).__init__(*args)
+        self._address = kwargs.get('fault_address', None)
+        self._length = kwargs.get('length', None)
 
     @property
     def fault_address(self):
@@ -89,7 +100,12 @@ class TransferFaultError(TransferError):
         self._length = length
 
     def __str__(self):
-        desc = "SWD/JTAG Transfer Fault"
+        desc = "Memory transfer fault"
+        if self.args:
+            if len(self.args) == 1:
+                desc += " (" + str(self.args[0]) + ")"
+            else:
+                desc += " " + str(self.args) + ""
         if self._address is not None:
             desc += " @ 0x%08x" % self._address
             if self._length is not None:
@@ -97,11 +113,17 @@ class TransferFaultError(TransferError):
         return desc
   
 class FlashFailure(TargetError):
-    """! @brief Exception raised when flashing fails for some reason. """
-    def __init__(self, msg, address=None, result_code=None):
-        super(FlashFailure, self).__init__(msg)
-        self._address = address
-        self._result_code = result_code
+    """! @brief Exception raised when flashing fails for some reason.
+    
+    Positional arguments passed to the constructor are passed through to the superclass'
+    constructor, and thus operate like any other standard exception class. The flash address that
+    failed and/or result code from the algorithm can optionally be recorded in the exception, if
+    passed to the constructor as 'address' and 'result_code' keyword arguments.
+    """
+    def __init__(self, *args, **kwargs):
+        super(FlashFailure, self).__init__(*args)
+        self._address = kwargs.get('address', None)
+        self._result_code = kwargs.get('result_code', None)
     
     @property
     def address(self):
@@ -110,6 +132,19 @@ class FlashFailure(TargetError):
     @property
     def result_code(self):
         return self._result_code
+
+    def __str__(self):
+        desc = super(FlashFailure, self).__str__()
+        parts = []
+        if self.address is not None:
+            parts.append("address 0x%08x" % self.address)
+        if self.result_code is not None:
+            parts.append("result code 0x%x" % self.result_code)
+        if parts:
+            if desc:
+                desc += " "
+            desc += "(%s)" % ("; ".join(parts))
+        return desc
 
 class FlashEraseFailure(FlashFailure):
     """! @brief An attempt to erase flash failed. """

--- a/pyocd/debug/svd/loader.py
+++ b/pyocd/debug/svd/loader.py
@@ -20,7 +20,10 @@ import pkg_resources
 import zipfile
 
 from .parser import SVDParser
-from ...utility.compatibility import FileNotFoundError
+from ...utility.compatibility import (
+    FileNotFoundError,
+    BadZipFile,
+    )
 
 LOG = logging.getLogger(__name__)
 
@@ -34,7 +37,7 @@ class SVDFile(object):
             zip_stream = pkg_resources.resource_stream("pyocd", BUILTIN_SVD_DATA_PATH)
             zip = zipfile.ZipFile(zip_stream, 'r')
             return SVDFile(zip.open(svd_name))
-        except (FileNotFoundError, BadZipFile) as err:
+        except (KeyError, FileNotFoundError, BadZipFile) as err:
             from ...core.session import Session
             LOG.warning("unable to open builtin SVD file: %s", err, exc_info=Session.get_current().log_tracebacks)
             return None

--- a/pyocd/debug/svd/loader.py
+++ b/pyocd/debug/svd/loader.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2015-2019 Arm Limited
+# Copyright (c) 2015-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ import pkg_resources
 import zipfile
 
 from .parser import SVDParser
-from ...utility.compatibility import FileNotFoundError_
+from ...utility.compatibility import FileNotFoundError
 
 LOG = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class SVDFile(object):
             zip_stream = pkg_resources.resource_stream("pyocd", BUILTIN_SVD_DATA_PATH)
             zip = zipfile.ZipFile(zip_stream, 'r')
             return SVDFile(zip.open(svd_name))
-        except (FileNotFoundError_, zipfile.BadZipFile) as err:
+        except (FileNotFoundError, BadZipFile) as err:
             from ...core.session import Session
             LOG.warning("unable to open builtin SVD file: %s", err, exc_info=Session.get_current().log_tracebacks)
             return None

--- a/pyocd/flash/file_programmer.py
+++ b/pyocd/flash/file_programmer.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2018-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@ import errno
 from .loader import FlashLoader
 from ..core import exceptions
 from ..debug.elf.elf import (ELFBinaryFile, SH_FLAGS)
-from ..utility.compatibility import FileNotFoundError_
+from ..utility.compatibility import FileNotFoundError
 
 LOG = logging.getLogger(__name__)
 
@@ -115,7 +115,7 @@ class FileProgrammer(object):
         
         # Check for valid path first.
         if isPath and not os.path.isfile(file_or_path):
-            raise FileNotFoundError_(errno.ENOENT, "No such file: '{}'".format(file_or_path))
+            raise FileNotFoundError(errno.ENOENT, "No such file: '{}'".format(file_or_path))
         
         # If no format provided, use the file's extension.
         if not file_format:

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -35,7 +35,6 @@ from ..trace.swv import SWVReader
 from ..utility.sockets import ListenerSocket
 from .syscall import GDBSyscallIOHandler
 from ..debug import semihost
-from ..cache.memory import MemoryAccessError
 from .context_facade import GDBDebugContextFacade
 from .symbols import GDBSymbolProvider
 from ..rtos import RTOS
@@ -761,10 +760,7 @@ class GDBServer(threading.Thread):
             # Flush so an exception is thrown now if invalid memory was accesses
             self.target_context.flush()
             val = hex_encode(bytearray(mem))
-        except exceptions.TransferError:
-            LOG.debug("get_memory failed at 0x%x" % addr)
-            val = b'E01' #EPERM
-        except MemoryAccessError as e:
+        except exceptions.TransferError as e:
             LOG.debug("get_memory failed at 0x%x: %s", addr, str(e))
             val = b'E01' #EPERM
         return self.create_rsp_packet(val)
@@ -787,12 +783,9 @@ class GDBServer(threading.Thread):
                 # Flush so an exception is thrown now if invalid memory was accessed
                 self.target_context.flush()
             resp = b"OK"
-        except exceptions.TransferError:
-            LOG.debug("write_memory failed at 0x%x" % addr)
+        except exceptions.TransferError as e:
+            LOG.debug("write_memory_hex failed at 0x%x: %s", addr, str(e))
             resp = b'E01' #EPERM
-        except MemoryAccessError as e:
-            LOG.debug("get_memory failed at 0x%x: %s", addr, str(e))
-            val = b'E01' #EPERM
 
         return self.create_rsp_packet(resp)
 
@@ -813,12 +806,9 @@ class GDBServer(threading.Thread):
                 # Flush so an exception is thrown now if invalid memory was accessed
                 self.target_context.flush()
             resp = b"OK"
-        except exceptions.TransferError:
-            LOG.debug("write_memory failed at 0x%x" % addr)
+        except exceptions.TransferError as e:
+            LOG.debug("write_memory failed at 0x%x: %s", addr, str(e))
             resp = b'E01' #EPERM
-        except MemoryAccessError as e:
-            LOG.debug("get_memory failed at 0x%x: %s", addr, str(e))
-            val = b'E01' #EPERM
 
         return self.create_rsp_packet(resp)
 

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -339,7 +339,7 @@ class STLink(object):
                         # Clear sticky errors.
                         self._clear_sticky_error()
                 
-                        exc = exceptions.TransferFaultError()
+                        exc = exceptions.TransferFaultError("read")
                         exc.fault_address = faultAddr
                         exc.fault_length = thisTransferSize - (faultAddr - addr)
                         raise exc
@@ -373,7 +373,7 @@ class STLink(object):
                         # Clear sticky errors.
                         self._clear_sticky_error()
                 
-                        exc = exceptions.TransferFaultError()
+                        exc = exceptions.TransferFaultError("write")
                         exc.fault_address = faultAddr
                         exc.fault_length = thisTransferSize - (faultAddr - addr)
                         raise exc

--- a/pyocd/probe/tcp_client_probe.py
+++ b/pyocd/probe/tcp_client_probe.py
@@ -191,10 +191,6 @@ class TCPClientProbe(DebugProbe):
     
     def _create_exception_from_status_code(self, status, message):
         """! @brief Convert a status code into an exception instance."""
-        # The TransferFaultError class requires special handling because it doesn't take a
-        # message as the first argument.
-        if status == self.StatusCode.TRANSFER_FAULT:
-            return exceptions.TransferFaultError()
         # Other status codes can use the map.
         return self.STATUS_CODE_CLASS_MAP.get(status, exceptions.ProbeError)(message)
 

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -25,17 +25,12 @@ import itertools
 import six
 import struct
 
-# zipfile from Python 2 has a misspelled BadZipFile exception class.
-try:
-    from zipfile import BadZipFile
-except ImportError:
-    from zipfile import BadZipfile as BadZipFile
-
 from .flash_algo import PackFlashAlgo
 from ... import core
 from ...core import exceptions
 from ...core.target import Target
 from ...core.memory_map import (MemoryMap, MemoryType, MEMORY_TYPE_CLASS_MAP, FlashRegion)
+from ...utility.compatibility import BadZipFile
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2017-2019 Arm Limited
+# Copyright (c) 2017-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ from ..family import FAMILIES
 from .. import TARGET
 from ...coresight.coresight_target import CoreSightTarget
 from ...debug.svd.loader import SVDFile
-from ...utility.compatibility import FileNotFoundError_
+from ...utility.compatibility import FileNotFoundError
 
 try:
     import cmsis_pack_manager
@@ -162,7 +162,7 @@ class PackTargets(object):
                         "set_default_reset_type": _PackTargetMethods._pack_target_set_default_reset_type,
                     })
             return targetClass
-        except (MalformedCmsisPackError, FileNotFoundError_) as err:
+        except (MalformedCmsisPackError, FileNotFoundError) as err:
             LOG.warning(err)
             return None
 
@@ -183,7 +183,7 @@ class PackTargets(object):
             # Make sure there isn't a duplicate target name.
             if part not in TARGET:
                 TARGET[part] = tgt
-        except (MalformedCmsisPackError, FileNotFoundError_) as err:
+        except (MalformedCmsisPackError, FileNotFoundError) as err:
             LOG.warning(err)
 
     @staticmethod

--- a/pyocd/utility/compatibility.py
+++ b/pyocd/utility/compatibility.py
@@ -66,6 +66,12 @@ try:
 except NameError:
     FileNotFoundError = OSError
 
+# zipfile from Python 2 has a misspelled BadZipFile exception class.
+try:
+    from zipfile import BadZipFile
+except ImportError:
+    from zipfile import BadZipfile as BadZipFile
+
 try:
     from shutil import get_terminal_size
 except ImportError:

--- a/pyocd/utility/compatibility.py
+++ b/pyocd/utility/compatibility.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2018-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,11 +61,10 @@ else:
             return v
 
 # Make FileNotFoundError available to Python 2.x.
-if not PY3:
-    FileNotFoundError = IOError
-
-# Symbol to reference either the builtin FNF or our custom subclass.
-FileNotFoundError_ = FileNotFoundError
+try:
+    FileNotFoundError = FileNotFoundError
+except NameError:
+    FileNotFoundError = OSError
 
 try:
     from shutil import get_terminal_size

--- a/test/unit/test_exceptions.py
+++ b/test/unit/test_exceptions.py
@@ -1,0 +1,93 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from pyocd.core.exceptions import *
+
+# Tests for TransferFaultError.
+class TestFaultError:
+    def test_no_args(self):
+        e = TransferFaultError()
+        assert str(e) == 'Memory transfer fault'
+    
+    def test_no_args_set_addr(self):
+        e = TransferFaultError()
+        e.fault_address = 0x1000
+        assert str(e) == 'Memory transfer fault @ 0x00001000'
+    
+    def test_no_args_set_addr_len(self):
+        e = TransferFaultError()
+        e.fault_address = 0x1000
+        e.fault_length = 0x8
+        assert str(e) == 'Memory transfer fault @ 0x00001000-0x00001007'
+
+    def test_msg(self):
+        e = TransferFaultError("temporal anomaly")
+        assert str(e) == 'Memory transfer fault (temporal anomaly)'
+
+    def test_arg_tuple(self):
+        e = TransferFaultError(-1, 1234)
+        assert str(e) == 'Memory transfer fault (-1, 1234)'
+    
+    def test_msg_ctor_addr(self):
+        e = TransferFaultError("my bad", fault_address=0x20008400)
+        assert e.fault_address == 0x20008400
+        assert str(e) == 'Memory transfer fault (my bad) @ 0x20008400'
+    
+    def test_msg_ctor_addr_len(self):
+        e = TransferFaultError("my bad", fault_address=0x20008400, length=32)
+        assert e.fault_address == 0x20008400
+        assert str(e) == 'Memory transfer fault (my bad) @ 0x20008400-0x2000841f'
+
+# Tests for FlashFailure.
+class TestFlashFailure:
+    def test_no_args(self):
+        e = FlashFailure()
+        assert str(e) == ""
+        assert e.address == None
+        assert e.result_code == None
+
+    def test_msg(self):
+        e = FlashFailure("something exploded")
+        assert str(e) == "something exploded"
+        assert e.address == None
+        assert e.result_code == None
+
+    def test_addr(self):
+        e = FlashFailure(address=0x4000)
+        assert str(e) == "(address 0x00004000)"
+        assert e.address == 0x4000
+        assert e.result_code == None
+
+    def test_code(self):
+        e = FlashFailure(result_code=0x104)
+        assert str(e) == "(result code 0x104)"
+        assert e.address == None
+        assert e.result_code == 0x104
+
+    def test_addr_code(self):
+        e = FlashFailure(address=0x4000, result_code=0x104)
+        assert str(e) == "(address 0x00004000; result code 0x104)"
+        assert e.address == 0x4000
+        assert e.result_code == 0x104
+
+    def test_msg_addr_code(self):
+        e = FlashFailure("major error", address=0x4000, result_code=0x104)
+        assert str(e) == "major error (address 0x00004000; result code 0x104)"
+        assert e.address == 0x4000
+        assert e.result_code == 0x104
+


### PR DESCRIPTION
Clean up `TransferFaultError` and `FlashFailure` so they accept standard constructor arguments, and format those arguments properly check converted to string.

Remove the `MemoryAccessError` exception that was only raised in one case by the memory cache. This also resulting in cleaning up a bit of code in `GDBServer`.

Cleaned up some exception names in the Python 2 compatibility utilities.